### PR TITLE
vectors - create vector index - add validation to dataType and dimension

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1064,6 +1064,10 @@ module.exports = {
                 properties: {
                     vector_index_name: { wrapper: SensitiveString },
                     vector_bucket_name: { wrapper: SensitiveString },
+                    data_type: {
+                        type: 'string',
+                        enum: ['float32']
+                    },
                     distance_metric: {
                         type: 'string',
                         enum: ['cosine', 'euclidean']

--- a/src/endpoint/vector/ops/vector_index_create.js
+++ b/src/endpoint/vector/ops/vector_index_create.js
@@ -3,6 +3,8 @@
 //const config = require('../../../../config');
 const dbg = require('../../../util/debug_module')(__filename);
 
+const { VectorError } = require('../vector_errors');
+
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_CreateIndex.html
  */
@@ -14,6 +16,8 @@ async function post_create_index(req, res) {
     const vector_bucket_name = req.body.vectorBucketName;
     const dimension = req.body.dimension;
     const distance_metric = req.body.distanceMetric;
+    const data_type = req.body.dataType;
+
     let metadata_configuration;
     if (req.body.metadataConfiguration) {
         metadata_configuration = {
@@ -21,9 +25,28 @@ async function post_create_index(req, res) {
         };
     }
 
+    if (dimension < 1 || dimension > 4096) {
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList: [{path: 'dimension', message: "Invalid value."}],
+        });
+    }
+
+    if (data_type !== 'float32') {
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList: [{path: 'dataType', message: "Invalid value."}],
+        });
+    }
+
     await req.vector_sdk.create_vector_index({
         vector_index_name,
         vector_bucket_name,
+        data_type,
         dimension,
         distance_metric,
         metadata_configuration

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2459,7 +2459,7 @@ async function create_vector_index(req) {
         vector_index.vector_bucket = vector_bucket._id;
         vector_index.distance_metric = req.rpc_params.distance_metric;
         vector_index.dimension = req.rpc_params.dimension;
-        vector_index.data_type = 'float32';
+        vector_index.data_type = req.rpc_params.data_type || 'float32';
         vector_index.metadata_configuration = req.rpc_params.metadata_configuration;
 
         changes.insert.vector_indices = [vector_index];


### PR DESCRIPTION
### Describe the Problem
Vector index can be created with wrong dimension.
Create vector index ignores dataType given by user (there's only one applicable value).

### Explain the Changes
1. Add validation to the fields.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6758
2. https://redhat.atlassian.net/browse/DFBUGS-6757

### Testing Instructions:
1. See bugs.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional data_type parameter for vector index creation (supports float32).
* **Bug Fixes / Improvements**
  * Input validation for vector index dimension (1–4096) and data_type with clearer validation responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->