### PR TITLE
NC | RDMA | CUDA and cuobjserver fix library loading paths by machine arch

### DIFF
--- a/src/native/cuda/cuda_napi.cpp
+++ b/src/native/cuda/cuda_napi.cpp
@@ -77,6 +77,21 @@ cuda_napi_ctx_init(Napi::Env env, int dev_num = 0)
 {
     if (cuda_napi_dev_num == dev_num && cuda_napi_ctx) return;
 
+    // Try to load libcuda to ensure it's loaded before we use its symbols.
+    // If another path is needed at runtime, the user can set LD_PRELOAD to the correct path of libcuda.so.
+    const char* cuda_lib_path1 = 
+        "/usr/lib64/libcuda.so"; // RHEL/CentOS path
+    std::string cuda_lib_path2 = 
+        "/usr/lib/" + get_machine_arch() + "-linux-gnu/libcuda.so"; // Ubuntu/Debian path
+    void* lib_handle = dlopen(cuda_lib_path1, RTLD_NOW | RTLD_GLOBAL);
+    if (!lib_handle) {
+        lib_handle = dlopen(cuda_lib_path2.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        if (!lib_handle) {
+            LOG("CUDA: dlopen libcuda failed "
+                << DVAL(cuda_lib_path1) << DVAL(cuda_lib_path2));
+        }
+    }
+
     CUdevice dev = -1;
     CUcontext ctx = 0;
 

--- a/src/native/cuobj/cuobj_server_napi.cpp
+++ b/src/native/cuobj/cuobj_server_napi.cpp
@@ -156,11 +156,13 @@ CuObjServerNapi::CuObjServerNapi(const Napi::CallbackInfo& info)
 
     // Try to load libcuobjserver to ensure it's loaded before we use its symbols.
     // If another path is needed at runtime, the user can set LD_PRELOAD to the correct path of libcuobjserver.so.
-    const char* cuobj_server_lib_path1 = "/usr/lib64/libcuobjserver.so"; // RHEL/CentOS path
-    const char* cuobj_server_lib_path2 = "/usr/lib/x86_64-linux-gnu/libcuobjserver.so"; // Ubuntu/Debian path
+    const char* cuobj_server_lib_path1 = 
+        "/usr/lib64/libcuobjserver.so"; // RHEL/CentOS path
+    std::string cuobj_server_lib_path2 = 
+        "/usr/lib/" + get_machine_arch() + "-linux-gnu/libcuobjserver.so"; // Ubuntu/Debian path
     void* lib_handle = dlopen(cuobj_server_lib_path1, RTLD_NOW | RTLD_GLOBAL);
     if (!lib_handle) {
-        lib_handle = dlopen(cuobj_server_lib_path2, RTLD_NOW | RTLD_GLOBAL);
+        lib_handle = dlopen(cuobj_server_lib_path2.c_str(), RTLD_NOW | RTLD_GLOBAL);
         if (!lib_handle) {
             LOG("CuObjServerNapi: dlopen libcuobjserver failed "
                 << DVAL(cuobj_server_lib_path1) << DVAL(cuobj_server_lib_path2));

--- a/src/native/util/os.h
+++ b/src/native/util/os.h
@@ -12,6 +12,7 @@ namespace noobaa
 
 pid_t get_current_tid();
 uid_t get_current_uid();
+std::string get_machine_arch();
 
 /**
  * ThreadScope should be created on stack in a thread.

--- a/src/native/util/os_darwin.cpp
+++ b/src/native/util/os_darwin.cpp
@@ -4,6 +4,7 @@
 #include "common.h"
 #include <sys/kauth.h> // for KAUTH_UID_NONE
 #include <sys/param.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 #include <algorithm>
 #include <pwd.h>
@@ -38,6 +39,17 @@ get_current_uid()
     gid_t gid;
     MUST_SYS(_mac_thread_getugid(&uid, &gid));
     return uid;
+}
+
+std::string
+get_machine_arch()
+{
+    std::string machine = "x86_64";
+    struct utsname u;
+    if (uname(&u) == 0) {
+        machine = u.machine;
+    }
+    return machine;
 }
 
 const uid_t ThreadScope::orig_uid = getuid();

--- a/src/native/util/os_linux.cpp
+++ b/src/native/util/os_linux.cpp
@@ -5,6 +5,7 @@
 
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <sys/capability.h>
 #include <grp.h>
 #include <limits.h>
@@ -23,6 +24,17 @@ uid_t
 get_current_uid()
 {
     return syscall(SYS_geteuid);
+}
+
+std::string
+get_machine_arch()
+{
+    std::string machine = "x86_64";
+    struct utsname u;
+    if (uname(&u) == 0) {
+        machine = u.machine;
+    }
+    return machine;
 }
 
 const uid_t ThreadScope::orig_uid = getuid();


### PR DESCRIPTION
(cherry picked from commit 5b33693dfba2e0c8e1d622e1744c21cc97e8ebc0)

### Describe the Problem
Issues with loading CUDA and cuObject libraries in runtime

### Explain the Changes
1. loading CUDA before using it's symbols
2. Fixing both loads (CUDA and cuObj) using the machine_arch

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced library loading for CUDA components with improved distribution compatibility (RHEL/CentOS and Ubuntu/Debian) and automatic detection of system architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9616)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->