### PR TITLE
Filter by deleted when listing multipart parts from the DB

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1291,6 +1291,7 @@ class MDStore {
             size: { $exists: true },
             md5_b64: { $exists: true },
             create_time: { $exists: true },
+            deleted: null,
         }, {
             sort: {
                 num: 1,


### PR DESCRIPTION
### Describe the Problem
- in object_server.list_multiparts, the query did not filter by "deleted".
- This is both wrong semantically and caused the query to miss the index.

### Explain the Changes
1. Added `deleted: null` to the md_store query.
2. The query now hit the necessary index.

#### Query plan before:
```sql
nbcore=# EXPLAIN SELECT * FROM objectmultiparts WHERE ((data->>'obj'='69ef2eaf8b04fc000d445b17' and data ? 'obj') and data->'num'>'0'::jsonb and data ? 'size' and data ? 'md5_b64' and data ? 'create_time') ORDER BY data->'num' ASC, data->'create_time' DESC LIMIT 1000;
                                                                                                                  QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=25.31..25.32 rows=1 width=196)
   ->  Sort  (cost=25.31..25.32 rows=1 width=196)
         Sort Key: ((data -> 'num'::text)), ((data -> 'create_time'::text)) DESC
         ->  Seq Scan on objectmultiparts  (cost=0.00..25.30 rows=1 width=196)
               Filter: ((data ? 'obj'::text) AND (data ? 'size'::text) AND (data ? 'md5_b64'::text) AND (data ? 'create_time'::text) AND ((data -> 'num'::text) > '0'::jsonb) AND ((data ->> 'obj'::text) = '69ef2eaf8b04fc000d445b17'::text))
(5 rows)
```

#### Query plan after:
```sql
nbcore=# EXPLAIN SELECT * FROM objectmultiparts WHERE ((data->>'obj'='69ef2eaf8b04fc000d445b17' and data ? 'obj') and data->'num'>'0'::jsonb and data ? 'size' and data ? 'md5_b64' and data ? 'create_time' AND data ? 'deleted') ORDER BY data->'num' ASC, data->'create_time' DESC LIMIT 1000;
                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.17..8.18 rows=1 width=196)
   ->  Sort  (cost=8.17..8.18 rows=1 width=196)
         Sort Key: ((data -> 'num'::text)), ((data -> 'create_time'::text)) DESC
         ->  Index Scan using idx_btree_objectmultiparts_obj on objectmultiparts  (cost=0.12..8.16 rows=1 width=196)
               Index Cond: ((data ->> 'obj'::text) = '69ef2eaf8b04fc000d445b17'::text)
               Filter: ((data ? 'size'::text) AND (data ? 'md5_b64'::text) AND (data ? 'create_time'::text) AND ((data -> 'num'::text) > '0'::jsonb))
(6 rows)
```


### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6548

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of multipart operation queries by filtering out deleted items, ensuring only active operations are returned in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->