### PR TITLE
vectors - add next_token validation for all list ops (dfs 6808)

### DIFF
--- a/src/endpoint/vector/ops/vector_index_list.js
+++ b/src/endpoint/vector/ops/vector_index_list.js
@@ -2,6 +2,8 @@
 'use strict';
 //const config = require('../../../../config');
 const dbg = require('../../../util/debug_module')(__filename);
+const { VectorError } = require('../vector_errors');
+const { next_token_sanity_check } = require('../../../util/vectors_util');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_ListIndexes.html
@@ -14,6 +16,15 @@ async function post_list_index(req, res) {
     const prefix = req.body.prefix;
     const vector_bucket_name = req.body.vectorBucketName;
     const next_token = req.body.nextToken;
+
+    if (!next_token_sanity_check(next_token)) {
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList: [{path: 'nextToken', message: "Bad nextToken"}],
+        });
+    }
 
     const list_res = await req.vector_sdk.list_vector_indices({
         vector_bucket_name,

--- a/src/endpoint/vector/ops/vector_list_vector_buckets.js
+++ b/src/endpoint/vector/ops/vector_list_vector_buckets.js
@@ -2,6 +2,8 @@
 'use strict';
 //const config = require('../../../../config');
 const dbg = require('../../../util/debug_module')(__filename);
+const { VectorError } = require('../vector_errors');
+const { next_token_sanity_check } = require('../../../util/vectors_util');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_ListVectorBuckets.html
@@ -13,6 +15,15 @@ async function post_list_vector_buckets(req, res) {
     const max_results = req.body.maxResults || 500;
     const prefix = req.body.prefix;
     const next_token = req.body.nextToken;
+
+    if (!next_token_sanity_check(next_token)) {
+        throw new VectorError({
+            code: VectorError.ValidationException.code,
+            http_code: VectorError.ValidationException.http_code,
+            message: VectorError.ValidationException.message,
+            fieldList: [{path: 'nextToken', message: "Bad nextToken"}],
+        });
+    }
 
     const list_res = await req.vector_sdk.list_vector_buckets({
         max_results,

--- a/src/endpoint/vector/ops/vector_list_vectors.js
+++ b/src/endpoint/vector/ops/vector_list_vectors.js
@@ -4,6 +4,7 @@
 const _ = require('lodash');
 
 const { VectorError } = require('../vector_errors');
+const { next_token_sanity_check } = require('../../../util/vectors_util');
 
 const dbg = require('../../../util/debug_module')(__filename);
 
@@ -76,22 +77,6 @@ function segment_validate(count, index) {
     if (count <= 0) return {path: "segmentCount", message: "Must be greater than zero."};
     if (index < 0) return {path: "segmentIndex", message: "Cannot be negative."};
     if (index >= count) return {path: "segmentIndex", message: "Must be less than segmentCount."};
-}
-
-//validate next_token is of the form number_number
-function next_token_sanity_check(next_token) {
-    if (!next_token) return true;
-    const delim = next_token.indexOf('_');
-    if (delim === -1) return false;
-    const split = next_token.split('_');
-    if (split.length !== 2) return false;
-    if (split[0] === '' || split[1] === '') return false;
-    const start = Number(split[0]);
-    const end = Number(split[1]);
-    if (Number.isNaN(start) || Number.isNaN(end)) return false;
-    if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < 0) return false;
-    if (start >= end) return false;
-    return true;
 }
 
 exports.handler = post_list_vectors;

--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -154,6 +154,168 @@ mocha.describe('vectors_ops', function() {
             validate_vector_bucket(response.vectorBuckets[0], vector_bucket_name1, beforeTs, afterTs);
         });
 
+        mocha.it('should reject invalid next_token - missing underscore', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '123'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - multiple underscores', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '10_20_30'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - empty first part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '_100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - empty second part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '100_'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - non-numeric first part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: 'abc_100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - non-numeric second part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '10_xyz'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - negative first part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '-10_100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - negative second part', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '10_-100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - start >= end', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '100_100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should reject invalid next_token - start > end', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '200_100'
+            });
+
+            try {
+                await send(s3_vectors_client, command);
+                assert.fail('Expected ValidationException to be thrown');
+            } catch (err) {
+                assert.strictEqual(err.name, 'ValidationException');
+            }
+        });
+
+        mocha.it('should accept valid next_token format', async function() {
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
+
+            const command = new s3vectors.ListVectorBucketsCommand({
+                nextToken: '0_100'
+            });
+
+            // Should not throw - valid format
+            const response = await send(s3_vectors_client, command);
+            assert(response);
+        });
+
         mocha.it('should delete a vector bucket', async function() {
             await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name1);
 

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -431,6 +431,22 @@ async function delete_vectors(vector_bucket, vector_index, keys) {
     return await vc.delete_vectors(vector_bucket, vector_index, keys);
 }
 
+//validate next_token is of the form number_number
+function next_token_sanity_check(next_token) {
+    if (!next_token) return true;
+    const delim = next_token.indexOf('_');
+    if (delim === -1) return false;
+    const split = next_token.split('_');
+    if (split.length !== 2) return false;
+    if (split[0] === '' || split[1] === '') return false;
+    const start = Number(split[0]);
+    const end = Number(split[1]);
+    if (Number.isNaN(start) || Number.isNaN(end)) return false;
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < 0) return false;
+    if (start >= end) return false;
+    return true;
+}
+
 exports.delete_vector_bucket = delete_vector_bucket;
 exports.create_vector_index = create_vector_index;
 exports.delete_vector_index = delete_vector_index;
@@ -438,3 +454,4 @@ exports.put_vectors = put_vectors;
 exports.list_vectors = list_vectors;
 exports.query_vectors = query_vectors;
 exports.delete_vectors = delete_vectors;
+exports.next_token_sanity_check = next_token_sanity_check;


### PR DESCRIPTION
### Describe the Problem
next_token is validate only for list vectors op. Wrong token for list vector buckets and list vector index is ignored.

### Explain the Changes
1. Add next_token validation to all list ops.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6808

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened pagination token validation for vector listing endpoints; invalid tokens now produce clearer validation errors tied to the nextToken field, preventing downstream calls.
* **Tests**
  * Added integration tests covering malformed and valid pagination tokens to ensure consistent rejection of bad tokens and acceptance of properly formatted ones.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9594)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->