### PR TITLE
NC | RDMA | s3perf (using s3_rdma_client) RDMA register buffer

### DIFF
--- a/src/native/cuobj/cuobj_client_napi.cpp
+++ b/src/native/cuobj/cuobj_client_napi.cpp
@@ -319,11 +319,9 @@ CuObjClientWorker::Execute()
     // caller should ideally register it beforehand, or deregister after use
     ssize_t max_size = client->cuMemObjGetMaxRequestCallbackSize(_ptr);
     if (max_size < static_cast<ssize_t>(_size)) {
-        cuObjErr_t ret_get_mem = client->cuMemObjGetDescriptor(_ptr, _size);
-        if (ret_get_mem != CU_OBJ_SUCCESS) {
-            SetError(XSTR() << "CuObjClientWorker: Failed to register rdma buffer " << DVAL(ret_get_mem));
-            return;
-        }
+        SetError(XSTR() << "CuObjClientWorker: buffer not registered "
+                        << DVAL(_ptr) << DVAL(_size) << DVAL(mem_type) << DVAL(max_size));
+        return;
     }
 
     if (_op_type == CUOBJ_GET) {
@@ -390,9 +388,9 @@ CuObjClientWorker::start_op(
     _wrap->_thread_callback.Release();
 
     // after sending the op on main thread, the worker now waits for wakeup
-    // guard using predicate and check for _completed because spurious wakeups 
+    // guard using predicate and check for _completed because spurious wakeups
     // can cause threads to wake without a notification causing undefined behavior.
-    _cond.wait(lock, [this]{ return _completed; });
+    _cond.wait(lock, [this] { return _completed; });
     lock.unlock();
 
     // _ret_size was set by the server response in the callback

--- a/src/util/rdma_utils.js
+++ b/src/util/rdma_utils.js
@@ -419,6 +419,7 @@ function new_rdma_client() {
  * @returns {S3}
  */
 function s3_rdma_client(s3_config, client_buf, rdma_client) {
+    rdma_client.register_buffer(client_buf);
     const s3 = new S3(s3_config);
     s3.middlewareStack.use(s3_rdma_client_plugin(client_buf, rdma_client));
     return s3;
@@ -491,7 +492,9 @@ function s3_rdma_client_middleware(client_buf, rdma_client) {
                         throw new S3Error(S3Error.S3RdmaIoError,
                             `Received error from server, status code: ${rdma_reply.status_code}`);
                     }
-                    result.output.rdma_reply = rdma_reply;
+                    if (result?.output) {
+                        result.output.rdma_reply = rdma_reply;
+                    }
                     callback(null, Number(rdma_reply.num_bytes));
                 } catch (err) {
                     console.warn('S3-RDMA: Received error from server', err);
@@ -503,6 +506,8 @@ function s3_rdma_client_middleware(client_buf, rdma_client) {
         if (ret_size < 0) {
             console.warn('S3-RDMA: Failed RDMA operation', ret_size, op_type, client_buf.length);
         }
+
+        if (!result) throw new Error('Result was not set by RDMA callback');
 
         return result;
     };


### PR DESCRIPTION
(cherry picked from commit 24001eec3ccbdf41f469da63643d80e93c93f274)

### Describe the Problem
We didn't always register the buffer before using it - now we will

### Explain the Changes
1. Register the buffer before we start the S3 client
2. Throw an error in case the buffer is not registered before using it
3. non-related fix for cases where the result is empty - we will throw

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1.  Run s3perf with cuda option: `s3perf.js --size 16 --concur 90 --rdma --cuda --put`
2. Make sure you don't fail


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter RDMA buffer validation with clearer errors when a buffer exceeds allowed size or isn't registered.
  * Ensured client-side buffers are explicitly registered before RDMA use.
  * Hardened middleware handling: safely guard result assignment and raise an error if the RDMA callback fails to produce a result.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9606)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->