### PR TITLE
fix race condition when loading system_store in CORE source path

### DIFF
--- a/src/server/bg_services/objects_reclaimer.js
+++ b/src/server/bg_services/objects_reclaimer.js
@@ -30,7 +30,7 @@ class ObjectsReclaimer {
         const reclaimed_objects_ids = [];
         await P.all(unreclaimed_objects.map(async obj => {
             try {
-                await map_deleter.delete_object_mappings(obj, true);
+                await map_deleter.delete_object_mappings(obj);
                 reclaimed_objects_ids.push(obj._id);
             } catch (err) {
                 dbg.error(`got error when trying to delete object ${obj.key} mappings :`, err);

--- a/src/server/system_services/system_store.js
+++ b/src/server/system_services/system_store.js
@@ -468,14 +468,14 @@ class SystemStore extends EventEmitter {
 
                 if (this.source === SOURCE.CORE) {
                     try {
-                        this.data = new SystemStoreData();
-                        await this._read_new_data_from_core(this.data);
+                        await this._read_new_data_from_core(new_data);
                     } catch (e) {
                         dbg.error("Failed to load system store from core. Will load from db.", e);
                         from_core_failure = true;
                     }
                 }
 
+                // _read_new_data_from_db overwrites all collections, so partial CORE data is safe
                 if (this.source === SOURCE.DB || from_core_failure) {
                     await this._read_new_data_from_db(new_data);
                 }
@@ -492,6 +492,10 @@ class SystemStore extends EventEmitter {
                 if (this.source === SOURCE.DB || from_core_failure) {
                     this.old_db_data = this._update_data_from_new(this.old_db_data || {}, new_data);
                     this.data = _.cloneDeep(this.old_db_data);
+                } else {
+                    // keep old_db_data current so DB fallback has a valid base for incremental merge
+                    this.old_db_data = new_data;
+                    this.data = _.cloneDeep(new_data);
                 }
                 millistamp = time_utils.millistamp();
                 this.data.rebuild();
@@ -517,7 +521,7 @@ class SystemStore extends EventEmitter {
     //return the latest copy of in-memory data
     async recent_db_data() {
         if (this.source === SOURCE.CORE) {
-                throw new RpcError('BAD_REQUEST', 'recent_db_data is not available for CORE source');
+            throw new RpcError('BAD_REQUEST', 'recent_db_data is not available for CORE source');
         }
         return this._load_serial.surround(async () => this.old_db_data);
     }


### PR DESCRIPTION
### Describe the Problem

Identified during warp test. When `SYSTEM_STORE_SOURCE=CORE`, uploads to S3 endpoints fail with:
```
TypeError: Cannot read properties of undefined (reading '<tier_id>')
    at SystemStoreData.get_by_id (system_store.js)
    at get tier (map_api_types.js)
```

The CORE load path in `system_store.js` eagerly replaced `this.data` with a fresh `SystemStoreData()` instance before calling `rebuild()`. Since the constructor does not initialize `idmap`, any concurrent request (e.g. an upload calling `get_by_id`) that lands during the async gaps between the assignment and `rebuild()` hits `undefined.idmap`, causing the TypeError. The DB path did not have this issue because it reads into a local variable and only assigns `this.data` at the last moment.

### Explain the Changes
1. Read CORE data into the existing `new_data` local variable instead of directly into `this.data`, keeping the old (valid) `this.data` alive during all async operations.
2. Defer `this.data` assignment to just before `rebuild()`, eliminating the race window, matching the pattern already used by the DB path.
3. Maintain `this.old_db_data` in the CORE success path so that if a subsequent load falls back to DB, the incremental merge has a valid base state.
4. Unrelated change - Remove unused second argument (`true`) passed to `map_deleter.delete_object_mappings()` in `objects_reclaimer.js`.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Set `SYSTEM_STORE_SOURCE=CORE` on the endpoint pod.
2. Run concurrent S3 uploads (e.g. with `warp`) while triggering a system store reload (e.g. by creating/editing a bucket or pool to trigger `publish_to_cluster`).
3. Verify uploads no longer fail with `TypeError: Cannot read properties of undefined` in `get_by_id`.
4. Verify that after a CORE load failure (e.g. simulate by temporarily stopping the core pod), the endpoint falls back to DB loading successfully.


- [ ] Doc added/updated
- [ ] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved object cleanup process for better reliability during garbage collection operations.
  * Enhanced system data loading with more robust fallback handling to ensure data integrity and availability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->