### PR TITLE
Added a fix so replication target reachability and copy failures are reported correctly

### DIFF
--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -208,8 +208,6 @@ class LogReplicationScanner {
                     diff_keys = { ...diff_keys, ...keys_diff_map };
                 }
             }
-            // target bucket is reachable
-            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
             dbg.error('log_replication_scanner: failed to get buckets diff, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
@@ -226,8 +224,6 @@ class LogReplicationScanner {
         let src_dst_objects_list;
         try {
             src_dst_objects_list = await this.head_objects(src_bucket.name, dst_bucket.name, candidates);
-            // target bucket is reachable
-            replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
             dbg.error('log_replication_scanner: failed to head objects, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
@@ -321,7 +317,6 @@ class LogReplicationScanner {
      * @param {string} replication_id
      */
     async copy_objects(src_bucket_name, dst_bucket_name, keys_diff_map, rule_id, replication_id) {
-        if (!Object.keys(keys_diff_map).length) return;
         const copy_type = replication_utils.get_copy_type();
         const copy_res = await replication_utils.copy_objects(
             this._scanner_sem,
@@ -330,6 +325,7 @@ class LogReplicationScanner {
             src_bucket_name.unwrap(),
             dst_bucket_name.unwrap(),
             keys_diff_map,
+            replication_id,
         );
         dbg.log2('log_replication_scanner: scan copy_objects: ', keys_diff_map);
         // in case of log-based replication there is no need for the src_cont_token, hence the undefined.

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -120,8 +120,6 @@ class ReplicationScanner {
                 keys_diff_map = buckets_diff_result.keys_diff_map;
                 src_cont_token = buckets_diff_result.first_bucket_cont_token;
                 dst_cont_token = buckets_diff_result.second_bucket_cont_token;
-
-                replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
             } catch (err) {
                 dbg.error('replication_scanner: failed to get buckets diff, target may be unreachable:',
                     src_bucket.name, dst_bucket.name, err);
@@ -145,8 +143,12 @@ class ReplicationScanner {
                     src_bucket.name,
                     dst_bucket.name,
                     keys_diff_map,
+                    replication_id,
                 );
                 dbg.log0('replication_scanner: scan copy_res:', copy_res);
+            } else {
+                replication_utils.update_replication_target_status(
+                    replication_id, src_bucket.name, dst_bucket.name, true);
             }
 
             await replication_store.update_replication_status_by_id(replication_id,

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -52,8 +52,8 @@ function get_rule_and_bucket_status(rule, src_cont_token, keys_diff_map, copy_re
         }, { num_keys_to_copy: 0, num_bytes_to_copy: 0 }
     );
 
-    const num_keys_moved = copy_res.num_of_objects;
-    const num_bytes_moved = copy_res.size_of_objects;
+    const num_keys_moved = (copy_res && copy_res.num_of_objects) || 0;
+    const num_bytes_moved = (copy_res && copy_res.size_of_objects) || 0;
 
     const rule_status = {
         last_cycle_rule_id: rule,
@@ -252,11 +252,15 @@ function get_copy_type() {
     return 'MIX';
 }
 
-async function copy_objects(scanner_semaphore, client, copy_type, src_bucket_name, dst_bucket_name, keys_diff_map) {
+async function copy_objects(scanner_semaphore, client, copy_type, src_bucket_name, dst_bucket_name, keys_diff_map, replication_id) {
+    const keys_length = Object.keys(keys_diff_map || {});
+    if (!keys_length.length) {
+        return { num_of_objects: 0, size_of_objects: 0 };
+    }
+
+    let res;
     try {
-        const keys_length = Object.keys(keys_diff_map);
-        if (!keys_length.length) return;
-        const res = await scanner_semaphore.surround_count(keys_length, //We will do key by key even when a key have more then one version
+        res = await scanner_semaphore.surround_count(keys_length, //We will do key by key even when a key have more then one version
             async () => {
                 try {
                     //calling copy_objects in the replication server
@@ -279,11 +283,21 @@ async function copy_objects(scanner_semaphore, client, copy_type, src_bucket_nam
                     dbg.error('replication_utils copy_objects: error: ', err, src_bucket_name, dst_bucket_name, keys_diff_map);
                 }
             });
-        return res;
     } catch (err) {
         dbg.error('replication_utils copy_objects: semaphore error:', err, err.stack);
         // no need to handle semaphore errors, eventually the object will be uploaded
+        return;
     }
+
+    const moved = Number(res?.num_of_objects) || 0;
+    if (replication_id) {
+        if (moved > 0) {
+            update_replication_target_status(replication_id, src_bucket_name, dst_bucket_name, true);
+        } else {
+            update_replication_target_status(replication_id, src_bucket_name, dst_bucket_name, false);
+        }
+    }
+    return res ?? { num_of_objects: 0, size_of_objects: 0 };
 }
 
 //TODO: probably need to handle it also, getting an objects and not keys array

--- a/src/test/unit_tests/internal/test_replication_metrics.test.js
+++ b/src/test/unit_tests/internal/test_replication_metrics.test.js
@@ -35,6 +35,7 @@ const mock_store = { buckets: [], deleted: new Map(),
     },
 };
 jest.mock('../../../server/system_services/system_store', () => ({ get_instance: () => ({ data: mock_store }) }));
+jest.mock('../../../server/common_services/auth_server', () => ({ make_auth_token: () => ({ token: 't' }) }));
 
 const mock_core = jest.fn();
 jest.mock('../../../server/analytic_services/prometheus_reporting', () => ({ get_core_report: () => mock_core() }));
@@ -52,6 +53,10 @@ const reset = () => { const h = g()?.hashMap; g()?.reset?.(); Object.keys(h || {
 const tgts = r => Object.values(g().hashMap).filter(e => e.labels?.replication_id === String(r)).map(e => e.labels.target_bucket);
 const probe = (r, s, d, ok = true) => u.update_replication_target_status(r, s, d, ok);
 const reconcile = () => u.reconcile_replication_target_status();
+const gauge = () => Object.values(g().hashMap).find(e => e.labels?.target_bucket === DST)?.value;
+const copy_sem = { surround_count: async (_n, fn) => fn() };
+const copy_client = { replication: { copy_objects: jest.fn() } };
+const copy_keys = { key1: [{ Size: 1 }] };
 
 const seed = (rid, dsts, o = {}) => {
     const rules = dsts.map((n, i) => ({ rule_id: `r${i}`, destination_bucket: `dst-id-${n}` }));
@@ -140,7 +145,48 @@ describe('NooBaa_replication_target_status', () => {
         ['sets gauge to 0 when replication scanner bucket diff fails (target unreachable)', false, 0],
     ])('%s', (_desc, ok, want) => {
         probe(R1, SRC, DST, ok);
-        expect(Object.values(g().hashMap).find(e => e.labels?.target_bucket === DST)?.value).toBe(want);
+        expect(gauge()).toBe(want);
+    });
+
+    describe('scan reachability after diff', () => {
+        beforeEach(() => {
+            mock_store.systems = [{ _id: 'sys', owner: { _id: 'owner' } }];
+            copy_client.replication.copy_objects.mockReset();
+        });
+
+        it.each([
+            [
+                'sets replication_target_status to 1 after copy_objects when at least one object was replicated',
+                { num_of_objects: 1, size_of_objects: 1 },
+                1,
+            ],
+            [
+                'sets replication_target_status to 0 after copy_objects when copy fails and num_of_objects moved is 0',
+                { num_of_objects: 0, size_of_objects: 0 },
+                0,
+            ],
+        ])('%s', async (_desc, res, want) => {
+            copy_client.replication.copy_objects.mockResolvedValue(res);
+            await u.copy_objects(copy_sem, copy_client, 'MIX', SRC, DST, copy_keys, R1);
+            expect(gauge()).toBe(want);
+        });
+
+        it('does not update replication_target_status when copy_objects is called with an empty keys_diff_map', async () => {
+            probe(R1, SRC, DST, false);
+            await u.copy_objects(copy_sem, copy_client, 'MIX', SRC, DST, {}, R1);
+            expect(copy_client.replication.copy_objects).not.toHaveBeenCalled();
+            expect(gauge()).toBe(0);
+        });
+
+        it('keeps replication_target_status at 0 after failed copy and sets 1 only when scan has no keys to copy', async () => {
+            copy_client.replication.copy_objects.mockResolvedValue({ num_of_objects: 0, size_of_objects: 0 });
+            await u.copy_objects(copy_sem, copy_client, 'MIX', SRC, DST, copy_keys, R1);
+            expect(gauge()).toBe(0);
+            await u.copy_objects(copy_sem, copy_client, 'MIX', SRC, DST, {}, R1);
+            expect(gauge()).toBe(0);
+            probe(R1, SRC, DST, true);
+            expect(gauge()).toBe(1);
+        });
     });
 
     it.each([


### PR DESCRIPTION
### Describe the Problem
Replication could look “reachable” in metrics when the target was actually broken (diff/listing OK but copy failing or returning zero moves), so reachability alerts were unreliable.

### Explain the Changes
1.  Tie `replication_target_status` to real outcomes: scan resets each cycle and records unreachable on zero-move copies (with replication_id on copy_objects); log replication does the same without a global reset, and only marks reachable after a successful copy or when there is nothing to copy.
2. `replication_utils.copy_objects` — optional replication_id, unreachable when `moved === 0`, safer `copy_res` for prom reporting; semaphore path unchanged.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: https://redhat.atlassian.net/browse/DFBUGS-6508

### Testing Instructions:
1. Create two obc and target bucket obc should be backed by external bucket.
2.  Check if replication is working fine, then delete the external bucket of target obc and wait for `NooBaaReplicationTargetUnreachable` alert firing.
3. Verify if replication is working fine, and also check the replication_target_status metrics using below commands (It should contain 4 metrics for each replication rule_id having reachable state).
> $ JWT_TOKEN=$(kubectl get secret/noobaa-metrics-auth-secret -o jsonpath={.data.metrics_token} | base64 -d)
> $ kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/bg_workers | grep replication_target_status

`prometheus dashboard flow:

0) Prereqs: kubectl and helm work against your cluster. Set once:
export NS=default

1) Add Helm repo
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update

2) Install or upgrade kube-prometheus-stack (match NooBaa labels):
helm upgrade prometheus prometheus-community/kube-prometheus-stack --install --namespace $NS --create-namespace --set prometheus.prometheusSpec.serviceMonitorSelector.matchLabels.app=noobaa --set prometheus.prometheusSpec.ruleSelector.matchLabels.prometheus=k8s --set prometheus.prometheusSpec.ruleSelector.matchLabels.role=alert-rules

Check it applied:
helm -n $NS get values prometheus
kubectl -n $NS get prometheus -o yaml | grep -A30 serviceMonitorSelector

3) Fix TLS on NooBaa ServiceMonitors (minimal tlsConfig)
Replace tlsConfig so there is no caFile, no ca: {}, no cert: {} — only skip-verify and SNI:

kubectl -n "$NS" patch servicemonitor noobaa-mgmt-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/1/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}},
  {"op":"replace","path":"/spec/endpoints/2/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"noobaa-mgmt.'"$NS"'.svc"}}
]'
kubectl -n "$NS" patch servicemonitor s3-service-monitor --type=json -p='[
  {"op":"replace","path":"/spec/endpoints/0/tlsConfig","value":{"insecureSkipVerify":true,"serverName":"s3.'"$NS"'.svc"}}
]'

4) Verify scraping and metrics
POD=$(kubectl -n $NS get pods -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22s3%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D%22noobaa-mgmt%22%7D'
kubectl -n $NS exec "$POD" -c prometheus -- wget -qO- 'http://127.0.0.1:9090//api/v1/query?query=NooBaa_num_buckets'

5) Prometheus UI port-forward
kubectl port-forward -n $NS pod/prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
Open http://127.0.0.1:9090 — Graph, Status → Targets, Alerts, Rules.

6) What to expect (so you’re not surprised)
Core system metrics (NooBaa_num_buckets, etc.) usually show under job=noobaa-mgmt.
Endpoint metrics (NooBaa_Endpoint_*) show under job=s3 on :9443.
Replication metrics only appear after replication is configured and scanners update them.`



- [ ] Doc added/updated
- [ ] Tests added
- [ ] 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replication reachability detection so target status reflects actual transfer outcomes.
  * Prevented incorrect reachable/status flips by tying status updates to actual copy results.
  * Added safeguards for missing copy results and transient semaphore errors to avoid cascading failures and ensure more reliable replication metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9610)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->