### PR TITLE
use prepared statements for db get querries

### DIFF
--- a/config.js
+++ b/config.js
@@ -693,6 +693,8 @@ config.INLINE_MAX_SIZE = 4096;
 // (IO_OBJECT_RANGE_ALIGN / CHUNK_SPLIT_AVG_CHUNK). Objects with more parts fall back to
 // the standard read_object_mapping RPC.
 config.MAPPINGS_PREFETCH_NUM_PARTS = config.IO_OBJECT_RANGE_ALIGN / config.CHUNK_SPLIT_AVG_CHUNK;
+// When true, use named prepared statements so PostgreSQL can cache the query plan across calls
+config.DB_PREPARED_STATEMENTS_ENABLED = true;
 
 config.DEFERRED_PUT_MAPPING_MAX_PARTS = 30; // max deferred parts before flushing mappings to DB
 ///////////////////////////////

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -2074,7 +2074,12 @@ class MDStore {
                 AND (p.data->>'end')::bigint > $4
         `;
         const values = [String(obj_id), start_gte, start_lt, end_gt];
-        const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
+        const res = await db_client.instance().executeSQL(query, values, {
+            preferred_pool: this._postgres_pool,
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
+                `find_parts_chunks_blocks_by_range:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
+                undefined,
+        });
         return _parse_mapping(res.rows[0]?.mapping, sorter);
     }
 
@@ -2135,7 +2140,12 @@ class MDStore {
             GROUP BY obj._id, obj.data
         `;
         const values = [`${bucket_id}`, key, max_parts];
-        const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
+        const res = await db_client.instance().executeSQL(query, values, {
+            preferred_pool: this._postgres_pool,
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
+                `find_object_with_mapping_by_key:${this._objects.name}:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
+                undefined,
+        });
         if (!res.rows.length) return null;
         const row = res.rows[0];
         const obj = decode_json(object_md_schema, row.obj_data);


### PR DESCRIPTION
### Describe the Problem
following #9514 the two new statements still take a lot of time to prepare in the postgress DB

### Explain the Changes
1. add a statement name so postgress will use the statements as prepare statements and cache the plan for subsequent calls

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8846

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configuration toggle to enable or disable named prepared statements for PostgreSQL (enabled by default).
* **Improvements**
  * When enabled, database queries can be sent with stable, reusable names so the database can cache query plans, reducing latency and improving query stability and predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->