### PR TITLE
vectors - metadata in list vectors (6818) and get index(6817), get vectors op (6820)

### DIFF
--- a/src/endpoint/vector/ops/vector_get_vectors.js
+++ b/src/endpoint/vector/ops/vector_get_vectors.js
@@ -1,0 +1,35 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+//const config = require('../../../../config');
+const dbg = require('../../../util/debug_module')(__filename);
+
+const { VectorError } = require('../vector_errors');
+
+/**
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetVectors.html
+ */
+async function post_get_vectors(req, res) {
+
+    dbg.log0("post_get_vectors body = ", req.body);
+
+    if (!Array.isArray(req.body.keys) || req.body.keys.length === 0) {
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList: [{path: 'keys', message: "Invalid value."}],
+        });
+    }
+
+    const list = await req.vector_sdk.get_vectors({
+        vector_bucket_name: req.body.vectorBucketName,
+        vector_index_name: req.body.indexName,
+        keys: req.body.keys,
+        return_metadata: req.body.returnMetadata,
+    });
+
+    return list;
+}
+
+exports.handler = post_get_vectors;
+

--- a/src/endpoint/vector/ops/vector_index_get.js
+++ b/src/endpoint/vector/ops/vector_index_get.js
@@ -12,7 +12,7 @@ async function post_get_index(req, res) {
 
     const vector_index_info = req.vector_index;
 
-    return {
+    const vector_index_info_aws = {
         index: {
             indexName: vector_index_info.name,
             vectorBucketName: vector_index_info.vector_bucket,
@@ -20,9 +20,16 @@ async function post_get_index(req, res) {
             dataType: vector_index_info.data_type,
             distanceMetric: vector_index_info.distance_metric,
             creationTime: vector_index_info.creation_time / 1000,
-            metadataConfiguration: vector_index_info.metadata_configuration,
         }
     };
+
+    if (vector_index_info.metadata_configuration?.non_filterable_metadata_keys?.length) {
+        vector_index_info_aws.index.metadataConfiguration = {
+            nonFilterableMetadataKeys: vector_index_info.metadata_configuration.non_filterable_metadata_keys
+        };
+    }
+
+    return vector_index_info_aws;
 }
 
 exports.handler = post_get_index;

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -95,6 +95,11 @@ const VECTOR_OPS = js_utils.deep_freeze({
         load_vector_bucket: true,
         load_vector_index: true,
     },
+    GetVectors: {
+        handler: require('./ops/vector_get_vectors'),
+        load_vector_bucket: true,
+        load_vector_index: true,
+    },
     DeleteVectors: {
         handler: require('./ops/vector_delete_vectors'),
         load_vector_bucket: true,

--- a/src/sdk/vector_sdk.js
+++ b/src/sdk/vector_sdk.js
@@ -125,6 +125,10 @@ class VectorSDK {
         return await vector_utils.list_vectors(this.req.vector_bucket, this.req.vector_index, params);
     }
 
+    async get_vectors(params) {
+        return await vector_utils.get_vectors(this.req.vector_bucket, this.req.vector_index, params);
+    }
+
     async delete_vectors(params) {
         await vector_utils.delete_vectors(this.req.vector_bucket, this.req.vector_index, params.keys);
     }

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -355,6 +355,38 @@ mocha.describe('vectors_ops', function() {
             validate_vector_index(response.index, vector_bucket_name1, vector_index_name1, beforeTs, afterTs);
         });
 
+        mocha.it('should get a vector index (metadataConfiguration)', async function() {
+            const beforeTs = Date.now();
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const metadata_configuration = {
+                nonFilterableMetadataKeys: ['field_name', 'field_name2']
+            };
+            const create_command = new s3vectors.CreateIndexCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                dataType: s3vectors.DataType.FLOAT32,
+                dimension: 3,
+                distanceMetric: s3vectors.DistanceMetric.EUCLIDEAN,
+                metadataConfiguration: metadata_configuration
+            });
+            await send(s3_vectors_client, create_command);
+            created_vector_indices.push({
+                vector_bucket: vector_bucket_name1,
+                vector_index: vector_index_name1
+            });
+            const afterTs = Date.now();
+
+            const get_command = new s3vectors.GetIndexCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+            });
+            const response = await send(s3_vectors_client, get_command);
+
+            validate_vector_index(response.index, vector_bucket_name1, vector_index_name1, beforeTs, afterTs);
+            assert.deepStrictEqual(response.index.metadataConfiguration, metadata_configuration);
+        });
+
         mocha.it('should delete a vector index', async function() {
             await create_vector_index(s3_vectors_client, created_vector_buckets,
                 created_vector_indices, vector_bucket_name1, vector_index_name1);
@@ -410,6 +442,40 @@ mocha.describe('vectors_ops', function() {
             const response = await send(s3_vectors_client, list_command);
 
             compare_vectors(response.vectors, vectors, true);
+        });
+
+        mocha.it('should list vectors (return_metadata)', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const vectors = [
+                {
+                    key: "vector_id_1",
+                    data: {float32: [0.1, 0.2, 0.3]},
+                    metadata: {source_file: 'doc1.txt', chunk_id: '1'}
+                },
+                {
+                    key: "vector_id_2",
+                    data: {float32: [0.4, 0.5, 0.6]},
+                    metadata: {source_file: 'doc2.txt', chunk_id: '2'}
+                }
+            ];
+
+            const put_command = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                vectors
+            });
+            await send(s3_vectors_client, put_command);
+
+            const list_command = new s3vectors.ListVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                returnMetadata: true,
+            });
+            const response = await send(s3_vectors_client, list_command);
+
+            compare_vectors(response.vectors, vectors, true, true);
         });
 
         mocha.it('should list vectors (next_token, max_results)', async function() {
@@ -1512,6 +1578,45 @@ mocha.describe('vectors_ops', function() {
             compare_vectors(response.vectors, vectors, false);
         });
 
+        mocha.it('should get vectors by key', async function() {
+            await create_vector_index(s3_vectors_client, created_vector_buckets,
+                created_vector_indices, vector_bucket_name1, vector_index_name1);
+
+            const vectors = [
+                {
+                    key: "vector_id_1",
+                    data: { float32: [1, 2, 3] },
+                    metadata: {
+                        color: "red"
+                    }
+                },
+                {
+                    key: "vector_id_2",
+                    data: { float32: [3, 4, 5] },
+                    metadata: {
+                        color: "blue"
+                    }
+                }
+            ];
+
+            const put_command = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                vectors
+            });
+            await send(s3_vectors_client, put_command);
+
+            const get_command = new s3vectors.GetVectorsCommand({
+                vectorBucketName: vector_bucket_name1,
+                indexName: vector_index_name1,
+                keys: ["vector_id_2", "vector_id_1"],
+                returnMetadata: true
+            });
+            const response = await send(s3_vectors_client, get_command);
+
+            compare_vectors(response.vectors, vectors, true);
+        });
+
         mocha.it('should create a vector bucket (default resource)', async function() {
 
             //make an account with a default NSR
@@ -1613,21 +1718,25 @@ async function send(client, command) {
     return response;
 }
 
-function compare_vectors(actual, expected, expect_data) {
+function compare_vectors(actual, expected, expect_data, expect_metadata) {
     assert.strictEqual(actual.length, expected.length);
 
-    const expected_map = new Map(expected.map(x => [x.key, expect_data ? x.data.float32 : x]));
+    const expected_map = new Map(expected.map(x => [x.key, x]));
 
     for (let i = 0; i < actual.length; ++i) {
         const actual_vector = actual[i];
-        const expected_data = expected_map.get(actual_vector.key);
-        assert(expected_data);
+        const expected_vector = expected_map.get(actual_vector.key);
+        assert(expected_vector);
         if (expect_data) {
             const actual_data = actual_vector.data.float32;
+            const expected_data = expected_vector.data.float32;
             assert.strictEqual(actual_data.length, expected_data.length);
             for (let j = 0; j < actual_data.length; ++j) {
                 assert(Math.abs(actual_data[j] - expected_data[j]) < 0.00001);
             }
+        }
+        if (expect_metadata) {
+            assert.deepStrictEqual(actual_vector.metadata, expected_vector.metadata);
         }
     }
 }

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -520,6 +520,7 @@ const VECTOR_OP_NAME_TO_ACTION = Object.freeze({
     DeleteIndex: 's3vectors:DeleteIndex',
     PutVectors: 's3vectors:PutVectors',
     ListVectors: 's3vectors:ListVectors',
+    GetVectors: 's3vectors:GetVectors',
     QueryVectors: 's3vectors:QueryVectors',
     DeleteVectors: 's3vectors:DeleteVectors',
     PutVectorBucketPolicy: 's3vectors:PutVectorBucketPolicy',

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -243,7 +243,7 @@ class LanceConn extends VectorConn {
         query.limit(limit);
         const lance_res = await query.toArray();
         dbg.log0("list_vectors lance_res =", lance_res);
-        const aws_vectors = Array.from(lance_res, lance_vector => this._lance_to_aws(lance_vector));
+        const aws_vectors = Array.from(lance_res, lance_vector => this._lance_to_aws(lance_vector, params.return_metadata));
         dbg.log0("list_vectors aws_vectors =", aws_vectors);
         return {
             vectors: aws_vectors,
@@ -268,6 +268,20 @@ class LanceConn extends VectorConn {
         const aws_vectors = Array.from(lance_res, lance_vector => this._lance_to_aws(lance_vector, return_metadata, return_distance));
         dbg.log0("query_vectors aws_vectors =", aws_vectors);
         return {vectors: aws_vectors}; //TODO - return distance metric?
+    }
+
+    async get_vectors(vector_bucket, vector_index, ids, return_metadata) {
+        dbg.log2("get_vectors vector_bucket =", vector_bucket.name.unwrap(), ", vector_index =", vector_index.name.unwrap(), ", ids =", ids);
+        const table_name = vector_bucket.name.unwrap() + "_" + vector_index.name.unwrap();
+        const table = await this.get_table(table_name);
+
+        // Escape single quotes in ids to prevent injection
+        const escaped_ids = ids.map(qoute_string);
+        const lance_res = await table.query().where('id in (' + escaped_ids.join(',') + ')').toArray();
+        dbg.log2("get_vectors lance_res =", lance_res);
+        const aws_vectors = Array.from(lance_res, lance_vector => this._lance_to_aws(lance_vector, return_metadata));
+        dbg.log2("get_vectors aws_vectors =", aws_vectors);
+        return { vectors: aws_vectors };
     }
 
     async delete_vectors(vector_bucket, vector_index, ids) {
@@ -425,6 +439,12 @@ async function query_vectors(vector_bucket, vector_index, {query_vector, topk, r
     return await vc.query_vectors(vector_bucket, vector_index, query_vector.float32, topk, return_metadata, return_distance, filter);
 }
 
+async function get_vectors(vector_bucket, vector_index, {keys, return_metadata}) {
+    dbg.log2("get_vectors vector_bucket_name =", vector_bucket.name.unwrap(), ", vector_index_name =", vector_index.name.unwrap(), ", keys =", keys);
+    const vc = await getVectorConn(vector_bucket);
+    return await vc.get_vectors(vector_bucket, vector_index, keys, return_metadata);
+}
+
 async function delete_vectors(vector_bucket, vector_index, keys) {
     dbg.log0("delete_vectors vector_bucket_name =", vector_bucket.name.unwrap(), ", vector_index_name =", vector_index.name.unwrap(), ", keys =", keys);
     const vc = await getVectorConn(vector_bucket);
@@ -453,5 +473,6 @@ exports.delete_vector_index = delete_vector_index;
 exports.put_vectors = put_vectors;
 exports.list_vectors = list_vectors;
 exports.query_vectors = query_vectors;
+exports.get_vectors = get_vectors;
 exports.delete_vectors = delete_vectors;
 exports.next_token_sanity_check = next_token_sanity_check;


### PR DESCRIPTION
### Describe the Problem
-list vectors ignores 'return-metadata' parameter.
-get index does not return metadataConfiguration field content.
-get vectors op is missing

### Explain the Changes
1. Pass 'return-metadata' param to vector connection's list vectors impl.
2. Fix metadataConfiguration field name in get index op.
3. Add get vector op.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6818
2. https://redhat.atlassian.net/browse/DFBUGS-6817
3. https://redhat.atlassian.net/browse/DFBUGS-6820

### Testing Instructions:
1.  node ./node_modules/mocha/bin/mocha ./src/test/integration_tests/api/vectors/test_vectors_ops.js


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve multiple vectors simultaneously by their keys
  * Vectors can now optionally be returned with their associated metadata

* **Bug Fixes**
  * Fixed vector index metadata configuration handling to return only when data is present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->