### PR TITLE
vectors - policy - allow everything to admin (DFBUGS-6733)

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1433,6 +1433,8 @@ module.exports = {
                 bucket_claim: { $ref: 'common_api#/definitions/bucket_claim' },
                 tags: { $ref: 'common_api#/definitions/tagging' },
                 vector_policy: { $ref: 'common_api#/definitions/bucket_policy'},
+                system_id: { objectid: true },
+                system_owner: {$ref: '#/definitions/owner_account'}
             }
         },
 

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -272,6 +272,15 @@ async function authorize_request_vector_policy(req) {
 
     const account = req.object_sdk.requesting_account;
     const is_nc_deployment = Boolean(req.object_sdk.nsfs_config_root);
+    const system_owner_id = req.vector_bucket.system_owner?.id;
+    const account_identifier_id = access_policy_utils.get_account_identifier_id(is_nc_deployment, account);
+
+    //this allows ODF gui to show details on every vector bucket (see https://redhat.atlassian.net/browse/DFBUGS-6733)
+    const is_containerized_system_owner = !is_nc_deployment && Boolean(system_owner_id) &&
+        (String(system_owner_id) === String(account_identifier_id));
+    dbg.log2("policy auth: vb =", req.vector_bucket.name, ", account_identifier_id =",
+        account_identifier_id, " ,system_owner._id =", system_owner_id, ", is_system_owner =", is_containerized_system_owner);
+    if (is_containerized_system_owner) return;
 
     // No bucket policy: same as s3_rest when !s3_policy — only owner or IAM user under that root account.
     if (!vector_policy) {
@@ -290,7 +299,6 @@ async function authorize_request_vector_policy(req) {
     }
 
     const account_identifiers = [];
-    const account_identifier_id = access_policy_utils.get_account_identifier_id(is_nc_deployment, account);
     if (account_identifier_id) account_identifiers.push(account_identifier_id);
     if (is_nc_deployment && account.owner === undefined) {
         account_identifiers.push(account.name.unwrap());

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2375,6 +2375,11 @@ function get_vector_bucket_info(vector_bucket) {
         bucket_claim: vector_bucket.bucket_claim,
         tags: vector_bucket.tags,
         vector_policy: vector_bucket.vector_policy,
+        system_id: vector_bucket.system._id,
+        system_owner: {
+            id: vector_bucket.system.owner._id,
+            email: vector_bucket.system.owner.email
+        }
     };
     return info;
 }

--- a/src/test/integration_tests/api/vectors/test_vector_bucket_policy.js
+++ b/src/test/integration_tests/api/vectors/test_vector_bucket_policy.js
@@ -14,7 +14,6 @@ if (is_nc_coretest) {
 }
 coretest.setup(setup_options);
 const config = require('../../../../../config');
-const { S3 } = require('@aws-sdk/client-s3');
 const s3vectors = require('@aws-sdk/client-s3vectors');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const mocha = require('mocha');
@@ -22,8 +21,7 @@ const assert = require('assert');
 const fs = require('fs').promises;
 const https = require('https');
 const path = require('path');
-const { rpc_client, EMAIL, get_current_setup_options, stop_nsfs_process, start_nsfs_process } = coretest;
-const http_utils = require('../../../../util/http_utils');
+const { rpc_client, get_current_setup_options, stop_nsfs_process, start_nsfs_process } = coretest;
 
 const VECTOR_BUCKET = 'test-vec-policy-buc';
 /** Distinct from test_vectors_ops (same fs_root_path is rejected as IN_USE / "Target already in use"). */
@@ -32,8 +30,6 @@ const nsr = 'nsr-vector-policy';
 
 mocha.describe('vector_bucket_policy', function() {
 
-    /** @type {S3} */
-    let s3_client;
     let s3_vectors_client;
 
     mocha.before(async function() {
@@ -49,9 +45,22 @@ mocha.describe('vector_bucket_policy', function() {
             await fs.mkdir(LANCE_ROOT, { recursive: true });
         }
 
-        const account_info = await rpc_client.account.read_account({ email: EMAIL });
-        const access_key = account_info.access_keys[0].access_key.unwrap();
-        const secret_key = account_info.access_keys[0].secret_key.unwrap();
+        const account = {
+            has_login: false,
+            s3_access: true,
+            name: "user",
+            email: "user@noobaa.com"
+        };
+        if (process.env.NC_CORETEST) {
+            account.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: LANCE_ROOT
+            };
+        }
+        const user_account_details = await rpc_client.account.create_account(account);
+        const access_key = user_account_details.access_keys[0].access_key.unwrap();
+        const secret_key = user_account_details.access_keys[0].secret_key.unwrap();
 
         const client_params = {
             endpoint: coretest.get_https_address_vectors(),
@@ -87,27 +96,9 @@ mocha.describe('vector_bucket_policy', function() {
                 priority: 'high',
             }
         );
-
-        const http_address = is_nc_coretest ? coretest.get_https_address() : coretest.get_http_address();
-        const s3_client_params = {
-            endpoint: http_address,
-            credentials: {
-                accessKeyId: access_key,
-                secretAccessKey: secret_key,
-            },
-            forcePathStyle: true,
-            region: config.DEFAULT_REGION,
-            requestHandler: new NodeHttpHandler(is_nc_coretest ? {
-                httpsAgent: new https.Agent({ rejectUnauthorized: false }),
-            } : {
-                httpAgent: http_utils.get_unsecured_agent(http_address),
-            }),
-        };
-        s3_client = new S3(s3_client_params);
     });
 
     mocha.beforeEach(async function() {
-        await s3_client.createBucket({ Bucket: 'lance' });
         await create_vector_bucket(s3_vectors_client, VECTOR_BUCKET);
     });
 
@@ -122,7 +113,6 @@ mocha.describe('vector_bucket_policy', function() {
         await send(s3_vectors_client, new s3vectors.DeleteVectorBucketCommand({
             vectorBucketName: VECTOR_BUCKET
         }));
-        await s3_client.deleteBucket({ Bucket: 'lance' });
     });
 
     ////////////////////////////////


### PR DESCRIPTION
### Describe the Problem
ODF UI fails to show details for vector buckets.

### Explain the Changes
Allow system owner (AKA noobaa admin) to execute all action on vector buckets. This is similar to object bucket behaviour.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6733

### Testing Instructions:
1. Create a vector OBC
2. List indexes with admin user.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector bucket responses now include system ID and system owner details.

* **Improvements**
  * Authorization flow refined to skip redundant permission checks when the system owner matches the requester’s account identifier.

* **Tests**
  * Integration tests updated to create test accounts dynamically and simplify setup/cleanup to only manage vector-bucket resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->