### PR TITLE
NC | buffer pool fix - xl pool used only for rdma

### DIFF
--- a/config.js
+++ b/config.js
@@ -824,11 +824,15 @@ const remaining_mem = Math.max(0, config.BUFFERS_MEM_LIMIT -
 config.NSFS_BUF_POOL_MEM_LIMIT_M = range_utils.align_down(remaining_mem * 0.1, config.NSFS_BUF_SIZE_M);
 // L buffers share 90% of remaining memory, with 4GB mem and L size of 8MB this gives ~450 L buffers
 config.NSFS_BUF_POOL_MEM_LIMIT_L = range_utils.align_down(remaining_mem * 0.9, config.NSFS_BUF_SIZE_L);
-// XL buffers are treated as extension to the memory and will be allocated on top as needed,
-// however we will periodically release unused XL buffers back to the system
-config.NSFS_BUF_POOL_MEM_LIMIT_XL = config.NSFS_WANTED_BUFFERS_NUMBER * config.NSFS_BUF_SIZE_XL;
+
+// XL buffers are used for RDMA and treated as extension to the memory limit (config.BUFFERS_MEM_LIMIT)
+config.NSFS_BUF_POOL_XL_ENABLED_FOR_RDMA = true;
+config.NSFS_BUF_POOL_XL_MIN_SIZE = config.NSFS_BUF_SIZE_XL / 2;
+// with 64 XL buffers of size 64MB - the extended memory can grow up to 4GB (at max concurrency)
+config.NSFS_BUF_POOL_MAX_COUNT_XL = 64;
+config.NSFS_BUF_POOL_MEM_LIMIT_XL = config.NSFS_BUF_POOL_MAX_COUNT_XL * config.NSFS_BUF_SIZE_XL;
 // XL buffers not used in the last interval will be released back to the system (0 means disable)
-config.NSFS_BUF_POOL_XL_RELEASE_UNUSED_INTERVAL = 0;
+config.NSFS_BUF_POOL_XL_RELEASE_UNUSED_INTERVAL = 60000;
 
 config.NSFS_BUF_WARMUP_SPARSE_FILE_READS = true;
 

--- a/src/sdk/endpoint_stats_collector.js
+++ b/src/sdk/endpoint_stats_collector.js
@@ -92,6 +92,7 @@ class EndpointStatsCollector {
         this.prom_metrics_report = prom_report.get_endpoint_report();
         this.semaphore_reports = {
             object_io: [],
+            nsfs_xl: [],
             nsfs_l: [],
             nsfs_m: [],
             nsfs_s: [],

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -58,6 +58,8 @@ const multi_buffer_pool = new buffer_utils.MultiSizeBuffersPool({
             size: config.NSFS_BUF_SIZE_XL,
             sem_size: config.NSFS_BUF_POOL_MEM_LIMIT_XL,
             release_unused_interval: config.NSFS_BUF_POOL_XL_RELEASE_UNUSED_INTERVAL,
+            is_overcommit: true, // this pool's memory is overcommitted on top of config.BUFFERS_MEM_LIMIT
+            min_size: config.NSFS_BUF_POOL_XL_MIN_SIZE,
         },
     ],
     warning_timeout: config.NSFS_BUF_POOL_WARNING_TIMEOUT,

--- a/src/server/bg_services/semaphore_monitor.js
+++ b/src/server/bg_services/semaphore_monitor.js
@@ -7,6 +7,7 @@ const endpoint_stats_collector = require('../../sdk/endpoint_stats_collector').i
 const { multi_buffer_pool } = require('../../sdk/namespace_fs');
 
 const nsfs_semaphores = {
+    "nsfs_xl": config.NSFS_BUF_SIZE_XL,
     "nsfs_l": config.NSFS_BUF_SIZE_L,
     "nsfs_m": config.NSFS_BUF_SIZE_M,
     "nsfs_s": config.NSFS_BUF_SIZE_S,
@@ -78,7 +79,8 @@ class SemaphoreMonitor {
 
     sample_nsfs_semaphore(name) {
         const buffer_size = nsfs_semaphores[name];
-        const buffers_pool_sem = multi_buffer_pool.get_buffers_pool(buffer_size).sem;
+        const allow_overcommit = true; // for sampling we want to get any pool
+        const buffers_pool_sem = multi_buffer_pool.get_buffers_pool(buffer_size, allow_overcommit).sem;
         if (!buffers_pool_sem) {
             dbg.log0('semaphore_monitor: buffers_pool_sem is invalid', this.object_io);
             return;

--- a/src/test/unit_tests/util_functions_tests/test_buffer_pool.js
+++ b/src/test/unit_tests/util_functions_tests/test_buffer_pool.js
@@ -63,7 +63,7 @@ mocha.describe('Test buffers pool', function() {
             }, {
                 size: BUF_LIMIT3,
                 sem_size: SEM_LIMIT3,
-            }, ],
+            }],
             warning_timeout: 0,
         });
         const lazy_fill = new Array(MAX_POOL_ALLOWED1 + 2).fill(0);
@@ -97,4 +97,142 @@ mocha.describe('Test buffers pool', function() {
         buf = await multi_buffer_pool.get_buffers_pool(-1).get_buffer();
         assert(buf.buffer.length === BUF_LIMIT3, 'Allocated different buffer size than expected for negative');
     });
+
+
+    mocha.it('picks pool by is_default, min_size, is_overcommit', async function() {
+        const SIZE_S = 1024;
+        const SIZE_M = 4 * SIZE_S;
+        const SIZE_L = 4 * SIZE_M;
+        const SIZE_XL = 4 * SIZE_L;
+        const MIN_SIZE_XL = SIZE_XL / 2;
+        const NUM_BUFFERS = 8;
+        const multi_buffer_pool = new buffer_utils.MultiSizeBuffersPool({
+            sorted_buf_sizes: [{
+                size: SIZE_S,
+                sem_size: SIZE_S * NUM_BUFFERS,
+            }, {
+                size: SIZE_M,
+                sem_size: SIZE_M * NUM_BUFFERS,
+            }, {
+                size: SIZE_L,
+                sem_size: SIZE_L * NUM_BUFFERS,
+                is_default: true,
+            }, {
+                size: SIZE_XL,
+                sem_size: SIZE_XL * NUM_BUFFERS,
+                min_size: MIN_SIZE_XL,
+                is_overcommit: true,
+            }],
+        });
+
+        /**
+         * @param {number} expected_size 
+         * @param {boolean} allow_overcommit
+         * @param {any} size
+         */
+        const expect = (expected_size, allow_overcommit, size) => {
+            const bp = multi_buffer_pool.get_buffers_pool(size, allow_overcommit);
+            assert.strictEqual(bp.buf_size, expected_size, `get_buffers_pool(${size}) returned pool ${bp.buf_size} expected ${expected_size}`);
+        };
+
+        /**
+         * @param {number} expected_size 
+         * @param {any} size
+         */
+        const expect_always = (expected_size, size) => {
+            expect(expected_size, false, size);
+            expect(expected_size, true, size);
+        };
+
+        expect_always(SIZE_S, 0);
+        expect_always(SIZE_S, 1);
+        expect_always(SIZE_S, SIZE_S - 1);
+        expect_always(SIZE_S, SIZE_S);
+
+        expect_always(SIZE_M, SIZE_S + 1);
+        expect_always(SIZE_M, SIZE_S * 2);
+        expect_always(SIZE_M, SIZE_M - 1);
+        expect_always(SIZE_M, SIZE_M);
+
+        expect_always(SIZE_L, SIZE_M + 1);
+        expect_always(SIZE_L, SIZE_M * 2);
+        expect_always(SIZE_L, SIZE_L - 1);
+        expect_always(SIZE_L, SIZE_L);
+        expect_always(SIZE_L, SIZE_L + 1);
+        expect_always(SIZE_L, MIN_SIZE_XL - 1);
+
+        // edge cases pick default pool (probably config/calculation error)
+        expect_always(SIZE_L, -1);
+        expect_always(SIZE_L, '1');
+        expect_always(SIZE_L, 1n);
+        expect_always(SIZE_L, false);
+        expect_always(SIZE_L, NaN);
+        expect_always(SIZE_L, Infinity);
+        expect_always(SIZE_L, -Infinity);
+        expect_always(SIZE_L, undefined);
+
+        // no overcommit
+        expect(SIZE_L, false, MIN_SIZE_XL);
+        expect(SIZE_L, false, MIN_SIZE_XL + 1);
+        expect(SIZE_L, false, SIZE_XL - 1);
+        expect(SIZE_L, false, SIZE_XL);
+        expect(SIZE_L, false, SIZE_XL + 1);
+        expect(SIZE_L, false, SIZE_XL * 1000000000);
+
+        // with overcommit
+        expect(SIZE_XL, true, MIN_SIZE_XL);
+        expect(SIZE_XL, true, MIN_SIZE_XL + 1);
+        expect(SIZE_XL, true, SIZE_L * 2);
+        expect(SIZE_XL, true, SIZE_XL - 1);
+        expect(SIZE_XL, true, SIZE_XL);
+        expect(SIZE_XL, true, SIZE_XL + 1);
+        expect(SIZE_XL, true, SIZE_XL * 1000000000);
+    });
+
+    mocha.it('releases unused buffers', async function() {
+        // @ts-ignore
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const DT = 100;
+        const BUF_SIZE = 1024;
+        const NUM_BUFFERS = 8;
+        const SEM_LIMIT = BUF_SIZE * NUM_BUFFERS;
+        const bp = new buffer_utils.BuffersPool({
+            buf_size: BUF_SIZE,
+            sem: new semaphore.Semaphore(SEM_LIMIT, {
+                timeout: DT * 2,
+                timeout_error_code: 'TEST_BUFFER_POOL_TIMEOUT',
+            }),
+            warning_timeout: DT * 2,
+            release_unused_interval: DT,
+        });
+
+        /**
+         * @param {number} n 
+         * @returns {Promise<Array<{ buffer: Buffer, callback: () => void }>>}
+         */
+        const allocate = async n => await Promise.all(new Array(n).fill(0).map(() => bp.get_buffer()));
+
+        /**
+         * @param {Array<{ buffer: Buffer, callback: () => void }>} allocs 
+         */
+        const deallocate = allocs => allocs.forEach(alloc => alloc.callback());
+
+        await new Promise(r => setTimeout(r, DT / 4));
+        for (let t = 0; t < 100; t++) {
+            const used = Math.floor(Math.random() * (NUM_BUFFERS + 1));
+            const unused = Math.max(bp.buffers.length - used, 0);
+            console.log(`Test iteration ${t} buffers ${bp.buffers.length} used ${used} unused ${unused} sem ${bp.sem.value}`);
+            const allocs = await allocate(used);
+            assert.strictEqual(bp.buffers.length, unused, 'buffers.length != unused after allocation');
+            assert.strictEqual(bp.sem.value, SEM_LIMIT - used * BUF_SIZE, 'sem.value != SEM_LIMIT - used * BUF_SIZE');
+            deallocate(allocs);
+            assert.strictEqual(bp.buffers.length, unused + used, 'buffers.length != unused + used after deallocation');
+            assert.strictEqual(bp.sem.value, SEM_LIMIT, 'sem.value != SEM_LIMIT after deallocation');
+            await new Promise(r => setTimeout(r, DT));
+            assert.strictEqual(bp.buffers.length, used, 'buffers.length != used after release interval');
+            assert.strictEqual(bp.sem.value, SEM_LIMIT, 'sem.value != SEM_LIMIT after release interval');
+        }
+
+    });
+
 });

--- a/src/util/buffer_utils.js
+++ b/src/util/buffer_utils.js
@@ -183,18 +183,28 @@ class BuffersPool {
      * @param {{
      *      buf_size: number;
      *      sem: import('./semaphore').Semaphore;
-     *      warning_timeout: number;
+     *      warning_timeout?: number;
      *      release_unused_interval?: number;
      *      buffer_alloc?: (size: number) => Buffer;
+     *      min_size?: number;
+     *      is_overcommit?: boolean;
      * }} params
      */
-    constructor({ buf_size, sem, warning_timeout, release_unused_interval, buffer_alloc }) {
+    constructor({
+        buf_size, sem,
+        buffer_alloc,
+        warning_timeout = 0,
+        release_unused_interval = 0,
+        min_size = 0,
+        is_overcommit = false,
+    }) {
         const MIN_BUFFERS = 8;
         if (sem.value < MIN_BUFFERS * buf_size) {
             dbg.error(`BuffersPool: buffer size ${buf_size} pool size ${sem.value}`,
                 `is too small and should have room for at least ${MIN_BUFFERS} buffers`);
         }
         this.buf_size = buf_size;
+        /** @type {Buffer[]} */
         this.buffers = [];
         this.sem = sem;
         this.warning_timeout = warning_timeout;
@@ -203,21 +213,20 @@ class BuffersPool {
         if (release_unused_interval > 0) {
             this.release_interval = setInterval(() => this._release_unused(), release_unused_interval).unref();
         }
+        this.min_size = min_size; // used by MultiSizeBuffersPool
+        this.is_overcommit = is_overcommit; // used by MultiSizeBuffersPool 
     }
 
     // if configured, called periodically to release unused buffers back to the system
     _release_unused() {
         if (this.lowest_buffers_length > 0) {
-            // choosing to release half of the lowest number of buffers recently to balance 
-            // between releasing unused buffers and keeping some buffers in the pool for future use,
-            const release_count = Math.min(this.buffers.length, Math.ceil(this.lowest_buffers_length / 2));
-            if (release_count > 0) {
-                dbg.log0('BuffersPool: releasing unused buffers',
-                    'lowest_buffers_length', this.lowest_buffers_length,
-                    'release_count', release_count);
+            // release the amount of buffers that were not used in the last interval
+            const unused = Math.min(this.lowest_buffers_length, this.buffers.length);
+            if (unused > 0) {
+                dbg.log0('BuffersPool: releasing unused buffers', unused, 'out of', this.buffers.length);
                 // decreasing the buffers array length will unref the last buffers of the array
                 // and allow them to be garbage collected
-                this.buffers.length -= release_count;
+                this.buffers.length -= unused;
             }
         }
         // start a new interval of tracking the lowest buffers length
@@ -231,7 +240,7 @@ class BuffersPool {
      * }>}
      */
     async get_buffer() {
-        dbg.log1('BufferPool.get_buffer: sem value', this.sem._value, 'waiting_value', this.sem._waiting_value, 'buffers length', this.buffers.length);
+        dbg.log1('BufferPool.get_buffer: ', 'buffer size', this.buf_size, 'sem value', this.sem._value, 'waiting_value', this.sem._waiting_value, 'buffers length', this.buffers.length);
         let buffer = null;
         let warning_timer;
         // Lazy allocation of buffers pool, first cycle will take up buffers
@@ -294,6 +303,8 @@ class MultiSizeBuffersPool {
      *           sem_size: number;
      *           is_default?: boolean;
      *           release_unused_interval?: number;
+     *           min_size?: number;
+     *           is_overcommit?: boolean;
      *      }>;
      *      warning_timeout?: number;
      *      sem_timeout?: number,
@@ -302,10 +313,21 @@ class MultiSizeBuffersPool {
      *      buffer_alloc?: (size: number) => Buffer;
      * }} params
      */
-    constructor({ sorted_buf_sizes, warning_timeout, sem_timeout, sem_timeout_error_code, sem_warning_timeout, buffer_alloc }) {
-        /** @type {BuffersPool} */
-        this.default_pool = null;
-        this.pools = sorted_buf_sizes.map(({ size, sem_size, is_default, release_unused_interval }) => {
+    constructor({
+        sorted_buf_sizes,
+        warning_timeout,
+        sem_timeout,
+        sem_timeout_error_code,
+        sem_warning_timeout,
+        buffer_alloc,
+    }) {
+        this.pools = sorted_buf_sizes.map(({
+            size, sem_size,
+            is_default = false,
+            release_unused_interval = 0,
+            min_size = 0,
+            is_overcommit = false,
+        }) => {
             const pool = new BuffersPool({
                 buf_size: size,
                 sem: new semaphore.Semaphore(sem_size, {
@@ -313,9 +335,11 @@ class MultiSizeBuffersPool {
                     timeout_error_code: sem_timeout_error_code,
                     warning_timeout: sem_warning_timeout,
                 }),
-                warning_timeout: warning_timeout,
+                warning_timeout,
                 release_unused_interval,
-                buffer_alloc
+                buffer_alloc,
+                min_size,
+                is_overcommit,
             });
             if (is_default) {
                 this.default_pool ||= pool;
@@ -330,22 +354,27 @@ class MultiSizeBuffersPool {
 
     /**
      * Returns the buffers pool that fits the given size.
-     * It returns the largest pool if no size is provided.
-     * It returns the smallest pool that covers the given size.
-     * If no pool , the largest pool is returned.
+     * It returns the default pool if no size is provided.
+     * Then it looks for the first pool that covers the requested size.
+     * If allow_overcommit is false, pools that are overcommitting will not be used.
+     * If no pool was found for the given size, the default pool is returned.
      * The caller should be prepared to use buffers larger than the requested size, 
      * or smaller than the requested size if there is no pool for that size.
      * @param {number} [size]
+     * @param {boolean} [allow_overcommit]
      * @returns {BuffersPool}
      */
-    get_buffers_pool(size) {
-        if (typeof size !== 'number' || size < 0) {
+    get_buffers_pool(size, allow_overcommit = false) {
+        if ((!size && size !== 0) || size < 0 || !Number.isInteger(size)) {
             return this.default_pool;
         }
-        for (const bp of this.pools) {
-            if (size <= bp.buf_size) {
-                return bp;
-            }
+        for (let i = 0; i < this.pools.length; ++i) {
+            const bp = this.pools[i];
+            // if the pool buf size is smaller than the requested size, skip to the next pool (unless it's the last pool)
+            if (size > bp.buf_size && i !== this.pools.length - 1) continue;
+            if (bp.is_overcommit && !allow_overcommit) continue;
+            if (size < bp.min_size) continue;
+            return bp;
         }
         return this.default_pool;
     }
@@ -355,11 +384,12 @@ class MultiSizeBuffersPool {
      * 
      * @template T
      * @param {number} size
+     * @param {boolean} allow_overcommit
      * @param {(buffer: Buffer) => Promise<T>} func 
      * @returns {Promise<T>}
      */
-    async use_buffer(size, func) {
-        return this.get_buffers_pool(size).use_buffer(func);
+    async use_buffer(size, allow_overcommit, func) {
+        return this.get_buffers_pool(size, allow_overcommit).use_buffer(func);
     }
 }
 

--- a/src/util/rdma_utils.js
+++ b/src/util/rdma_utils.js
@@ -239,7 +239,8 @@ async function read_file_to_rdma(rdma_info, reader, multi_buffer_pool, abort_sig
 async function write_file_from_rdma_buffered(rdma_info, writer, multi_buffer_pool, abort_signal) {
     const rdma_server = await s3_rdma_server(rdma_info.ip);
     // we use the largest buffer size we can from the pools, and then read in chunks
-    return await multi_buffer_pool.use_buffer(rdma_info.size, async buffer => {
+    const allow_overcommit = config.NSFS_BUF_POOL_XL_ENABLED_FOR_RDMA;
+    return await multi_buffer_pool.use_buffer(rdma_info.size, allow_overcommit, async buffer => {
         rdma_server.register_buffer(buffer);
         let pos = 0;
         while (pos < rdma_info.size) {
@@ -284,24 +285,32 @@ async function write_file_from_rdma_buffered(rdma_info, writer, multi_buffer_poo
 async function read_file_to_rdma_buffered(rdma_info, reader, multi_buffer_pool, abort_signal) {
     const rdma_server = await s3_rdma_server(rdma_info.ip);
 
+    // take into account the client buffer size and the file read range size
+    // to use a smaller buffer pool if possible
+    const target_size = Math.min(rdma_info.size, reader.end - reader.start);
+    if (target_size <= 0) {
+        return { status_code: 200, num_bytes: 0 };
+    }
+
     // we use the largest buffer size we can from the pools
     // hopefully we can complete the read in one go but if not, we will iterate in blocks,
     // and rdma each one to the client to the correct offset in the remote buffer,
     // before we read the next chunk to the same local buffer.
-    return await multi_buffer_pool.use_buffer(rdma_info.size, async buffer => {
+    const allow_overcommit = config.NSFS_BUF_POOL_XL_ENABLED_FOR_RDMA;
+    return await multi_buffer_pool.use_buffer(target_size, allow_overcommit, async buffer => {
 
         rdma_server.register_buffer(buffer);
 
         // iterate with blocks
         let pos = 0;
-        while (pos < rdma_info.size) {
+        while (pos < target_size) {
 
             // allow fast abort by checking before and after the reads
             abort_signal?.throwIfAborted();
 
             // read the next chunk from the file into local buffer
             const client_buf_offset = rdma_info.offset + pos;
-            const remain_size = rdma_info.size - pos;
+            const remain_size = target_size - pos;
             const read_size = Math.min(remain_size, buffer.length);
             const nread = await reader.read_into_buffer(buffer, 0, read_size);
             // console.log('GGG RDMA nread', nread);


### PR DESCRIPTION
(cherry picked from commit 1c1514b7d0009fabd2548cfed2d7e396a4154ad1)

### Describe the Problem
We were using the XL buffer by default when the size of the buffer is higher than 8MB
The memory limit for the XL buffer was capped at 512 buffers - which can lead to 32GB extra memory.
Memory used by XL buffer wasn't released by default.

### Explain the Changes
1. We will use XL buffer just for RDMA - we will have overcommit flag - set just for RDMA
2. We will change the default limit for XL buffer to 4GB - 64 buffers max
3. We will add min_size for the XL buffer - we will use XL buffer only for buffers with minimum size half the size of XL buffer - 32GB and up by default
4. We will release the unused buffers every 1 min

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * RDMA-aware XL buffer controls, explicit XL minimum size, and a fixed XL allocation cap; XL memory limit calculation updated.
  * XL unused buffers now released periodically (60s) instead of disabled.
  * Pool selection enhanced with configurable min-size and overcommit behavior; RDMA paths respect overcommit setting.

* **Tests**
  * Added tests for pool selection behavior and unused-buffer release timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9609)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->