### PR TITLE
vectors - fix list indexes for OBC case (df 6855)

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2271,7 +2271,7 @@ async function delete_vector_bucket(req) {
     });
 }
 
-async function list_vector_objects(req, unsorted_system_collection, get_info_func) {
+async function list_vector_objects(req, unsorted_system_collection, get_info_func, owner) {
     if (!unsorted_system_collection) {
         return {
             items: []
@@ -2286,7 +2286,7 @@ async function list_vector_objects(req, unsorted_system_collection, get_info_fun
     const unsorted_owned_collection = [];
     await _.forEach(unsorted_system_collection, async item => {
         if (item.deleting ||
-            !(await req.has_bucket_ownership_permission(item)) ||
+            !(await req.has_bucket_ownership_permission(owner || item)) ||
             (prefix && !item.name.unwrap().startsWith(prefix))) {
             return; //item is not relevant, skip it
         }
@@ -2521,7 +2521,10 @@ async function get_vector_index(req) {
 async function list_vector_indices(req) {
     dbg.log0("list_vector_indices req.rpc_params =", req.rpc_params);
     const vector_bucket = find_vector_bucket(req, req.rpc_params.vector_bucket_name);
-    const res = await list_vector_objects(req, vector_bucket.vector_indices_by_name, get_vector_index_info);
+    //for OBC, we need to check ownership by account.bucket_claim_owner field
+    //(see req.has_bucket_ownership_permission() -> auth_server.js.is_bucket_claim_owner())
+    //so for indexes we check ownership via vector bucket (instead of directly on index)
+    const res = await list_vector_objects(req, vector_bucket.vector_indices_by_name, get_vector_index_info, vector_bucket);
     return res;
 }
 


### PR DESCRIPTION
### Describe the Problem
Ownership check for vector index didn't take into consideration OBC case.
List indexes of OBC returned no results.

### Explain the Changes
1. Ownership check for vector indexes now relies on vector bucket, which correctly check for OBC ownership.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6855

### Testing Instructions:
1. Create vector OBC
2. Create vector index
3. List vector index


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization when listing vector objects so ownership is validated against an explicit owner (or the item itself when no owner is supplied), preventing improper access.
  * Updated index listing authorization to use the parent vector bucket as the owner, ensuring index access follows bucket ownership rules consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->