### PR TITLE
Added fix for resetting of replication_target_status to default

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -444,7 +444,7 @@ const NOOBAA_CORE_METRICS = js_utils.deep_freeze([{
         name: 'replication_target_status',
         configuration: {
             help: 'Replication target bucket reachability status (1=reachable, 0=unreachable)',
-            labelNames: ['source_bucket', 'target_bucket']
+            labelNames: ['replication_id', 'source_bucket', 'target_bucket']
         }
     }
 ]);
@@ -705,9 +705,14 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.bucket_last_cycle_error_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_error_objects_num);
     }
 
-    set_replication_target_status(source_bucket, target_bucket, is_reachable) {
+    reset_replication_target_status() {
         if (!this._metrics) return;
-        this._metrics.replication_target_status.set({ source_bucket, target_bucket }, Number(is_reachable));
+        this._metrics.replication_target_status.reset();
+    }
+
+    set_replication_target_status(replication_id, source_bucket, target_bucket, is_reachable) {
+        if (!this._metrics) return;
+        this._metrics.replication_target_status.set({ replication_id, source_bucket, target_bucket }, Number(is_reachable));
     }
 }
 

--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -90,7 +90,7 @@ class LogReplicationScanner {
                 if (!dst_bucket) {
                     dbg.error('log_replication_scanner: destination_bucket not found:', rule.destination_bucket, 'for replication_id:', replication_id);
                     const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
-                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket_name, false);
+                    replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket_name, false);
                     replication_utils.update_replication_prom_report(src_bucket.name, replication_id, {}, {
                         bucket_last_cycle_total_objects_num: total,
                         bucket_last_cycle_replicated_objects_num: 0,
@@ -111,7 +111,7 @@ class LogReplicationScanner {
                 } catch (err) {
                     dbg.error('log_replication_scanner: failed to process candidates, target may be unreachable:',
                         src_bucket.name, dst_bucket.name, err);
-                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+                    replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);
                     replication_utils.update_replication_prom_report(src_bucket.name, replication_id, {}, {
                         bucket_last_cycle_total_objects_num: total,
                         bucket_last_cycle_replicated_objects_num: 0,
@@ -147,18 +147,20 @@ class LogReplicationScanner {
         let copy_keys;
         let delete_keys;
         if (sync_versions) {
-            copy_keys = await this.process_candidates_sync_version(src_bucket, dst_bucket, candidates, false);
+            copy_keys = await this.process_candidates_sync_version(src_bucket, dst_bucket, candidates, false, replication_id);
             // for sync_versions enabled, deletions cannot be performed until the copying process is completed
             await this.copy_objects(src_bucket.name, dst_bucket.name, copy_keys, rule_id, replication_id);
 
             if (sync_deletions) { // If sync_deletions is enabled, then only the deletion keys for versioned objects are captured
-                const diff_keys = await this.process_candidates_sync_version(src_bucket, dst_bucket, candidates, sync_deletions);
+                const diff_keys = await this.process_candidates_sync_version(
+                    src_bucket, dst_bucket, candidates, sync_deletions, replication_id);
                 delete_keys = Object.keys(diff_keys); // fetching keys array from diff_keys
                 await this.delete_objects(dst_bucket.name, delete_keys);
             }
         } else {
             // here even if sync_deletions is disabled, we are processing delete_keys for not_sync_verison
-            ({ copy_keys, delete_keys } = await this.process_candidates_not_sync_version(src_bucket, dst_bucket, candidates));
+            ({ copy_keys, delete_keys } = await this.process_candidates_not_sync_version(
+                src_bucket, dst_bucket, candidates, replication_id));
 
             // calling copy_objects and delete_objects in parallel by passing batch of keys
             await Promise.all([
@@ -173,7 +175,7 @@ class LogReplicationScanner {
         return { copy_keys, delete_keys };
     }
 
-    async process_candidates_sync_version(src_bucket, dst_bucket, candidates, sync_deletions) {
+    async process_candidates_sync_version(src_bucket, dst_bucket, candidates, sync_deletions, replication_id) {
         const bucketDiff = new BucketDiff({
             first_bucket: src_bucket.name,
             second_bucket: dst_bucket.name,
@@ -206,12 +208,12 @@ class LogReplicationScanner {
                 }
             }
             // target bucket is reachable
-            replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, true);
+            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
             // target bucket is unreachable
             dbg.error('log_replication_scanner: failed to get buckets diff, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
-            replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);
             throw err;
         }
 
@@ -220,17 +222,17 @@ class LogReplicationScanner {
         return diff_keys;
     }
 
-    async process_candidates_not_sync_version(src_bucket, dst_bucket, candidates) {
+    async process_candidates_not_sync_version(src_bucket, dst_bucket, candidates, replication_id) {
         let src_dst_objects_list;
         try {
             src_dst_objects_list = await this.head_objects(src_bucket.name, dst_bucket.name, candidates);
             // target bucket is reachable
-            replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, true);
+            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
             // target bucket is unreachable
             dbg.error('log_replication_scanner: failed to head objects, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
-            replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);
             throw err;
         }
 

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -60,6 +60,8 @@ class ReplicationScanner {
 
     async scan() {
         if (!this.noobaa_connection) throw new Error('noobaa endpoint connection is not started yet...');
+        // full reset of replication_target_status, then set reachability again for each policy for this scan cycle
+        replication_utils.reset_replication_target_status();
         // find rule for each replication policy that was not updated for the longest period
         const least_recently_replicated_rules = await replication_store.find_rules_updated_longest_time_ago();
 
@@ -73,7 +75,7 @@ class ReplicationScanner {
                 // mark target bucket as unreachable (resolve display name from id while bucket row still exists)
                 if (src_bucket && !dst_bucket) {
                     const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
-                    replication_utils.update_replication_target_status(src_bucket.name, dst_bucket_name, false);
+                    replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket_name, false);
                     replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
                         rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
                 }
@@ -111,12 +113,12 @@ class ReplicationScanner {
                 dst_cont_token = buckets_diff_result.second_bucket_cont_token;
 
                 // target bucket is reachable
-                replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, true);
+                replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
             } catch (err) {
                 // target bucket is unreachable
                 dbg.error('replication_scanner: failed to get buckets diff, target may be unreachable:',
                     src_bucket.name, dst_bucket.name, err);
-                replication_utils.update_replication_target_status(src_bucket.name, dst_bucket.name, false);
+                replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);
                 replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
                     rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
                 throw err;

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -106,11 +106,17 @@ function report_failed_replication_cycle(bucket_name, replication_id, rule_id, t
         'replication_id:', replication_id, 'rule_id:', rule_id, 'total:', total);
 }
 
-function update_replication_target_status(source_bucket, target_bucket, is_reachable) {
+function reset_replication_target_status() {
+    const core_report = prom_reporting.get_core_report();
+    core_report.reset_replication_target_status();
+}
+
+function update_replication_target_status(replication_id, source_bucket, target_bucket, is_reachable) {
+    if (!replication_id) return;
     const core_report = prom_reporting.get_core_report();
     const src_name = source_bucket instanceof SensitiveString ? source_bucket.unwrap() : source_bucket;
     const dst_name = target_bucket instanceof SensitiveString ? target_bucket.unwrap() : target_bucket;
-    core_report.set_replication_target_status(src_name, dst_name, is_reachable);
+    core_report.set_replication_target_status(replication_id, src_name, dst_name, is_reachable);
 }
 
 // remove the `-deleting-<timestamp>` suffix noobaa appends while a bucket is being deleted
@@ -259,6 +265,7 @@ async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
 exports.get_rule_and_bucket_status = get_rule_and_bucket_status;
 exports.update_replication_prom_report = update_replication_prom_report;
 exports.report_failed_replication_cycle = report_failed_replication_cycle;
+exports.reset_replication_target_status = reset_replication_target_status;
 exports.update_replication_target_status = update_replication_target_status;
 exports.resolve_destination_bucket_name = resolve_destination_bucket_name;
 exports.get_object_md = get_object_md;


### PR DESCRIPTION
### Describe the Problem
replication_target_status could stay scraped after replication was removed or labels changed, because the gauge was only updated with set() and never cleared.

### Explain the Changes
1. Replication metrics: Call reset_replication_target_status() at the start of ReplicationScanner.scan() (same reset-then-repaint idea as set_bucket_status), with helpers on NooBaaCoreReport and replication_utils. Log replication scanner stays set-only so both scanners do not wipe the same gauge.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: https://redhat.atlassian.net/browse/DFBUGS-6398

### Testing Instructions:
1. Create two obc and set bucket replication, then copy some objects to src bucket.
2.  Check if replication is working fine, then delete the destination obc and wait for `NooBaaReplicationTargetUnreachable` alert firing.
3.  Now, delete the source obc and on after the next replication cycle check whether the alert is removed.

`prometheus dashboard flow:

0) Prereqs: kubectl and helm work against your cluster. Set once:
export NS=default

1) Add Helm repo
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update

2) Install or upgrade kube-prometheus-stack (match NooBaa labels):
helm upgrade prometheus prometheus-community/kube-prometheus-stack --install --namespace $NS --create-namespace --set prometheus.prometheusSpec.serviceMonitorSelector.matchLabels.app=noobaa --set prometheus.prometheusSpec.ruleSelector.matchLabels.prometheus=k8s --set prometheus.prometheusSpec.ruleSelector.matchLabels.role=alert-rules

Check it applied:
helm -n $NS get values prometheus
kubectl -n $NS get prometheus -o yaml | grep -A30 serviceMonitorSelector

3) Fix TLS on NooBaa ServiceMonitors (minimal tlsConfig)
Replace tlsConfig so there is no caFile, no ca: {}, no cert: {} — only skip-verify and SNI:

kubectl -n "$NS" patch servicemonitor noobaa-mgmt-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/1/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/2/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}}
]'
kubectl -n "$NS" patch servicemonitor s3-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"s3.'"$NS"'.svc"}}
]'

4) Verify scraping and metrics
POD=$(kubectl -n $NS get pods -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22s3%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22noobaa-mgmt%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090//api/v1/query?query=NooBaa_num_buckets'

5) Prometheus UI port-forward
kubectl port-forward -n $NS pod/prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
Open http://127.0.0.1:9090 — Graph, Status → Targets, Alerts, Rules.

6) What to expect (so you’re not surprised)
Core system metrics (NooBaa_num_buckets, etc.) usually show under job=noobaa-mgmt.
Endpoint metrics (NooBaa_Endpoint_*) show under job=s3 on :9443.
Replication metrics only appear after replication is configured and scanners update them.`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replication target status now includes a unique replication identifier for per-replication tracking and clearer metrics.
  * Scanning and background replication processes report reachability with replication-specific context, improving accuracy of reachable/unreachable status.
  * Monitoring now resets replication metrics at the start of each scan cycle to avoid stale status and ensure up-to-date reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9593)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->