### PR TITLE
Remove DB_TYPE `mongodb`

### DIFF
--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -102,7 +102,7 @@ class HostedAgents {
     async _start_pool_agent(pool) {
         if (!this._started) return;
         if (!pool) throw new Error(`Internal error: received pool ${pool}`);
-        if (config.DB_TYPE !== 'mongodb' && pool.resource_type === 'INTERNAL') return;
+        if (pool.resource_type === 'INTERNAL') return;
         dbg.log0(`_start_pool_agent for pool ${pool.name}`);
         const pool_id = String(pool._id);
         const node_name = 'noobaa-internal-agent-' + pool_id;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -710,7 +710,7 @@ interface APIClient {
  *
  **********************************************************/
 
-type DBType = 'postgres' | 'mongodb' | 'none';
+type DBType = 'postgres' | 'none';
 
 interface DBClient {
     operators: Set<string>;

--- a/src/server/object_services/map_builder.js
+++ b/src/server/object_services/map_builder.js
@@ -6,7 +6,6 @@ const assert = require('assert');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
-const config = require('../../../config.js');
 // const mapper = require('./mapper');
 const MDStore = require('./md_store').MDStore;
 const KeysLock = require('../../util/keys_lock');
@@ -257,8 +256,7 @@ class MapBuilder {
 
         // check if bucket master_key is enabled and chunk master keys disabled
         } else if (!chunk_master_key_id && bucket_m_key && bucket_m_key.disabled === false) {
-            // TODO: Or we can check if chunk.cipher_key instanceof mongodb.Binary
-            const cipher_key_buffer = config.DB_TYPE === 'mongodb' ? chunk.cipher_key.buffer : chunk.cipher_key;
+            const cipher_key_buffer = Buffer.isBuffer(chunk.cipher_key) ? chunk.cipher_key : chunk.cipher_key.buffer;
             const encrypted_cipher = mkm.encrypt_buffer_with_master_key_id(cipher_key_buffer, bucket_m_key._id);
             await MDStore.instance().update_chunk_by_id(chunk._id,
                 { cipher_key: encrypted_cipher, master_key_id: bucket_m_key._id });

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -792,11 +792,6 @@ class MDStore {
         const hint = 'latest_version_index';
         const sort = { bucket: 1, key: 1 };
 
-        // for mongodb add version_past to the sort
-        if (config.DB_TYPE === 'mongodb') {
-            sort.version_past = 1;
-        }
-
         const { key_query } = this._build_list_key_query_from_markers(prefix, delimiter, key_marker);
 
         const query = compact({

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1019,7 +1019,7 @@ async function delete_multiple_objects_by_filter(req) {
     let delete_results;
     let objects;
     // TODO: Add support to delete_objects_by_query also for versioning or add another function to support versioning.
-    if (req.bucket.versioning === 'DISABLED' && config.DB_TYPE !== 'mongodb' && reply_objects !== true) /* only for postgres */ {
+    if (req.bucket.versioning === 'DISABLED' && reply_objects !== true) {
         query.return_results = true; // we want to return the objects that were deleted
         objects = await MDStore.instance().delete_objects_by_query(query);
     } else {

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -1,8 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const config = require('../../../../config');
-
 module.exports = [
 
     // TODO index ??? find_objects() not indexed for the create_time
@@ -13,9 +11,6 @@ module.exports = [
         fields: {
             bucket: 1,
             key: 1,
-            // For MONGO deployments - we include version_past as extra index field to separate from null_version_index.
-            // note that version_past is always null here by partialFilterExpression.
-            ...(config.DB_TYPE === 'mongodb' ? { version_past: 1 } : {}),
         },
         options: {
             name: 'latest_version_index',
@@ -38,9 +33,6 @@ module.exports = [
         fields: {
             bucket: 1,
             key: 1,
-            // For MONGO deployments - we include version_enabled as extra index field to separate from latest_version_index.
-            // note that version_enabled is always null here by partialFilterExpression.
-            ...(config.DB_TYPE === 'mongodb' ? { version_enabled: 1 } : {}),
         },
         options: {
             name: 'null_version_index',

--- a/src/server/system_services/schemas/system_schema.js
+++ b/src/server/system_services/schemas/system_schema.js
@@ -100,7 +100,7 @@ module.exports = {
                     port: { $ref: 'common_api#/definitions/port' },
                     api: {
                         type: 'string',
-                        enum: ['mgmt', 's3', 'sts', 'md', 'bg', 'hosted_agents', 'mongodb', 'metrics', 'postgres', 'syslog', 'iam', 'vectors']
+                        enum: ['mgmt', 's3', 'sts', 'md', 'bg', 'hosted_agents', 'metrics', 'postgres', 'syslog', 'iam', 'vectors']
                     },
                     secure: { type: 'boolean' },
                     weight: { type: 'integer' }

--- a/src/upgrade/upgrade_scripts/5.22.0/upgrade_system_address_mongodb_api.js
+++ b/src/upgrade/upgrade_scripts/5.22.0/upgrade_system_address_mongodb_api.js
@@ -1,0 +1,40 @@
+/* Copyright (C) 2025 NooBaa */
+"use strict";
+
+async function run({ dbg, system_store }) {
+    try {
+        dbg.log0("starting upgrade system_address mongodb api...");
+        const system_updates = [system_store.data.systems[0]]
+            .map(system_record => {
+                const address_list = system_record.system_address;
+                if (!Array.isArray(address_list) ||
+                    !address_list.some(address_entry => address_entry && address_entry.api === "mongodb")) {
+                    return false;
+                }
+                return {
+                    _id: system_record._id,
+                    system_address: address_list.map(address_entry => {
+                        if (address_entry && address_entry.api === "mongodb") {
+                            return { ...address_entry, api: "postgres" };
+                        }
+                        return address_entry;
+                    }),
+                };
+            })
+            .filter(Boolean);
+        if (system_updates.length > 0) {
+            dbg.log0("rewriting legacy api mongodb to postgres in system_address");
+            await system_store.make_changes({ update: { systems: system_updates } });
+        } else {
+            dbg.log0("upgrade system_address mongodb api: no upgrade needed...");
+        }
+    } catch (error) {
+        dbg.error("got error while upgrading system_address mongodb api:", error);
+        throw error;
+    }
+}
+
+module.exports = {
+    run,
+    description: "Rewrite system_address entries with legacy api mongodb to postgres",
+};


### PR DESCRIPTION
### Explain the Changes
Remove DB_TYPE `mongodb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed MongoDB as a supported database option; PostgreSQL is now the sole supported backend.
  * Added an automatic upgrade that converts legacy MongoDB configuration entries to PostgreSQL.

* **Bug Fixes**
  * Consistent handling of internal agent pools and object listing/deletion behaviors to remove previous DB-specific inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->