### PR TITLE
Disable endpoint metrics server by default on containerized

### DIFF
--- a/config.js
+++ b/config.js
@@ -1081,7 +1081,9 @@ config.ENDPOINT_SSL_VECTOR_PORT = Number(process.env.ENDPOINT_SSL_VECTOR_PORT) |
 // each fork will get port in range [ENDPOINT_FORK_PORT_BASE, ENDPOINT_FORK_PORT_BASE + number of forks - 1)]
 config.ENDPOINT_FORK_PORT_BASE = Number(process.env.ENDPOINT_FORK_PORT_BASE) || undefined;
 config.ALLOW_HTTP = false;
-config.ALLOW_HTTP_METRICS = true;
+// On the containerized endpoint pod HTTP metrics are disabled by default (LOCAL_MD_SERVER=true)
+// On the other hand, on the containerized core pod and on NC, HTTP metrics are enabled by default (LOCAL_MD_SERVER is undefined).
+config.ALLOW_HTTP_METRICS = process.env.LOCAL_MD_SERVER !== 'true';
 config.ALLOW_HTTPS_METRICS = true;
 // config files should allow access to the owner of the files
 config.BASE_MODE_CONFIG_FILE = 0o600;

--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -190,8 +190,10 @@ async function start_server(
     // Try to open the port for listening, will retry then exist.
     while (retry_count) {
         try {
-            if (nsfs_config_root && !config.ALLOW_HTTP_METRICS) {
-                dbg.warn('HTTP is not allowed for NC NSFS metrics server.');
+            // ALLOW_HTTP_METRICS is false on the containerized endpoint pod (LOCAL_MD_SERVER=true).
+            // On core pod or on NC, it can be explicitly set to false via config.json to disable HTTP metrics.
+            if (!config.ALLOW_HTTP_METRICS) {
+                dbg.warn('HTTP is not allowed for metrics server.');
             } else if (port > 0) {
                 await http_utils.start_http_server(port, 'METRICS', metrics_request_handler);
             } else {


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
Note - process.env.LOCAL_MD_SERVER=true only on the endpoint pod on NooBaa Containerized (set by NooBaa operator)
1. changed `ALLOW_HTTP_METRICS` configuration from default true to be more specific per deployment and pod - 
On NC - no change - `process.env.LOCAL_MD_SERVER` is undefined, therefore it's `ALLOW_HTTP_METRICS=true`
On Containerized - 
noobaa-core-0 pod - `process.env.LOCAL_MD_SERVER` is undefined, therefore it's `ALLOW_HTTP_METRICS=true`
endpoint pod - `process.env.LOCAL_MD_SERVER=true`, threrefore `ALLOW_HTTP_METRICS=false`
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated HTTP metrics server configuration to be dynamically controlled based on deployment environment settings.
  * Metrics server is now automatically disabled when running in local server mode, optimizing resource usage in development environments.
  * Refined metrics reporting service startup logic by simplifying prerequisite validation requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->