### PR TITLE
vectors - use upsert (dfs 6782), validate dimension (dfs 6785)

### DIFF
--- a/src/endpoint/vector/ops/vector_put_vectors.js
+++ b/src/endpoint/vector/ops/vector_put_vectors.js
@@ -3,12 +3,29 @@
 //const config = require('../../../../config');
 const dbg = require('../../../util/debug_module')(__filename);
 
+const { VectorError } = require('../vector_errors');
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_PutVectors.html
  */
 async function post_put_vectors(req, res) {
 
     dbg.log0("post_put_vectors body = ", req.body);
+
+    //validate vectors length matches index's dimension
+    const vectors = req.body.vectors;
+    const dimension = req.vector_index.dimension;
+
+    for (const vector of vectors) {
+        if (vector.data?.float32?.length !== dimension) {
+            throw new VectorError({
+                code: VectorError.ValidationException.code,
+                http_code: VectorError.ValidationException.http_code,
+                message: `Invalid record for key ${vector.key}: vector must have length ${dimension}, but has length ${vector.data?.float32?.length}`,
+                fieldList: [{path: 'vectors', message: "Vector has different dimension than index."}],
+            });
+        }
+    }
+
 
     await req.vector_sdk.put_vectors({
         vector_bucket_name: req.body.vectorBucketName,

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -171,8 +171,12 @@ class LanceConn extends VectorConn {
 
         let table = await this.get_table(table_name);
         if (table) {
-            dbg.log("put_vectors table found in memory");
-            await table.add(lance_vectors);
+            dbg.log0("put_vectors table found in memory");
+            //perform upsert - update if id already exists, otherwise insert
+            await table.mergeInsert("id")
+                .whenMatchedUpdateAll()
+                .whenNotMatchedInsertAll()
+                .execute(lance_vectors);
         } else {
             dbg.log0("put_vectors create table");
             try {


### PR DESCRIPTION
### Describe the Problem
1. Duplicate keys are allowed in index.
2. Vector dimension is not validated

### Explain the Changes
1. Perform upsert instead of insert to update key instead of duplicate it.
2. Validate vectors' dimension in put-vectors handler.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6782
2. https://redhat.atlassian.net/browse/DFBUGS-6785

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector dimension validation now provides clear error messages when vectors don't match index dimension requirements.

* **Bug Fixes**
  * Vector upsert operations improved to update existing entries instead of creating duplicate records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->