### PR TITLE
s3 putObject optimization - reduced DB queries

### DIFF
--- a/config.js
+++ b/config.js
@@ -688,6 +688,7 @@ config.INLINE_MAX_SIZE = 4096;
 // the standard read_object_mapping RPC.
 config.MAPPINGS_PREFETCH_NUM_PARTS = config.IO_OBJECT_RANGE_ALIGN / config.CHUNK_SPLIT_AVG_CHUNK;
 
+config.DEFERRED_PUT_MAPPING_MAX_PARTS = 30; // max deferred parts before flushing mappings to DB
 ///////////////////////////////
 // CACHE (ACCOUNT, BUCKET)   //
 ///////////////////////////////
@@ -1233,7 +1234,7 @@ config.S3_RDMA_AGENT_CUOBJ = 'cuobj';
 // client request header for the RDMA token
 config.S3_RDMA_TOKEN_HDR = 'x-amz-rdma-token';
 config.S3_RDMA_VALIDATE_TOKEN_HDR = true;
-// server response header for reply code (e.g. 200, 204, 206, 501) 
+// server response header for reply code (e.g. 200, 204, 206, 501)
 config.S3_RDMA_REPLY_HDR = 'x-amz-rdma-reply';
 // server response header for number of bytes transferred
 config.S3_RDMA_BYTES_HDR = 'x-amz-rdma-bytes-transferred';

--- a/docs/design/DeferredObjectUpload.md
+++ b/docs/design/DeferredObjectUpload.md
@@ -1,0 +1,282 @@
+# Deferred Object Upload: Reducing PostgreSQL WAL Writes for Small Objects
+
+## Background
+
+NooBaa stores object metadata in PostgreSQL. Every S3 `PUT` object goes through
+a multi-step upload flow that issues several independent INSERT/UPDATE
+statements against the database. Each statement triggers its own WAL (Write-Ahead
+Log) flush, which is the primary bottleneck for small-object workloads where the
+I/O payload is negligible compared to the metadata overhead.
+
+## Previous Implementation
+
+A simple `PutObject` (non-multipart) followed this sequence of database
+round-trips:
+
+```mermaid
+sequenceDiagram
+    participant C as Client (object_io)
+    participant S as Server (object_server)
+    participant DB as PostgreSQL
+
+    C->>S: create_object_upload
+    S->>DB: INSERT objectmd (upload row)
+    Note over DB: WAL flush #1
+    S-->>C: obj_id
+
+    loop For each chunk group
+        C->>S: put_mapping(chunks)
+        S->>DB: INSERT chunks
+        S->>DB: INSERT parts (uncommitted)
+        S->>DB: INSERT blocks
+        Note over DB: WAL flush #2..N
+        S-->>C: ok
+    end
+
+    C->>S: complete_object_upload
+    S->>DB: SELECT find_object_null_version
+    Note over DB: WAL flush #N+1
+    S->>DB: UPDATE objectmd (soft-delete old)
+    Note over DB: WAL flush #N+2
+    S->>DB: UPDATE parts (clear uncommitted)
+    Note over DB: WAL flush #N+3
+    S->>DB: SELECT nextval (version_seq)
+    S->>DB: UPDATE objectmd (finalize)
+    Note over DB: WAL flush #N+4
+    S-->>C: ok
+```
+
+For a single 4 KB object this meant **at least 5–7 separate statements**, each
+with its own WAL flush. At high throughput the WAL device becomes saturated long
+before CPU or network are the limiting factor.
+
+### Specific Problems for Small Objects
+
+- **WAL amplification**: A 4 KB object generates ~2–4 KB of actual data I/O but
+  several kilobytes of WAL writes across multiple transactions.
+- **Latency**: Each database round-trip adds network + query planning + WAL
+  sync latency, which dominates the overall PUT latency for small payloads.
+- **`_complete_object_parts`**: After `put_mapping`, the completion path ran
+  `_complete_object_parts` which updated every part to clear the `uncommitted`
+  flag and set the final byte ranges — an extra UPDATE per part that only matters
+  for multipart uploads.
+
+## New Implementation
+
+### Guiding Principle
+
+Batch multiple SQL statements into a **single database round-trip** using
+`MultiTableBulkOp` (a new cross-table bulk operation class) and batched
+`BEGIN; ...; COMMIT` transactions, so the database performs one WAL flush per
+upload instead of many.
+
+### Small Object (parts <= threshold, DISABLED versioning)
+
+When no conditional headers (`If-Match`, `If-None-Match`, etc.) are present —
+the common case — the `find_object_null_version` SELECT is eliminated entirely.
+The soft-delete of any prior object is performed by key inside the same batched
+transaction.
+
+```mermaid
+sequenceDiagram
+    participant C as Client (object_io)
+    participant S as Server (object_server)
+    participant DB as PostgreSQL
+
+    C->>S: create_object_upload(defer_put_mapping=true)
+    Note over S: No DB insert — objectmd returned in response
+    S-->>C: obj_id + deferred_object_md
+
+    loop For each chunk group
+        Note over C: Accumulate chunks/parts/blocks in memory
+        C->>C: _upload_chunks (skip put_mapping RPC)
+    end
+
+    C->>S: complete_object_upload(deferred_object_md, deferred_chunks)
+    S->>DB: SELECT nextval (version_seq)
+    S->>DB: Batched txn: soft-delete old, INSERT obj/chunks/parts/blocks
+    Note over DB: WAL flush (single flush for batched txn)
+    S-->>C: ok
+```
+
+When conditional headers **are** present, a separate
+`find_object_null_version` SELECT is issued first so the conditions can be
+evaluated before the write.
+
+### Large Object (parts > threshold, DISABLED versioning)
+
+```mermaid
+sequenceDiagram
+    participant C as Client (object_io)
+    participant S as Server (object_server)
+    participant DB as PostgreSQL
+
+    C->>S: create_object_upload(defer_put_mapping=true)
+    Note over S: No DB insert — objectmd returned in response
+    S-->>C: obj_id + deferred_object_md
+
+    loop Chunks until parts > threshold
+        Note over C: Accumulate chunks in memory
+        C->>C: _upload_chunks (skip put_mapping RPC)
+    end
+
+    Note over C: Threshold exceeded — flush deferred batch
+    C->>S: put_mapping(deferred_chunks, deferred_object_md)
+    S->>DB: Batched txn: INSERT objectmd/chunks/parts/blocks
+    Note over DB: WAL flush #1
+    S-->>C: ok
+
+    loop Remaining chunks
+        C->>S: put_mapping(chunks)
+        S->>DB: Batched txn: INSERT chunks/parts/blocks
+        Note over DB: WAL flush #2..M
+        S-->>C: ok
+    end
+
+    C->>S: complete_object_upload
+    S->>DB: SELECT nextval (version_seq)
+    S->>DB: Batched txn: soft-delete old by key, UPDATE objectmd
+    Note over DB: WAL flush #M+1
+    S-->>C: ok
+```
+
+### Changes by Component
+
+#### 1. Client Side — `object_io.js`
+
+- `upload_object` always requests `defer_put_mapping = true` for non-copy simple
+  uploads.
+- `_upload_chunks` accumulates mapping metadata (chunks, parts, blocks) in memory
+  as `complete_params.deferred_chunks` instead of calling the `put_mapping` RPC.
+- When the accumulated parts count exceeds `DEFERRED_PUT_MAPPING_MAX_PARTS`
+  (default 30), the deferred chunks are flushed to the database together with the
+  deferred object metadata in a single `put_mapping` call, and subsequent chunks
+  follow the normal (non-deferred) path. This avoids unbounded memory growth for
+  large objects.
+- On error, if the upload is still deferred (object metadata was never inserted),
+  the abort RPC is skipped since there is nothing in the database to clean up.
+
+#### 2. Server Side — `create_object_upload` in `object_server.js`
+
+- When `defer_put_mapping` is requested and the bucket's versioning is `DISABLED`,
+  the `INSERT INTO objectmds` is **skipped**.
+- Instead, the constructed `objectmd` record is returned in the RPC response
+  as `deferred_object_md`. The client carries it through the upload and sends it
+  back at completion.
+- For versioned buckets (`ENABLED` / `SUSPENDED`) or multipart uploads, deferral
+  is not used and the flow is unchanged.
+
+#### 3. Server Side — `put_mapping` / `PutMapping.update_db()` in `map_server.js`
+
+- `PutMapping.update_db()` **always** wraps all mapping inserts (chunks, parts,
+  blocks) into a single batched transaction via
+  `MDStore.insert_mappings_in_transaction()`, regardless of whether the upload
+  is deferred.
+- When `deferred_object_md` is present (first batch for a large object that
+  exceeded the parts threshold), the object INSERT is included in the same
+  transaction.
+
+#### 4. Server Side — `complete_object_upload` in `object_server.js`
+
+- Split into `_complete_simple_upload` (simple PUT) and
+  `_complete_multipart_upload` (multipart). Multipart is unchanged.
+- For simple uploads, the `_complete_object_parts` step is eliminated entirely.
+  Parts are inserted without the `uncommitted` flag, so there is no need to
+  clear it during completion.
+- `version_seq` is allocated via `alloc_object_version_seq()` for all
+  versioning modes.
+- Completion delegates to `_put_object_handle_latest_with_retries()` for all
+  versioning modes (DISABLED, ENABLED, SUSPENDED).
+- For DISABLED versioning, `_put_object_handle_latest` checks for conditional
+  headers (`If-Match`, etc.) via `has_md_conditions()`:
+  - **No conditions (common path)**: the `find_object_null_version` SELECT is
+    skipped. Instead, any existing object is soft-deleted by key inside the
+    same batched transaction — either via `delete_and_insert_deferred` (deferred
+    path) or `complete_object_upload_mark_remove_by_key` (non-deferred path).
+  - **With conditions**: the SELECT is issued first so the conditions can be
+    evaluated, then the appropriate insert/update is performed as before.
+
+#### 5. Database Layer — `postgres_client.js`
+
+- **`PgTransaction.execute_batch()`**: New method that acquires a connection,
+  sends a full batch query string (including `BEGIN` and `COMMIT`), and
+  guarantees cleanup on failure. Enables single-round-trip transactions.
+- **`BulkOp.execute()`**: Modified to use `execute_batch()` — batches
+  `BEGIN; stmt1; stmt2; ...; COMMIT` as a single query string instead of
+  separate `BEGIN`, batch, `COMMIT` round-trips.
+- **`MultiTableBulkOp`**: New class extending `BulkOp` that can insert docs
+  into multiple tables in a single batched transaction. Adds `insert_many()`
+  for cross-table inserts while inheriting `add_query()` and `execute()` from
+  `BulkOp`. Created via `PostgresClient.initializeMultiTableBulkOp(pool_name)`.
+- **`escapeLiteral`**: Re-exported from `pg` for safe SQL string interpolation
+  in raw queries (used by `MDStore` methods that build UPDATE-by-key SQL).
+
+#### 6. Database Layer — `MDStore` in `md_store.js`
+
+- **`insert_mappings_in_transaction`**: Uses `MultiTableBulkOp` to insert
+  all chunk, part, and block rows (and optionally the object row for deferred
+  uploads) in a single batched transaction.
+- **`delete_and_insert_deferred`**: Soft-deletes an existing object and
+  inserts the new object + deferred mappings in a single batched transaction
+  (one round trip). Accepts either `delete_obj_id` (by id, when the object
+  was already fetched for md_conditions) or `bucket_id` + `key` (by key,
+  eliminating the prior SELECT).
+- **`complete_object_upload_mark_remove_by_key`**: For non-deferred DISABLED
+  uploads without md_conditions. Soft-deletes the existing null-version by
+  key and updates `put_obj` in a single `OrderedBulkOp` batch. The key-based
+  UPDATE is a no-op when no prior object exists.
+
+### What Did Not Change
+
+- **Multipart uploads** (`CreateMultipartUpload` / `UploadPart` /
+  `CompleteMultipartUpload`): The full original flow is preserved.
+  `_complete_multipart_upload` still calls `_complete_object_parts` to
+  resequence parts.
+- **Versioned buckets** (`ENABLED` / `SUSPENDED`): Object metadata is always
+  inserted at `create_object_upload` time. The deferred path is limited to
+  `DISABLED` versioning.
+- **`put_mapping` for large objects**: When the deferred parts threshold is
+  exceeded during streaming, chunks are flushed to the database via the normal
+  `put_mapping` RPC (with the deferred object metadata piggy-backed on the
+  first call). Subsequent chunks go through the regular non-deferred path.
+
+## WAL Flush Comparison
+
+DB round trips and WAL flushes for the common case (no conditional headers):
+
+| Scenario | Before | After | DB round trips |
+|---|---|---|---|
+| Small object, new key, DISABLED versioning | 5–7 flushes | **1 flush** (batched txn) | nextval + 1 batch |
+| Small object, overwrite, DISABLED versioning | 6–8 flushes | **1 flush** (soft-delete by key in same batch) | nextval + 1 batch |
+| Small object, ENABLED versioning | 5–7 flushes | **3–4 flushes** (unchanged except mapping batch) | nextval + SELECT + batch |
+| Large object (> threshold), DISABLED versioning | 5–7+ flushes | **2–3 flushes** (first batch + completion) | nextval + M batches |
+
+When conditional headers are present (rare), DISABLED versioning adds one
+extra round trip for the `find_object_null_version` SELECT.
+
+## Future Work
+
+The `UploadPart` S3 op follows a similar pattern to simple `PutObject`: it calls
+`put_mapping` per part, each generating its own WAL flush. For workloads with
+many small parts, the same deferred-mapping strategy can be applied:
+
+1. **Deferred part mappings**: Accumulate chunk/part/block metadata in memory
+   across `UploadPart` calls and flush them in a single batched transaction at
+   `CompleteMultipartUpload`, collapsing N `put_mapping` round-trips into one.
+2. **Deferred uploads for versioned buckets**: Currently deferral and the
+   single-transaction completion path are limited to `DISABLED` versioning.
+   Extending them to `ENABLED` and `SUSPENDED` buckets is straightforward since
+   `_put_object_handle_latest_with_retries` already handles all versioning modes.
+3. **Remove `version_seq` allocation for DISABLED versioning**: The `nextval`
+   call is only needed for S3 event notification sequencer ordering. For
+   DISABLED versioning the timestamp-based fallback sequencer is sufficient,
+   so this round-trip can be eliminated entirely.
+4. **Batch `put_mapping` across concurrent parts**: When multiple parts stream
+   concurrently, a shared write queue could batch their mapping inserts into
+   fewer, larger batched transactions.
+
+## Configuration
+
+| Parameter | Default | Description |
+|---|---|---|
+| `DEFERRED_PUT_MAPPING_MAX_PARTS` | 30 | Maximum number of deferred parts to accumulate in memory before flushing to the database. Controls the trade-off between memory usage and WAL reduction. |

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -61,6 +61,7 @@ module.exports = {
                         idate: true
                     },
                     storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                    defer_put_mapping: { type: 'boolean' },
                 }
             },
             reply: {
@@ -74,6 +75,11 @@ module.exports = {
                     chunk_coder_config: { $ref: 'common_api#/definitions/chunk_coder_config' },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     bucket_master_key_id: { objectid: true },
+                    deferred_object_md: {
+                        type: 'object',
+                        additionalProperties: true,
+                        properties: {},
+                    },
                 }
             },
             auth: { system: ['admin', 'user'] }
@@ -163,6 +169,15 @@ module.exports = {
                     },
                     last_modified_time: {
                         idate: true
+                    },
+                    deferred_object_md: {
+                        type: 'object',
+                        additionalProperties: true,
+                        properties: {},
+                    },
+                    deferred_chunks: {
+                        type: 'array',
+                        items: { $ref: '#/definitions/chunk_info' }
                     },
                 }
             },
@@ -422,6 +437,11 @@ module.exports = {
                     },
                     location_info: { $ref: 'common_api#/definitions/location_info' },
                     move_to_tier: { objectid: true },
+                    deferred_object_md: {
+                        type: 'object',
+                        additionalProperties: true,
+                        properties: {},
+                    },
                 },
             },
             auth: { system: ['admin', 'user'] }

--- a/src/sdk/map_client.js
+++ b/src/sdk/map_client.js
@@ -93,6 +93,7 @@ class MapClient {
      * @param {nb.LocationInfo} [props.location_info]
      * @param {nb.Tier} [props.move_to_tier]
      * @param {boolean} [props.check_dups]
+     * @param {boolean} [props.skip_put_mapping]
      * @param {boolean} [props.verification_mode]
      * @param {Object} props.rpc_client
      * @param {string} [props.desc]
@@ -108,6 +109,7 @@ class MapClient {
         this.location_info = props.location_info;
         this.move_to_tier = props.move_to_tier;
         this.check_dups = Boolean(props.check_dups);
+        this.skip_put_mapping = Boolean(props.skip_put_mapping);
         this.rpc_client = props.rpc_client;
         this.desc = props.desc;
         this.report_error = props.report_error;
@@ -123,7 +125,10 @@ class MapClient {
         this.chunks = chunks;
         await this.process_mapping();
         await this.move_blocks_to_storage_class();
-        await this.put_mapping();
+        // Deferred simple upload: caller persists mappings (complete_object_upload or staged put_mapping).
+        if (!this.skip_put_mapping) {
+            await this.put_mapping();
+        }
     }
 
     /**

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -756,9 +756,28 @@ interface DBClient {
     make_object_diff(current: object, prev: object): object;
 
     executeSQL<T>(query: string, params: Array<any>, options?: { query_name?: string, preferred_pool?: string }): Promise<sqlResult<T>>;
+
+    initializeMultiTableBulkOp(pool_name?: string): MultiTableBulkOp;
+}
+
+interface MultiTableBulkOp {
+    length: number;
+    insert_many(entries: { table: DBCollection, docs: object[] }[]): this;
+    add_query(sql: string): void;
+    execute(): Promise<BulkOpResult>;
+}
+
+interface BulkOpResult {
+    err: Error | undefined;
+    ok: boolean;
+    nInserted: number;
+    nMatched: number;
+    nModified: number;
+    nRemoved: number;
 }
 
 interface DBSequence {
+    seqname(): string;
     nextsequence(): Promise<number>;
 }
 
@@ -791,7 +810,8 @@ interface DBCollection {
     stats(): Promise<mongodb.CollStats>;
 
     validate(doc: object, warn?: 'warn'): object;
-
+    get_id(data: object): string;
+    get_pool(): string;
     name: any;
     schema: any;
 }
@@ -912,15 +932,15 @@ interface BucketSpace {
     put_public_access_block({ bucket_name, public_access_block }): Promise<any>;
     delete_public_access_block({ bucket_name }): Promise<any>;
 
-    create_vector_bucket(params: object) : Promise<any>;
-    get_vector_bucket({vector_bucket_name}) : Promise<any>;
-    delete_vector_bucket({vector_bucket_name}) : Promise<any>;
-    list_vector_buckets({max_results, prefix, next_token}) : Promise<any>;
+    create_vector_bucket(params: object): Promise<any>;
+    get_vector_bucket({ vector_bucket_name }): Promise<any>;
+    delete_vector_bucket({ vector_bucket_name }): Promise<any>;
+    list_vector_buckets({ max_results, prefix, next_token }): Promise<any>;
 
-    create_vector_index(params: object) : Promise<any>;
-    get_vector_index({vector_bucket_name, vector_index_name}) : Promise<any>;
-    list_vector_indices({vector_bucket_name, max_results, prefix, next_token}) : Promise<any>;
-    delete_vector_index({vector_bucket_name, vector_index_name}) : Promise<any>;
+    create_vector_index(params: object): Promise<any>;
+    get_vector_index({ vector_bucket_name, vector_index_name }): Promise<any>;
+    list_vector_indices({ vector_bucket_name, max_results, prefix, next_token }): Promise<any>;
+    delete_vector_index({ vector_bucket_name, vector_index_name }): Promise<any>;
 }
 
 /**********************************************************

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -54,6 +54,7 @@ Object.isFrozen(RpcError); // otherwise unused
  * @property {function} [async_get_last_modified_time]
  * @property {function} [upload_chunks_hook]
  * @property {string} [bucket_master_key_id]
+ * @property {boolean} [defer_put_mapping]
  *
  * @typedef {Object} ReadParams
  * @property {Object} client
@@ -206,6 +207,12 @@ class ObjectIO {
             'storage_class',
             'last_modified_time',
         );
+        if (!params.copy_source) {
+            // Server may return objectmd in the reply and skip insert (see create_object_upload);
+            // _upload_chunks then defers or flushes put_mapping by size.
+            create_params.defer_put_mapping = true;
+        }
+        /** @type {Object} */
         const complete_params = _.pick(params,
             'obj_id',
             'bucket',
@@ -223,6 +230,11 @@ class ObjectIO {
             params.chunk_coder_config = create_reply.chunk_coder_config;
             params.bucket_master_key_id = create_reply.bucket_master_key_id;
             complete_params.obj_id = create_reply.obj_id;
+            if (create_reply.deferred_object_md) {
+                // Only set when server actually deferred (e.g. DISABLED versioning); else object is in DB.
+                params.defer_put_mapping = true;
+                complete_params.deferred_object_md = create_reply.deferred_object_md;
+            }
             if (params.copy_source) {
                 await this._upload_copy(params, complete_params);
             } else {
@@ -242,7 +254,8 @@ class ObjectIO {
             return complete_result;
         } catch (err) {
             dbg.warn('upload_object: failed upload', complete_params, err);
-            if (params.obj_id) {
+            // Deferred create skipped insert_object; abort would no-op / error on missing row.
+            if (params.obj_id && !params.defer_put_mapping) {
                 try {
                     await params.client.object.abort_object_upload(_.pick(params, 'bucket', 'key', 'obj_id'));
                     dbg.log0('upload_object: aborted object upload', complete_params);
@@ -471,7 +484,9 @@ class ObjectIO {
                     start: params.start,
                     end: params.start + chunk_info.size,
                     seq: params.seq,
-                    uncommitted: !params.complete_upload,
+                    // Multipart uploads need part positions finalized at complete_object_upload;
+                    // simple uploads stream sequential start/end/seq here, so leave uncommitted unset.
+                    uncommitted: Boolean(!params.complete_upload && params.multipart_id),
                     // millistamp: time_utils.millistamp(),
                     // bucket: params.bucket,
                     // key: params.key,
@@ -512,17 +527,40 @@ class ObjectIO {
                 key: params.key,
             };
 
+            // Defer DB put_mapping: either buffer chunks for small objects (complete),
+            // or flush first batch with deferred_object_md for large objects (see below).
+            const is_deferred = Boolean(params.defer_put_mapping);
             const mc = new MapClient({
                 object_md,
                 chunks: map_chunks,
                 location_info: params.location_info,
                 check_dups: !is_using_encryption,
+                skip_put_mapping: is_deferred,
                 rpc_client: params.client,
                 desc: params.desc,
                 report_error: (block_md, action, err) => this._report_error_on_object_upload(params, block_md, action, err),
             });
             await mc.run();
             if (mc.had_errors) throw new Error('Upload map errors');
+
+            if (is_deferred) {
+                const api_chunks = mc.chunks
+                    .filter(chunk => !chunk.had_errors)
+                    .map(chunk => chunk.to_api());
+                if (!complete_params.deferred_chunks) complete_params.deferred_chunks = [];
+                complete_params.deferred_chunks.push(...api_chunks);
+                if (complete_params.deferred_chunks.length >= config.DEFERRED_PUT_MAPPING_MAX_PARTS) {
+                    const deferred_object_md = complete_params.deferred_object_md;
+                    delete complete_params.deferred_object_md;
+                    params.defer_put_mapping = false;
+                    await params.client.object.put_mapping({
+                        chunks: complete_params.deferred_chunks,
+                        deferred_object_md,
+                    });
+                    complete_params.deferred_chunks = [];
+                }
+            }
+
             if (params.upload_chunks_hook) params.upload_chunks_hook(params.range.end - params.range.start);
             return callback();
         } catch (err) {

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -236,11 +236,13 @@ class PutMapping {
     /**
      * @param {Object} props
      * @param {nb.Chunk[]} props.chunks
-     * @param {nb.Tier} props.move_to_tier
+     * @param {nb.Tier} [props.move_to_tier]
+     * @param {Object} [props.deferred_object_md]
      */
     constructor(props) {
         this.chunks = props.chunks;
         this.move_to_tier = props.move_to_tier;
+        this.deferred_object_md = props.deferred_object_md;
 
         /** @type {nb.BlockSchemaDB[]} */
         this.new_blocks = [];
@@ -359,16 +361,16 @@ class PutMapping {
     }
 
     async update_db() {
-        await Promise.all([
-            MDStore.instance().insert_blocks(this.new_blocks),
-            MDStore.instance().insert_chunks(this.new_chunks),
-            MDStore.instance().insert_parts(this.new_parts),
-            map_deleter.delete_blocks(this.delete_blocks),
-
-            // TODO
-            // (upload_size > obj.upload_size) && MDStore.instance().update_object_by_id(obj._id, { upload_size: upload_size })
-
-        ]);
+        // Single CTE transaction for chunks/parts/blocks (+ optional deferred object insert on first large batch).
+        await MDStore.instance().insert_mappings_in_transaction({
+            object_md: this.deferred_object_md,
+            chunks: this.new_chunks,
+            parts: this.new_parts,
+            blocks: this.new_blocks,
+        });
+        if (this.delete_blocks.length) {
+            await map_deleter.delete_blocks(this.delete_blocks);
+        }
     }
 
 }

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2400]*/
+/*eslint max-lines: ["error", 2500]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -12,7 +12,7 @@ const mime = require('mime-types');
 
 const dbg = require('../../util/debug_module')(__filename);
 const db_client = require('../../util/db_client');
-const { decode_json } = require('../../util/postgres_client.js');
+const { decode_json, escapeLiteral } = require('../../util/postgres_client.js');
 
 const aggregate_functions = require('../../util/aggregate_functions');
 const object_md_schema = require('./schemas/object_md_schema');
@@ -118,6 +118,63 @@ class MDStore {
     async insert_object(info) {
         this._objects.validate(info);
         return this._objects.insertOne(info);
+    }
+
+    /**
+     * All mapping inserts in a single batched transaction (BEGIN + INSERTs + COMMIT)
+     * to reduce WAL flushes. Optionally includes the object row for the first
+     * put_mapping with deferred_object_md.
+     */
+    async insert_mappings_in_transaction({ object_md, chunks, parts, blocks }) {
+        const entries = [];
+        if (object_md) entries.push({ table: this._objects, docs: [object_md] });
+        if (chunks && chunks.length) entries.push({ table: this._chunks, docs: chunks });
+        if (parts && parts.length) entries.push({ table: this._parts, docs: parts });
+        if (blocks && blocks.length) entries.push({ table: this._blocks, docs: blocks });
+        if (!entries.length) return;
+
+        const bulk = db_client.instance().initializeMultiTableBulkOp(this._postgres_pool);
+        bulk.insert_many(entries);
+        const res = await bulk.execute();
+        if (!res.ok) {
+            throw res.err || new Error('insert_mappings_in_transaction: bulk insert failed');
+        }
+    }
+
+    /**
+     * Soft-delete an existing object then insert a new object + deferred mappings
+     * in a single batched transaction (one round trip).
+     * Accepts either delete_obj_id (by id) or bucket_id + key (by key) for the soft-delete.
+     * When using bucket_id + key the separate find_object_null_version lookup is eliminated.
+     */
+    async delete_and_insert_deferred({ delete_obj_id, bucket_id, key, object_md, chunks, parts, blocks }) {
+        const bulk = db_client.instance().initializeMultiTableBulkOp(this._postgres_pool);
+        const deleted_json = JSON.stringify({ deleted: new Date().toISOString(), version_past: true });
+        if (delete_obj_id) {
+            bulk.add_query(
+                `UPDATE ${this._objects.name} SET data = data || ${escapeLiteral(deleted_json)}::jsonb` +
+                ` WHERE _id = ${escapeLiteral(String(delete_obj_id))} AND data->>'deleted' IS NULL`
+            );
+        } else if (bucket_id && key) {
+            bulk.add_query(
+                `UPDATE ${this._objects.name} SET data = data || ${escapeLiteral(deleted_json)}::jsonb` +
+                ` WHERE data->>'bucket' = ${escapeLiteral(String(bucket_id))}` +
+                ` AND data->>'key' = ${escapeLiteral(key)}` +
+                ` AND data->>'deleted' IS NULL` +
+                ` AND data->>'upload_started' IS NULL` +
+                ` AND data->>'version_enabled' IS NULL`
+            );
+        }
+        bulk.insert_many([
+            { table: this._objects, docs: [object_md] },
+            ...(chunks && chunks.length ? [{ table: this._chunks, docs: chunks }] : []),
+            ...(parts && parts.length ? [{ table: this._parts, docs: parts }] : []),
+            ...(blocks && blocks.length ? [{ table: this._blocks, docs: blocks }] : []),
+        ]);
+        const res = await bulk.execute();
+        if (!res.ok) {
+            throw res.err || new Error('delete_and_insert_deferred: bulk operation failed');
+        }
     }
 
     async update_object_by_id(obj_id, set_updates, unset_updates, inc_updates) {
@@ -537,6 +594,38 @@ class MDStore {
             dbg.error('complete_object_upload_latest_mark_remove_current: partial bulk update',
                 _.clone(res), unmark_obj, put_obj, set_updates, unset_updates);
             throw res.err || new Error('complete_object_upload_latest_mark_remove_current: partial bulk update');
+        }
+    }
+
+    /**
+     * Soft-delete the current null-version by bucket+key, then update put_obj with set/unset.
+     * Eliminates the separate find_object_null_version round trip when md_conditions are absent.
+     * The UPDATE-by-key is a no-op (0 rows) when no prior object exists.
+     */
+    async complete_object_upload_mark_remove_by_key({
+        bucket_id,
+        key,
+        put_obj,
+        set_updates,
+        unset_updates,
+    }) {
+        const bulk = this._objects.initializeOrderedBulkOp();
+        const deleted_json = JSON.stringify({ deleted: new Date().toISOString(), version_past: true });
+        bulk.add_query(
+            `UPDATE ${this._objects.name} SET data = data || ${escapeLiteral(deleted_json)}::jsonb` +
+            ` WHERE data->>'bucket' = ${escapeLiteral(String(bucket_id))}` +
+            ` AND data->>'key' = ${escapeLiteral(key)}` +
+            ` AND data->>'deleted' IS NULL` +
+            ` AND data->>'upload_started' IS NULL` +
+            ` AND data->>'version_enabled' IS NULL`
+        );
+        bulk.find({ _id: put_obj._id, deleted: null })
+            .updateOne({ $set: set_updates, $unset: unset_updates });
+        const res = await bulk.execute();
+        if (!res.ok || res.nModified < 1) {
+            dbg.error('complete_object_upload_mark_remove_by_key: partial bulk update',
+                _.clone(res), bucket_id, key, put_obj, set_updates, unset_updates);
+            throw res.err || new Error('complete_object_upload_mark_remove_by_key: partial bulk update');
         }
     }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2400]*/
+/*eslint max-lines: ["error", 2500]*/
 'use strict';
 
 require('../../util/fips');
@@ -119,8 +119,19 @@ async function create_object_upload(req) {
         info.storage_class = tier.storage_class;
     }
 
-    await MDStore.instance().insert_object(info);
-    object_md_cache.put_in_cache(String(info._id), info);
+    // for now we defer put mapping only for simple uploads and when versioning is disabled
+    // This should work the same for versioned buckets, but out of scope for now.
+    // TODO: revisit for versioned buckets
+    const defer_put_mapping = Boolean(
+        req.rpc_params.defer_put_mapping &&
+        !req.rpc_params.complete_upload &&
+        (!req.bucket.versioning || req.bucket.versioning === 'DISABLED')
+    );
+
+    if (!defer_put_mapping) {
+        await MDStore.instance().insert_object(info);
+        object_md_cache.put_in_cache(String(info._id), info);
+    }
 
     return {
         obj_id: info._id,
@@ -130,6 +141,7 @@ async function create_object_upload(req) {
         chunk_coder_config: req.bucket.tiering ? tier.chunk_config.chunk_coder_config : {},
         encryption,
         bucket_master_key_id: (req.bucket.master_key_id.disabled === false && req.bucket.master_key_id._id) || undefined,
+        deferred_object_md: defer_put_mapping ? info : undefined,
     };
 }
 
@@ -363,12 +375,19 @@ async function put_object_retention(req) {
 const ZERO_SIZE_ETAG = crypto.createHash('md5').digest('hex');
 
 /**
- *
  * complete_object_upload
- *
+ * Multipart: resequence parts from multiple multiparts, then same completion as before.
+ * Simple: no _complete_object_parts; DISABLED uses a single-CTE path in complete_simple_upload_disabled.
  */
 async function complete_object_upload(req) {
     throw_if_maintenance(req);
+    if (req.rpc_params.multiparts) {
+        return _complete_multipart_upload(req);
+    }
+    return _complete_simple_upload(req);
+}
+
+async function _complete_multipart_upload(req) {
     const set_updates = {};
     const unset_updates = {
         upload_size: 1,
@@ -406,9 +425,7 @@ async function complete_object_upload(req) {
         set_updates.sha256_b64 = req.rpc_params.sha256_b64;
     }
 
-    const map_res = req.rpc_params.multiparts ?
-        await _complete_object_multiparts(obj, req.rpc_params.multiparts) :
-        await _complete_object_parts(obj);
+    const map_res = await _complete_object_multiparts(obj, req.rpc_params.multiparts);
 
     if (req.rpc_params.size !== map_res.size) {
         if (req.rpc_params.size >= 0) {
@@ -446,17 +463,7 @@ async function complete_object_upload(req) {
     }
 
 
-    // retry on duplicate key error to handle a race condition between two concurrent PUT requests to the same key
-    const put_obj_attempts = 3;
-    await P.retry({
-        func: async () => {
-            await _put_object_handle_latest({ req, put_obj: obj, set_updates, unset_updates });
-        },
-        attempts: put_obj_attempts,
-        delay_ms: 50,
-        should_retry_func: err => MDStore.instance().is_err_duplicate_key(err),
-        error_logger: err => dbg.warn('got duplicate key error in _put_object_handle_latest. retrying... bucket=', req.bucket.name, 'key=', obj.key, 'err=', err)
-    });
+    await _put_object_handle_latest_with_retries({ req, put_obj: obj, set_updates, unset_updates });
 
     const took_ms = set_updates.create_time.getTime() - obj._id.getTimestamp().getTime();
     const upload_duration = time_utils.format_time_duration(took_ms);
@@ -464,6 +471,134 @@ async function complete_object_upload(req) {
     const upload_speed = size_utils.human_size(set_updates.size / took_ms * 1000);
     dbg.log1(`${obj.key} was uploaded by ${req.account && req.account.email.unwrap()} into bucket ${req.bucket.name.unwrap()}.` +
         `\nUpload size: ${upload_size}.` +
+        `\nUpload duration: ${upload_duration}.` +
+        `\nUpload speed: ${upload_speed}/sec.`,
+    );
+    return {
+        etag: get_etag(obj, set_updates),
+        version_id: MDStore.instance().get_object_version_id(set_updates),
+        encryption: obj.encryption,
+        size: set_updates.size,
+        content_type: obj.content_type,
+        seq: set_updates.version_seq,
+    };
+}
+
+async function _complete_simple_upload(req) {
+    const deferred_object_md = req.rpc_params.deferred_object_md;
+    const is_deferred = Boolean(deferred_object_md);
+
+    let obj;
+    if (is_deferred) {
+        load_bucket(req);
+        obj = deferred_object_md;
+        // RPC carries round-tripped metadata; reject mismatched tenant/bucket/key (same intent as check_object_mode).
+        if (String(obj._id) !== String(req.rpc_params.obj_id) ||
+            String(req.system._id) !== String(obj.system) ||
+            String(req.bucket._id) !== String(obj.bucket) ||
+            req.rpc_params.key !== obj.key) {
+            throw new RpcError('NO_SUCH_UPLOAD',
+                `deferred object metadata mismatch: bucket ${req.rpc_params.bucket} key ${req.rpc_params.key}`);
+        }
+    } else {
+        obj = await find_cached_object_upload(req);
+    }
+
+    if (req.rpc_params.size !== obj.size) {
+        if (obj.size >= 0) {
+            throw new RpcError('BAD_SIZE',
+                `size on complete object (${
+                            req.rpc_params.size
+                        }) differs from create object (${
+                            obj.size
+                        })`);
+        }
+    }
+
+    const set_updates = {};
+    if (req.rpc_params.md5_b64 && req.rpc_params.md5_b64 !== obj.md5_b64) {
+        if (obj.md5_b64) {
+            throw new RpcError('BAD_DIGEST_MD5',
+                'md5 on complete object differs from create object', {
+                    client: req.rpc_params.md5_b64,
+                    server: obj.md5_b64,
+                });
+        }
+        set_updates.md5_b64 = req.rpc_params.md5_b64;
+    }
+    if (req.rpc_params.sha256_b64 && req.rpc_params.sha256_b64 !== obj.sha256_b64) {
+        if (obj.sha256_b64) {
+            throw new RpcError('BAD_DIGEST_SHA256',
+                'sha256 on complete object differs from create object', {
+                    client: req.rpc_params.sha256_b64,
+                    server: obj.sha256_b64,
+                });
+        }
+        set_updates.sha256_b64 = req.rpc_params.sha256_b64;
+    }
+
+    set_updates.size = req.rpc_params.size >= 0 ? req.rpc_params.size : 0;
+    set_updates.num_parts = req.rpc_params.num_parts || 0;
+    if (req.rpc_params.etag) {
+        set_updates.etag = req.rpc_params.etag;
+    } else if (set_updates.size === 0) {
+        set_updates.etag = ZERO_SIZE_ETAG;
+    } else if (req.rpc_params.md5_b64) {
+        set_updates.etag = Buffer.from(req.rpc_params.md5_b64, 'base64').toString('hex');
+    }
+
+    set_updates.create_time = new Date();
+    if (req.bucket.namespace && req.bucket.namespace.caching) {
+        set_updates.cache_last_valid_time = new Date();
+    }
+    if (req.rpc_params.last_modified_time) {
+        set_updates.last_modified_time = new Date(req.rpc_params.last_modified_time);
+    }
+
+    const unset_updates = { upload_size: 1, upload_started: 1 };
+
+    set_updates.version_seq = await MDStore.instance().alloc_object_version_seq();
+    if (req.bucket.versioning === 'ENABLED') set_updates.version_enabled = true;
+
+    let deferred_mappings;
+    if (is_deferred) {
+        const deferred_chunks = req.rpc_params.deferred_chunks || [];
+        const put_map = new map_server.PutMapping({
+            chunks: deferred_chunks.map(c => new ChunkAPI(c, system_store)),
+        });
+        put_map.add_chunks();
+
+        const mapped_size = put_map.new_parts.reduce((max, p) => Math.max(max, p.end), 0);
+        const mapped_num_parts = put_map.new_parts.length;
+        if (set_updates.size !== mapped_size || set_updates.num_parts !== mapped_num_parts) {
+            throw new RpcError('BAD_SIZE',
+                `deferred mapping mismatch: size=${set_updates.size}/${mapped_size}` +
+                ` num_parts=${set_updates.num_parts}/${mapped_num_parts}`);
+        }
+
+        deferred_mappings = {
+            chunks: put_map.new_chunks,
+            parts: put_map.new_parts,
+            blocks: put_map.new_blocks,
+        };
+
+        // Apply final metadata to the deferred object before it gets inserted into the DB.
+        Object.assign(obj, set_updates);
+        for (const key of Object.keys(unset_updates)) delete obj[key];
+    }
+
+    await _put_object_handle_latest_with_retries({ req, put_obj: obj, set_updates, unset_updates, deferred_mappings, });
+
+    // Deferred path: obj._id may be a hex string from RPC; normalize for upload-duration logging.
+    const obj_id_ts = is_deferred ?
+        make_md_id(obj._id).getTimestamp().getTime() :
+        obj._id.getTimestamp().getTime();
+    const took_ms = set_updates.create_time.getTime() - obj_id_ts;
+    const upload_duration = time_utils.format_time_duration(took_ms);
+    const upload_size_str = size_utils.human_size(set_updates.size);
+    const upload_speed = size_utils.human_size(set_updates.size / took_ms * 1000);
+    dbg.log1(`${obj.key} was uploaded by ${req.account && req.account.email.unwrap()} into bucket ${req.bucket.name.unwrap()}.` +
+        `\nUpload size: ${upload_size_str}.` +
         `\nUpload duration: ${upload_duration}.` +
         `\nUpload speed: ${upload_speed}/sec.`,
     );
@@ -660,11 +795,11 @@ async function get_mapping(req) {
  */
 async function put_mapping(req) {
     throw_if_maintenance(req);
-    // TODO: const obj = await find_cached_object_upload(req);
-    const { chunks, move_to_tier } = req.rpc_params;
+    const { chunks, move_to_tier, deferred_object_md } = req.rpc_params;
     const put_map = new map_server.PutMapping({
         chunks: chunks.map(chunk_info => new ChunkAPI(chunk_info, system_store)),
         move_to_tier: move_to_tier && system_store.data.get_by_id(move_to_tier),
+        deferred_object_md,
     });
     await put_map.run();
 }
@@ -689,7 +824,7 @@ async function copy_object_mapping(req) {
         part.obj = obj._id;
         part.bucket = req.bucket._id;
         part.multipart = multipart ? multipart._id : undefined;
-        part.uncommitted = true;
+        part.uncommitted = multipart ? true : undefined;
     }
     await MDStore.instance().insert_parts(parts);
     return {
@@ -1824,23 +1959,67 @@ function _get_delete_obj_reply(deleted_obj, created_obj) {
 }
 
 
-async function _put_object_handle_latest({ req, put_obj, set_updates, unset_updates }) {
+async function _put_object_handle_latest_with_retries({ req, put_obj, set_updates, unset_updates, deferred_mappings = undefined }) {
+    const put_obj_attempts = 3;
+    await P.retry({
+        func: async () => {
+            await _put_object_handle_latest({ req, put_obj, set_updates, unset_updates, deferred_mappings });
+        },
+        attempts: put_obj_attempts,
+        delay_ms: 50,
+        should_retry_func: err => MDStore.instance().is_err_duplicate_key(err),
+        error_logger: err => dbg.warn('got duplicate key error in _put_object_handle_latest. retrying...',
+            'bucket=', req.bucket.name, 'key=', put_obj.key, 'err=', err)
+    });
+}
+
+async function _put_object_handle_latest({ req, put_obj, set_updates, unset_updates, deferred_mappings }) {
     const bucket_versioning = req.bucket.versioning;
 
     if (bucket_versioning === 'DISABLED') {
-        const obj = await MDStore.instance().find_object_null_version(req.bucket._id, put_obj.key);
-        http_utils.check_md_conditions(req.rpc_params.md_conditions, obj);
-        if (obj) {
-            // 2, 3, 6, 7
-            await MDStore.instance().complete_object_upload_latest_mark_remove_current_and_delete({
-                unmark_obj: obj,
-                put_obj: put_obj,
+        if (http_utils.has_md_conditions(req.rpc_params.md_conditions)) {
+            const obj = await MDStore.instance().find_object_null_version(req.bucket._id, put_obj.key);
+            http_utils.check_md_conditions(req.rpc_params.md_conditions, obj);
+            if (obj) {
+                if (deferred_mappings) {
+                    await MDStore.instance().delete_and_insert_deferred({
+                        delete_obj_id: obj._id,
+                        object_md: put_obj,
+                        ...deferred_mappings,
+                    });
+                } else {
+                    await MDStore.instance().complete_object_upload_latest_mark_remove_current_and_delete({
+                        unmark_obj: obj,
+                        put_obj: put_obj,
+                        set_updates,
+                        unset_updates,
+                    });
+                }
+            } else if (deferred_mappings) {
+                await MDStore.instance().insert_mappings_in_transaction({
+                    object_md: put_obj,
+                    ...deferred_mappings,
+                });
+            } else {
+                await MDStore.instance().update_object_by_id(put_obj._id, set_updates, unset_updates);
+            }
+        } else if (deferred_mappings) {
+            // No md_conditions: soft-delete by key + insert new object + mappings in one batch
+            await MDStore.instance().delete_and_insert_deferred({
+                bucket_id: req.bucket._id,
+                key: put_obj.key,
+                object_md: put_obj,
+                ...deferred_mappings,
+            });
+        } else {
+            // No md_conditions: soft-delete by key + update put_obj in one batch
+            await MDStore.instance().complete_object_upload_mark_remove_by_key({
+                bucket_id: req.bucket._id,
+                key: put_obj.key,
+                put_obj,
                 set_updates,
                 unset_updates,
             });
-        } else {
-            // 6
-            await MDStore.instance().update_object_by_id(put_obj._id, set_updates, unset_updates);
         }
         return;
     }
@@ -2077,28 +2256,6 @@ async function update_endpoint_stats(req) {
     ]);
 }
 
-/**
- * @param {nb.ObjectMD} obj
- */
-async function _complete_object_parts(obj) {
-    const context = {
-        pos: 0,
-        seq: 0,
-        num_parts: 0,
-        parts_updates: [],
-    };
-
-    const parts = await MDStore.instance().find_all_parts_of_object(obj);
-    _complete_next_parts(parts, context);
-    if (context.parts_updates.length) {
-        await MDStore.instance().update_parts_in_bulk(context.parts_updates);
-    }
-
-    return {
-        size: context.pos,
-        num_parts: context.num_parts,
-    };
-}
 
 /**
  * @param {nb.ObjectMD} obj

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -1107,6 +1107,11 @@ mocha.describe('s3_ops', function() {
             });
             const res2 = await s3.listObjects({ Bucket: bucket_name });
             assert.strictEqual(res2.Contents.length, (res1.Contents.length + 2));
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: text_file2 });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, file_body, 'copied object body should match source');
+            assert.strictEqual(get_res.ContentLength, file_body.length);
         });
 
         mocha.it('list-objects should return proper object owner and id', async function() {
@@ -1300,6 +1305,57 @@ mocha.describe('s3_ops', function() {
                         ETag: res7.CopyPartResult.ETag,
                         PartNumber: 1
                     }]
+                }
+            });
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: text_file2 });
+            const body = await get_res.Body.transformToString();
+            const expected_body = file_body2.slice(1, 6);
+            assert.strictEqual(body, expected_body, 'multipart copy body should match copied range');
+            assert.strictEqual(get_res.ContentLength, 5);
+        });
+
+        mocha.it('should copy via multipart upload and verify full object', async function() {
+            if (is_azure_mock) this.skip();
+            this.timeout(600000);
+            const src_key = 'mp-copy-source';
+            const dst_key = 'mp-copy-dest';
+            const src_body = 'multipart_copy_full_object_test_data';
+
+            await s3.putObject({ Bucket: bucket_name, Key: src_key, Body: src_body });
+
+            const create_res = await s3.createMultipartUpload({
+                Bucket: bucket_name,
+                Key: dst_key
+            });
+            const part_res = await s3.uploadPartCopy({
+                Bucket: bucket_name,
+                Key: dst_key,
+                UploadId: create_res.UploadId,
+                PartNumber: 1,
+                CopySource: `/${bucket_name}/${src_key}`,
+            });
+            await s3.completeMultipartUpload({
+                Bucket: bucket_name,
+                Key: dst_key,
+                UploadId: create_res.UploadId,
+                MultipartUpload: {
+                    Parts: [{
+                        ETag: part_res.CopyPartResult.ETag,
+                        PartNumber: 1
+                    }]
+                }
+            });
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: dst_key });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, src_body, 'multipart copied object should match source');
+            assert.strictEqual(get_res.ContentLength, src_body.length);
+
+            await s3.deleteObjects({
+                Bucket: bucket_name,
+                Delete: {
+                    Objects: [{ Key: src_key }, { Key: dst_key }]
                 }
             });
         });
@@ -1547,14 +1603,20 @@ mocha.describe('s3_ops', function() {
                 Key: copied_key,
                 CopySource: `/${bucket_name}/${key}`,
             });
+            assert.equal(res_put.$metadata.httpStatusCode, 200);
+            assert.equal(res_copy.$metadata.httpStatusCode, 200);
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: copied_key });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, body, 'copied body should match source');
+            assert.strictEqual(get_res.ContentLength, body.length);
+
             await s3.deleteObjects({
                 Bucket: bucket_name,
                 Delete: {
                     Objects: [{ Key: key }, { Key: copied_key }]
                 }
             });
-            assert.equal(res_put.$metadata.httpStatusCode, 200);
-            assert.equal(res_copy.$metadata.httpStatusCode, 200);
         });
 
         mocha.it('should copy object (with copy source: %2bucket%2key)', async function() {
@@ -1578,14 +1640,73 @@ mocha.describe('s3_ops', function() {
                 Key: copied_key,
                 CopySource: copy_source_escaped,
             });
+            assert.equal(res_put.$metadata.httpStatusCode, 200);
+            assert.equal(res_copy.$metadata.httpStatusCode, 200);
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: copied_key });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, body, 'copied body should match source after encoded copy');
+            assert.strictEqual(get_res.ContentLength, body.length);
+
             await s3.deleteObjects({
                 Bucket: bucket_name,
                 Delete: {
                     Objects: [{ Key: key }, { Key: copied_key }]
                 }
             });
-            assert.equal(res_put.$metadata.httpStatusCode, 200);
-            assert.equal(res_copy.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should copy object and overwrite existing key', async function() {
+            if (is_azure_mock) this.skip();
+            this.timeout(120000);
+            const key = 'overwrite-src';
+            const body_v1 = 'version_one_data';
+            const body_v2 = 'version_two_data_longer';
+            const target_key = 'overwrite-target';
+
+            await s3.putObject({ Bucket: bucket_name, Key: target_key, Body: body_v1 });
+            await s3.putObject({ Bucket: bucket_name, Key: key, Body: body_v2 });
+
+            await s3.copyObject({
+                Bucket: bucket_name,
+                Key: target_key,
+                CopySource: `/${bucket_name}/${key}`,
+            });
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: target_key });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, body_v2, 'overwritten key should have new body');
+            assert.strictEqual(get_res.ContentLength, body_v2.length);
+
+            await s3.deleteObjects({
+                Bucket: bucket_name,
+                Delete: {
+                    Objects: [{ Key: key }, { Key: target_key }]
+                }
+            });
+        });
+
+        mocha.it('should copy object across buckets and verify data', async function() {
+            if (is_azure_mock) this.skip();
+            this.timeout(120000);
+            const key = 'cross-bucket-src';
+            const body = 'cross_bucket_body_content_12345';
+            const target_key = 'cross-bucket-copy';
+
+            await s3.putObject({ Bucket: source_bucket, Key: key, Body: body });
+            await s3.copyObject({
+                Bucket: bucket_name,
+                Key: target_key,
+                CopySource: `/${source_bucket}/${key}`,
+            });
+
+            const get_res = await s3.getObject({ Bucket: bucket_name, Key: target_key });
+            const copied_body = await get_res.Body.transformToString();
+            assert.strictEqual(copied_body, body, 'cross-bucket copy body should match');
+            assert.strictEqual(get_res.ContentLength, body.length);
+
+            await s3.deleteObject({ Bucket: source_bucket, Key: key });
+            await s3.deleteObject({ Bucket: bucket_name, Key: target_key });
         });
 
         mocha.it('should getObjectAttributes', async function() {

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -660,6 +660,361 @@ mocha.describe('md_store', function() {
         });
     });
 
+    mocha.describe('delete_and_insert_deferred', function() {
+
+        function make_completed_object(overrides) {
+            const ts = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+            return {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: `daid_test_${ts}`,
+                content_type: 'application/octet-stream',
+                size: 100,
+                etag: 'abc123',
+                create_time: new Date(),
+                ...overrides,
+            };
+        }
+
+        function make_mapping_docs(obj_id) {
+            const chunk_id = md_store.make_md_id();
+            const frag_id = md_store.make_md_id();
+            const chunk = {
+                _id: chunk_id,
+                system: system_id,
+                bucket: bucket_id,
+                size: 100,
+                frag_size: 100,
+            };
+            const part = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                obj: obj_id,
+                chunk: chunk_id,
+                start: 0,
+                end: 100,
+                seq: 0,
+            };
+            const block = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                node: md_store.make_md_id(),
+                chunk: chunk_id,
+                frag: frag_id,
+                size: 100,
+            };
+            return { chunks: [chunk], parts: [part], blocks: [block] };
+        }
+
+        mocha.it('soft-deletes old object and inserts new object + mappings', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `daid_overwrite_${Date.now().toString(36)}`;
+            const obj_a = make_completed_object({ key });
+            await md_store.insert_object(obj_a);
+
+            const obj_b = make_completed_object({ key });
+            const { chunks, parts, blocks } = make_mapping_docs(obj_b._id);
+
+            await md_store.delete_and_insert_deferred({
+                delete_obj_id: obj_a._id,
+                object_md: obj_b,
+                chunks,
+                parts,
+                blocks,
+            });
+
+            const row_a = await md_store.find_object_by_id(obj_a._id);
+            assert(row_a.deleted, 'obj_a should be soft-deleted');
+            assert.strictEqual(row_a.version_past, true);
+            const row_b = await md_store.find_object_by_id(obj_b._id);
+            assert.strictEqual(row_b.key, key);
+            const found_chunks = await md_store.find_chunks_by_ids(chunks.map(c => c._id));
+            assert.strictEqual(found_chunks.length, 1);
+            const found_parts = await md_store.find_parts_by_start_range({
+                obj_id: obj_b._id,
+                start_gte: 0,
+                start_lt: 200,
+                end_gt: 0,
+            });
+            assert(found_parts.length >= 1, 'part should exist after deferred insert');
+        });
+
+        mocha.it('inserts new object + mappings without prior object', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const obj = make_completed_object();
+            const { chunks, parts, blocks } = make_mapping_docs(obj._id);
+
+            await md_store.insert_mappings_in_transaction({
+                object_md: obj,
+                chunks,
+                parts,
+                blocks,
+            });
+
+            const row = await md_store.find_object_by_id(obj._id);
+            assert.strictEqual(row.key, obj.key);
+            const found_chunks = await md_store.find_chunks_by_ids(chunks.map(c => c._id));
+            assert.strictEqual(found_chunks.length, 1, 'chunk should exist after insert');
+            const found_parts = await md_store.find_parts_by_start_range({
+                obj_id: obj._id,
+                start_gte: 0,
+                start_lt: 200,
+                end_gt: 0,
+            });
+            assert(found_parts.length >= 1, 'part should exist after insert');
+        });
+
+        mocha.it('soft-deletes by bucket+key and inserts new object + mappings', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `daid_bykey_${Date.now().toString(36)}`;
+            const obj_a = make_completed_object({ key });
+            await md_store.insert_object(obj_a);
+
+            const obj_b = make_completed_object({ key });
+            const { chunks, parts, blocks } = make_mapping_docs(obj_b._id);
+
+            await md_store.delete_and_insert_deferred({
+                bucket_id,
+                key,
+                object_md: obj_b,
+                chunks,
+                parts,
+                blocks,
+            });
+
+            const row_a = await md_store.find_object_by_id(obj_a._id);
+            assert(row_a.deleted, 'obj_a should be soft-deleted');
+            assert.strictEqual(row_a.version_past, true);
+            const row_b = await md_store.find_object_by_id(obj_b._id);
+            assert.strictEqual(row_b.key, key);
+            const found_chunks = await md_store.find_chunks_by_ids(chunks.map(c => c._id));
+            assert.strictEqual(found_chunks.length, 1);
+        });
+
+        mocha.it('by-key insert succeeds when no prior object exists', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const obj = make_completed_object();
+            const { chunks, parts, blocks } = make_mapping_docs(obj._id);
+
+            await md_store.delete_and_insert_deferred({
+                bucket_id,
+                key: obj.key,
+                object_md: obj,
+                chunks,
+                parts,
+                blocks,
+            });
+
+            const row = await md_store.find_object_by_id(obj._id);
+            assert.strictEqual(row.key, obj.key);
+        });
+    });
+
+    mocha.describe('insert_mappings_in_transaction', function() {
+
+        mocha.it('inserts all collections atomically', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const obj_id = md_store.make_md_id();
+            const chunk_id = md_store.make_md_id();
+            const frag_id = md_store.make_md_id();
+            const object_md = {
+                _id: obj_id,
+                system: system_id,
+                bucket: bucket_id,
+                key: `imt_all_${Date.now().toString(36)}`,
+                content_type: 'application/octet-stream',
+                size: 50,
+            };
+            const chunk = { _id: chunk_id, system: system_id, bucket: bucket_id, size: 50, frag_size: 50 };
+            const part = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                obj: obj_id, chunk: chunk_id, start: 0, end: 50, seq: 0,
+            };
+            const block = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                node: md_store.make_md_id(), chunk: chunk_id, frag: frag_id, size: 50,
+            };
+
+            await md_store.insert_mappings_in_transaction({
+                object_md,
+                chunks: [chunk],
+                parts: [part],
+                blocks: [block],
+            });
+
+            const obj_row = await md_store.find_object_by_id(obj_id);
+            assert.strictEqual(obj_row.key, object_md.key);
+            const found_chunks = await md_store.find_chunks_by_ids([chunk_id]);
+            assert.strictEqual(found_chunks.length, 1);
+            assert.strictEqual(found_chunks[0].size, 50);
+            const found_parts = await md_store.find_parts_by_start_range({
+                obj_id, start_gte: 0, start_lt: 100, end_gt: 0,
+            });
+            assert(found_parts.length >= 1);
+        });
+
+        mocha.it('no object_md, mappings only', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const obj_id = md_store.make_md_id();
+            const chunk_id = md_store.make_md_id();
+            const chunk = { _id: chunk_id, system: system_id, bucket: bucket_id, size: 30, frag_size: 30 };
+            const part = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                obj: obj_id, chunk: chunk_id, start: 0, end: 30, seq: 0,
+            };
+            const block = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                node: md_store.make_md_id(), chunk: chunk_id, frag: md_store.make_md_id(), size: 30,
+            };
+
+            await md_store.insert_mappings_in_transaction({
+                object_md: null,
+                chunks: [chunk],
+                parts: [part],
+                blocks: [block],
+            });
+
+            const found_chunks = await md_store.find_chunks_by_ids([chunk_id]);
+            assert.strictEqual(found_chunks.length, 1);
+            const obj_row = await md_store.find_object_by_id(obj_id);
+            assert.strictEqual(obj_row, null);
+        });
+
+        mocha.it('empty arrays is no-op', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            await md_store.insert_mappings_in_transaction({
+                object_md: null,
+                chunks: [],
+                parts: [],
+                blocks: [],
+            });
+        });
+
+        mocha.it('rolls back all inserts on constraint violation', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const obj_id = md_store.make_md_id();
+            const chunk_id = md_store.make_md_id();
+            const frag_id = md_store.make_md_id();
+            const object_md = {
+                _id: obj_id,
+                system: system_id,
+                bucket: bucket_id,
+                key: `imt_rollback_${Date.now().toString(36)}`,
+                content_type: 'application/octet-stream',
+                size: 50,
+            };
+            const chunk1 = { _id: chunk_id, system: system_id, bucket: bucket_id, size: 50, frag_size: 50 };
+            const chunk_dup = { _id: chunk_id, system: system_id, bucket: bucket_id, size: 50, frag_size: 50 };
+            const part = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                obj: obj_id, chunk: chunk_id, start: 0, end: 50, seq: 0,
+            };
+            const block = {
+                _id: md_store.make_md_id(), system: system_id, bucket: bucket_id,
+                node: md_store.make_md_id(), chunk: chunk_id, frag: frag_id, size: 50,
+            };
+
+            await assert.rejects(
+                () => md_store.insert_mappings_in_transaction({
+                    object_md,
+                    chunks: [chunk1, chunk_dup],
+                    parts: [part],
+                    blocks: [block],
+                }),
+                /duplicate key|unique/i
+            );
+
+            const obj_row = await md_store.find_object_by_id(obj_id);
+            assert.strictEqual(obj_row, null, 'object should not exist after rollback');
+            const found_chunks = await md_store.find_chunks_by_ids([chunk_id]);
+            assert.strictEqual(found_chunks.length, 0, 'chunk should not exist after rollback');
+        });
+    });
+
+    mocha.describe('complete_object_upload_mark_remove_by_key', function() {
+
+        mocha.it('soft-deletes existing object by key and updates put_obj', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `mrk_test_${Date.now().toString(36)}`;
+            const old_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key,
+                content_type: 'text/plain',
+                size: 10,
+                etag: 'old_etag',
+                create_time: new Date(),
+            };
+            await md_store.insert_object(old_obj);
+
+            const put_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key,
+                content_type: 'text/plain',
+                size: 20,
+                upload_started: md_store.make_md_id(),
+                create_time: new Date(),
+            };
+            await md_store.insert_object(put_obj);
+
+            const set_updates = { size: 20, etag: 'new_etag', create_time: new Date() };
+            const unset_updates = { upload_started: true };
+
+            await md_store.complete_object_upload_mark_remove_by_key({
+                bucket_id,
+                key,
+                put_obj,
+                set_updates,
+                unset_updates,
+            });
+
+            const old_row = await md_store.find_object_by_id(old_obj._id);
+            assert(old_row.deleted, 'old object should be soft-deleted');
+            assert.strictEqual(old_row.version_past, true);
+
+            const new_row = await md_store.find_object_by_id(put_obj._id);
+            assert.strictEqual(new_row.etag, 'new_etag');
+            assert.strictEqual(new_row.size, 20);
+        });
+
+        mocha.it('succeeds when no prior object exists (UPDATE is no-op)', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `mrk_noop_${Date.now().toString(36)}`;
+            const put_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key,
+                content_type: 'text/plain',
+                size: 15,
+                upload_started: md_store.make_md_id(),
+                create_time: new Date(),
+            };
+            await md_store.insert_object(put_obj);
+
+            const set_updates = { size: 15, etag: 'solo_etag', create_time: new Date() };
+            const unset_updates = { upload_started: true };
+
+            await md_store.complete_object_upload_mark_remove_by_key({
+                bucket_id,
+                key,
+                put_obj,
+                set_updates,
+                unset_updates,
+            });
+
+            const row = await md_store.find_object_by_id(put_obj._id);
+            assert.strictEqual(row.etag, 'solo_etag');
+            assert.strictEqual(row.size, 15);
+        });
+    });
+
     mocha.describe('parts and blocks mapping queries', function() {
 
         const frag_id = md_store.make_md_id();

--- a/src/test/integration_tests/internal/test_object_io.js
+++ b/src/test/integration_tests/internal/test_object_io.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines-per-function: ["error", 700]*/
+/*eslint max-lines-per-function: ["error", 800]*/
 'use strict';
 
 // setup coretest first to prepare the env
@@ -100,145 +100,145 @@ coretest.describe_mapper_test_case({
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                              [   ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                              [   ]
+     */
     mocha.it('range_part_upload_and_verify_range_in_cache', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 120, end: 130 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:    0[        ]
-    */
-   mocha.it('range_part_upload_and_verify_partial_range_in_cache_start', async function() {
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:    0[        ]
+     */
+    mocha.it('range_part_upload_and_verify_partial_range_in_cache_start', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 0, end: 15 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                        [      ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                        [      ]
+     */
     mocha.it('range_part_upload_and_verify_partial_range_in_cache_middle_start', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 50, end: 150 }
         });
     });
 
-   /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                                   [      ]
-    */
-   mocha.it('range_part_upload_and_verify_partial_range_in_cache_middle_end', async function() {
+    /*
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                                   [      ]
+     */
+    mocha.it('range_part_upload_and_verify_partial_range_in_cache_middle_end', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 150, end: 250 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                                                       [      ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                                                       [      ]
+     */
     mocha.it('range_part_upload_and_verify_partial_range_in_cache_end', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 450, end: 510 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:        [              ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:        [              ]
+     */
     mocha.it('range_part_upload_and_verify_partial_range_covering_cache_part', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 5, end: 25 }
         });
     });
 
     /*
-    *  cached_parts:         [   data  ]      [           ]        [          ]
-    *  read_range:               [                ]
-    */
+     *  cached_parts:         [   data  ]      [           ]        [          ]
+     *  read_range:               [                ]
+     */
     mocha.it('range_part_upload_and_verify_range_span_multiple_cached_parts_1', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 15, end: 110 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:               [                           ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:               [                           ]
+     */
     mocha.it('range_part_upload_and_verify_range_span_multiple_cached_parts_2', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 15, end: 210 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                        [                                      ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                        [                                      ]
+     */
     mocha.it('range_part_upload_and_verify_range_span_multiple_cached_parts_3', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 50, end: 510 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:       [  ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:       [  ]
+     */
     mocha.it('range_part_upload_and_verify_range_not_in_cached_parts_at_start', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 5, end: 10 }
         });
     });
 
     /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                                         [   ]
-    */
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                                         [   ]
+     */
     mocha.it('range_part_upload_and_verify_range_not_in_cached_parts_middle', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 220, end: 240 }
         });
     });
 
-   /*
-    *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
-    *  read_range:                                                             [   ]
-    */
-   mocha.it('range_part_upload_and_verify_range_not_in_cached_parts_at_end', async function() {
+    /*
+     *  cached_parts:         [  data  ]      [  data     ]        [  data    ]
+     *  read_range:                                                             [   ]
+     */
+    mocha.it('range_part_upload_and_verify_range_not_in_cached_parts_at_end', async function() {
         this.timeout(600000); // eslint-disable-line no-invalid-this
         await range_parts_upload_and_verify({
-            cached_parts: [{start: 100, end: 200 }, {start: 10, end: 20 }, {start: 400, end: 500 }],
+            cached_parts: [{ start: 100, end: 200 }, { start: 10, end: 20 }, { start: 400, end: 500 }],
             read_range: { start: 501, end: 510 }
         });
     });
@@ -257,6 +257,85 @@ coretest.describe_mapper_test_case({
             cached_parts: [],
             read_range: { start: 220, end: 240 }
         });
+    });
+
+    mocha.it('upload zero-size object via deferred path', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const key = `${KEY}-${key_counter}`;
+        key_counter += 1;
+        const params = {
+            client: rpc_client,
+            bucket,
+            key,
+            size: 0,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(Buffer.alloc(0)),
+        };
+        await object_io.upload_object(params);
+        const object_md = await rpc_client.object.read_object_md({ bucket, key, adminfo: {} });
+        assert.strictEqual(object_md.num_parts, 0);
+        assert.strictEqual(object_md.capacity_size, 0);
+        assert.strictEqual(object_md.etag, 'd41d8cd98f00b204e9800998ecf8427e');
+        await rpc_client.object.delete_object({ bucket, key });
+        coretest.log('upload zero-size deferred: OK');
+    });
+
+    mocha.it('upload small object via deferred path and verify', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const data = generator.update(Buffer.alloc(61));
+        const key = `${KEY}-${key_counter}`;
+        key_counter += 1;
+        const params = {
+            client: rpc_client,
+            bucket,
+            key,
+            size: 61,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(data),
+        };
+        await object_io.upload_object(params);
+        const object_md = await rpc_client.object.read_object_md({ bucket, key, adminfo: {} });
+        assert.strictEqual(object_md.size, 61);
+        assert(object_md.num_parts >= 1, 'num_parts should be >= 1');
+        assert.strictEqual(typeof object_md.etag, 'string');
+        assert(object_md.etag.length > 0, 'etag should be non-empty');
+        await verify_read_data(key, data, params.obj_id);
+        await rpc_client.object.delete_object({ bucket, key });
+        coretest.log('upload small deferred: OK');
+    });
+
+    mocha.it('overwrite object with same key preserves integrity', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const data_a = generator.update(Buffer.alloc(61));
+        const data_b = generator.update(Buffer.alloc(91));
+        const key = `${KEY}-${key_counter}`;
+        key_counter += 1;
+
+        await object_io.upload_object({
+            client: rpc_client,
+            bucket,
+            key,
+            size: 61,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(data_a),
+        });
+        const md_a = await rpc_client.object.read_object_md({ bucket, key });
+
+        await object_io.upload_object({
+            client: rpc_client,
+            bucket,
+            key,
+            size: 91,
+            content_type: 'application/octet-stream',
+            source_stream: readable_buffer(data_b),
+        });
+        const md_b = await rpc_client.object.read_object_md({ bucket, key });
+
+        assert.notStrictEqual(md_b.etag, md_a.etag, 'overwrite should produce different etag');
+        assert.strictEqual(md_b.size, 91);
+        await verify_read_data(key, data_b, md_b.obj_id);
+        await rpc_client.object.delete_object({ bucket, key });
+        coretest.log('overwrite integrity: OK');
     });
 
     mocha.it('read_object_md with should_prefetch_mappings populates prefetched_mappings', async function() {
@@ -335,7 +414,9 @@ coretest.describe_mapper_test_case({
             multiparts.push(mp);
         }
         await rpc_client.object.complete_object_upload({
-            obj_id, bucket, key,
+            obj_id,
+            bucket,
+            key,
             multiparts: multiparts.map((mp, i) => ({ num: i + 1, etag: mp.etag })),
         });
 
@@ -508,8 +589,15 @@ coretest.describe_mapper_test_case({
         key_counter += 1;
         const content_type = 'test/test';
         const etag = crypto_random_string(32);
-        const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key, content_type,
-            complete_upload: true, size: 12345, etag, last_modified_time: (new Date()).getTime() });
+        const { obj_id } = await rpc_client.object.create_object_upload({
+            bucket,
+            key,
+            content_type,
+            complete_upload: true,
+            size: 12345,
+            etag,
+            last_modified_time: (new Date()).getTime()
+        });
 
         const { cached_parts, read_range } = params;
         for (const part of cached_parts) {
@@ -595,7 +683,7 @@ coretest.describe_mapper_test_case({
             const data = generator.update(Buffer.alloc(end - start));
             return {
                 buffer: data,
-                generated_missing_parts: [ { start, end, data: data } ]
+                generated_missing_parts: [{ start, end, data: data }]
             };
         }
 

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -237,6 +237,18 @@ function check_md_conditions(conditions, obj) {
 }
 
 /**
+ * True when conditional headers require loading the current object for comparison.
+ * Must stay aligned with the early-return branches in {@link check_md_conditions}.
+ * @param {MDConditions} [conditions]
+ * @returns {boolean}
+ */
+function has_md_conditions(conditions) {
+    if (!conditions) return false;
+    const { if_match_etag, if_none_match_etag, if_modified_since, if_unmodified_since } = conditions;
+    return Boolean(if_match_etag || if_none_match_etag || if_modified_since || if_unmodified_since);
+}
+
+/**
  * see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
  * @param {string} condition the condition string from the header
  * @param {string} etag the object etag to match
@@ -1109,6 +1121,7 @@ exports.parse_url_query = parse_url_query;
 exports.parse_client_ip = parse_client_ip;
 exports.get_md_conditions = get_md_conditions;
 exports.check_md_conditions = check_md_conditions;
+exports.has_md_conditions = has_md_conditions;
 exports.match_etag = match_etag;
 exports.parse_http_ranges = parse_http_ranges;
 exports.format_http_ranges = format_http_ranges;

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -10,7 +10,7 @@ const { default: Ajv } = require('ajv');
 const crypto = require('crypto');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
-const { Pool, Client } = require('pg');
+const { Pool, Client, escapeLiteral } = require('pg');
 
 const P = require('./promise');
 const dbg = require('./debug_module')(__filename);
@@ -245,7 +245,8 @@ function convert_timestamps(where_clause) {
 }
 
 
-async function _do_query(pg_client, q, transaction_counter) {
+async function _do_query(pg_client, q, transaction_counter, options = {}) {
+    const {log_errors = true} = options;
     query_counter += 1;
 
     dbg.log3("pg_client.options?.host =", pg_client.options?.host, ", retry =", pg_client.retry_with_default_pool, ", q =", q);
@@ -265,7 +266,9 @@ async function _do_query(pg_client, q, transaction_counter) {
         return res;
     } catch (err) {
         if (err.routine === 'index_create' && err.code === '42P07') return;
-        dbg.error(`postgres_client: ${tag}: failed with error:`, err);
+        if (log_errors) {
+            dbg.error(`postgres_client: ${tag}: failed with error:`, err);
+        }
         await log_query(pg_client, q, tag, 0, /*should_explain*/ false);
         if (pg_client.retry_with_default_pool) {
             dbg.warn("retrying with default pool. q = ", q);
@@ -367,6 +370,34 @@ class PgTransaction {
         await this.query('COMMIT TRANSACTION');
     }
 
+    /**
+     * Acquire a connection, wrap the given queries in BEGIN/COMMIT, and send
+     * everything as a single round-trip. On error the transaction is rolled
+     * back before the connection is returned to the pool.
+     * @param {string} batch_text - semicolon-separated SQL (without BEGIN/COMMIT)
+     * @returns {Promise<any[]>} result set for each query (BEGIN/COMMIT entries excluded)
+     */
+    async execute_batch(batch_text) {
+        try {
+            this.pg_client = await this.pg_pool.connect();
+        } catch (err) {
+            dbg.error(DB_CONNECT_ERROR_MESSAGE, err);
+            throw new Error(DB_CONNECT_ERROR_MESSAGE);
+        }
+        this.pg_client.once('error', err => {
+            dbg.error('got error on pg_transaction', err, this.transaction_id);
+        });
+        try {
+            const full_query = `BEGIN; ${batch_text}; COMMIT`;
+            const raw = await _do_query(this.pg_client, { text: full_query }, this.transaction_id);
+            const results = Array.isArray(raw) ? raw : [raw];
+            return results.filter(r => r.command !== 'BEGIN' && r.command !== 'COMMIT');
+        } catch (err) {
+            try { await _do_query(this.pg_client, { text: 'ROLLBACK' }, this.transaction_id); } catch (rollback_err) { dbg.warn('rollback after batch error failed', rollback_err); }
+            throw err;
+        }
+    }
+
     async rollback() {
         await this.query('ROLLBACK TRANSACTION');
     }
@@ -411,15 +442,8 @@ class BulkOp {
         let nMatched = 0;
         let nModified = 0;
         let nRemoved = 0;
-        let should_rollback = false;
         try {
-            await this.transaction.begin();
-            should_rollback = true;
-            const batch_query = this.queries.join('; ');
-            let results = await this.transaction.query(batch_query);
-            if (!Array.isArray(results)) {
-                results = [results];
-            }
+            const results = await this.transaction.execute_batch(this.queries.join('; '));
             for (const res of results) {
                 if (res.command === 'UPDATE') {
                     nModified += res.rowCount;
@@ -430,12 +454,10 @@ class BulkOp {
                     nRemoved += res.rowCount;
                 }
             }
-            await this.transaction.commit();
             ok = true;
         } catch (err) {
             pg_error = err;
-            dbg.error('PgTransaction execute error', err);
-            if (should_rollback) await this.transaction.rollback();
+            dbg.error('BulkOp execute error', err);
         } finally {
             this.transaction.release();
         }
@@ -523,6 +545,34 @@ class OrderedBulkOp extends BulkOp {
         };
     }
 
+}
+
+/**
+ * BulkOp that can insert into multiple tables in a single batched transaction.
+ * Extends BulkOp to reuse add_query(), execute(), and transaction lifecycle.
+ * Unlike the single-table BulkOp, the constructor does not require a table
+ * name or schema — those are provided per-entry in insert_many().
+ */
+class MultiTableBulkOp extends BulkOp {
+    constructor({ pg_pool }) {
+        super({ pg_pool, name: undefined, schema: undefined });
+    }
+
+    /**
+     * @param {{ table: PostgresTable, docs: object[] }[]} entries
+     */
+    insert_many(entries) {
+        for (const { table, docs } of entries) {
+            if (!docs || !docs.length) continue;
+            const values = docs.map(doc => {
+                table.validate(doc);
+                const _id = get_id(doc);
+                return `(${escapeLiteral(String(_id))}, ${escapeLiteral(JSON.stringify(encode_json(table.schema, doc)))})`;
+            });
+            this.add_query(`INSERT INTO ${table.name}(_id, data) VALUES ${values.join(', ')}`);
+        }
+        return this;
+    }
 }
 
 class PostgresSequence {
@@ -1324,6 +1374,10 @@ class PostgresClient extends EventEmitter {
         return this.pools[name].instance;
     }
 
+    initializeMultiTableBulkOp(pool_name = 'default') {
+        return new MultiTableBulkOp({ pg_pool: this.get_pool(pool_name) });
+    }
+
     /**
      * Resolve pool for raw SQL. If `preferred_pool` is missing or unavailable,
      * falls back to the `default` pool (same name as {@link PostgresClient#get_pool}).
@@ -1352,11 +1406,12 @@ class PostgresClient extends EventEmitter {
      * @param {{
      *   query_name?: string,
      *   preferred_pool?: string,
+     *   log_errors?: boolean,
      * }} [options={}]
      * @returns {Promise<import('pg').QueryResult<T>>}
      */
     async executeSQL(query, params, options = {}) {
-        const { query_name, preferred_pool = 'default' } = options;
+        const { query_name, preferred_pool = 'default', log_errors = true } = options;
         const pool = this._get_pool_for_sql(preferred_pool);
 
         const q = {
@@ -1368,7 +1423,7 @@ class PostgresClient extends EventEmitter {
             q.name = query_name;
         }
 
-        const res = await _do_query(pool, q, 0);
+        const res = await _do_query(pool, q, 0, { log_errors });
 
         return res;
     }
@@ -1859,5 +1914,8 @@ PostgresClient._instance = undefined;
 
 // EXPORTS
 exports.PostgresClient = PostgresClient;
+exports.PgTransaction = PgTransaction;
 exports.instance = PostgresClient.instance;
+exports.encode_json = encode_json;
 exports.decode_json = decode_json;
+exports.escapeLiteral = escapeLiteral;


### PR DESCRIPTION
### Describe the Problem

NooBaa stores object metadata in PostgreSQL. Every S3 `PutObject` issues several independent INSERT/UPDATE statements (create upload, put mappings, complete upload), each triggering its own WAL flush. For small-object workloads the metadata overhead dominates: a 4 KB object generates 5-7+ WAL flushes, saturating the WAL device long before CPU or network become the bottleneck.

### Explain the Changes

1. **Deferred `create_object_upload`**: For simple (non-multipart) uploads on `DISABLED` versioning buckets, the `INSERT INTO objectmds` is skipped. The constructed `objectmd` is returned in the RPC response and carried by the client through the upload.
2. **Client-side mapping accumulation (`object_io.js`)**: `upload_object` always requests `defer_put_mapping = true` for non-copy simple uploads. `_upload_chunks` accumulates chunk/part/block metadata in memory instead of calling `put_mapping`. When accumulated parts exceed `DEFERRED_PUT_MAPPING_MAX_PARTS` (default 30), the deferred batch is flushed together with the deferred object metadata in a single `put_mapping` call.
3. **Transactional mapping inserts (`map_server.js`, `md_store.js`)**: `PutMapping.update_db()` always wraps all mapping inserts (chunks, parts, blocks) into a single batched transaction via `MDStore.insert_mappings_in_transaction()`, reducing WAL flushes even for non-deferred paths.
4. **Split `complete_object_upload` (`object_server.js`)**: Completion is split into `_complete_simple_upload` (simple PUT) and `_complete_multipart_upload` (multipart, unchanged). For simple uploads, the `_complete_object_parts` step is eliminated — parts are inserted without the `uncommitted` flag.
5. **Single-batch completion for DISABLED versioning (`md_store.js`, `object_server.js`)**: For the common case (no conditional headers), the `find_object_null_version` SELECT is eliminated. Soft-delete of any prior object is performed by key inside the same batched transaction using `delete_and_insert_deferred` (deferred path) or `complete_object_upload_mark_remove_by_key` (non-deferred path). When conditional headers are present, the SELECT is issued first so conditions can be evaluated.
6. **`PgTransaction.execute_batch` (`postgres_client.js`)**: New method that sends `BEGIN; queries; COMMIT` as a single round-trip. `BulkOp.execute()` updated to use it, reducing round trips for all existing bulk operations.
7. **`MultiTableBulkOp` (`postgres_client.js`)**: New class extending `BulkOp` for cross-table batched inserts. Adds `insert_many()` for multi-table INSERT; inherits `add_query()` and `execute()`. Accessed via `PostgresClient.initializeMultiTableBulkOp()` factory method.
8. **SQL injection prevention**: Raw SQL in new MDStore methods uses `pg.escapeLiteral` for all interpolated values.
9. **Copy object fix**: `copy_object_mapping` now conditionally sets `part.uncommitted` only for multipart copies, preventing copied parts from being invisible to read operations.
10. **Graceful abort**: On error, if the upload is still deferred (object metadata never inserted), the abort RPC is skipped.
11. **`object_api.js`**: Added `defer_put_mapping`, `deferred_object_md`, and `deferred_chunks` to RPC parameters/replies.
12. **`http_utils.js`**: Added `has_md_conditions` helper to detect conditional headers.

**WAL flush impact (common case, no conditional headers):**
| Scenario | Before | After | DB round trips |
|---|---|---|---|
| Small object, new key, DISABLED versioning | 5–7 flushes | **1 flush** | nextval + 1 batch |
| Small object, overwrite, DISABLED versioning | 6–8 flushes | **1 flush** | nextval + 1 batch |
| Small object, ENABLED versioning | 5–7 flushes | **3–4 flushes** | nextval + SELECT + batch |
| Large object (> threshold), DISABLED versioning | 5–7+ flushes | **2–3 flushes** | nextval + M batches |

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8748

### Testing Instructions:
1. Run `test_md_store` integration tests — new test cases covering `delete_and_insert_deferred` (by-id, by-key, no prior object), `insert_mappings_in_transaction` (with/without objectmd, empty arrays), and `complete_object_upload_mark_remove_by_key` (overwrite, no prior object).
2. Run `test_object_io` integration tests — test cases covering zero-size deferred upload, small object deferred upload with data verification, and key overwrite integrity.
3. Run `test_s3_ops` integration tests — enhanced existing copy-object tests to verify body content (not just listing), and added tests for copy-overwrite, cross-bucket copy, and multipart copy verification.
4. Run Ceph S3 tests to verify no regression in copy-object paths.

- [x] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred object-upload flow to batch metadata writes and improve small-object upload performance; SDK/client option to defer/skip immediate mapping and new API fields to support deferred uploads.
* **Documentation**
  * Added detailed design doc describing the deferred upload and batching approach.
* **Tests**
  * Expanded integration tests for deferred uploads, overwrite/deferred DB flows, and stronger S3 copy/data-integrity verifications.
* **Chores**
  * New configuration setting to control deferred flush threshold and small utility export to aid conditional-request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->