### PR TITLE
Change error from AccessDenied to Forbidden when not allowed to create new buckets

### DIFF
--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -296,7 +296,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
     async create_bucket(params, sdk) {
         return bucket_semaphore.surround_key(String(params.name), async () => {
             if (!sdk.requesting_account.allow_bucket_creation) {
-                throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
+                throw new RpcError('FORBIDDEN', 'Not allowed to create new buckets');
             }
             if (!sdk.requesting_account.nsfs_account_config || !sdk.requesting_account.nsfs_account_config.new_buckets_path) {
                 throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');
@@ -1200,7 +1200,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         return bucket_semaphore.surround_key(String(vector_bucket_name), async () => {
             const account = object_sdk.requesting_account;
             if (!account.allow_bucket_creation) {
-                throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
+                throw new RpcError('FORBIDDEN', 'Not allowed to create new buckets');
             }
             if (!account.nsfs_account_config || !account.nsfs_account_config.new_buckets_path) {
                 throw new RpcError('MISSING_NSFS_ACCOUNT_CONFIGURATION');

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1548,7 +1548,7 @@ function validate_bucket_creation(req, buckets_by_name, name = req.rpc_params.na
     }
 
     if (req.account.allow_bucket_creation === false) {
-        throw new RpcError('UNAUTHORIZED', 'Not allowed to create new buckets');
+        throw new RpcError('FORBIDDEN', 'Not allowed to create new buckets');
     }
 }
 


### PR DESCRIPTION

### Describe the Problem


### Explain the Changes
1. Change error from AccessDenied to Forbidden when not allowed to create new buckets, for example, when creating a bucket using credentials of an account created for obc.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for bucket creation permission denials with corrected error codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9612)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->