### PR TITLE
Add range filtering to read_object_md prefetch query

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -596,6 +596,8 @@ module.exports = {
                     md_conditions: { $ref: '#/definitions/md_conditions' },
                     encryption: { $ref: 'common_api#/definitions/object_encryption' },
                     should_prefetch_mappings: { type: 'boolean' },
+                    range_start: { type: 'integer' },
+                    range_end: { type: 'integer' },
                     adminfo: {
                         type: 'object',
                         properties: {

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -29,6 +29,14 @@ async function get_object(req, res) {
     }
     const md_conditions = http_utils.get_md_conditions(req);
 
+    let parsed_ranges;
+    try {
+        parsed_ranges = http_utils.parse_http_ranges(req.headers.range);
+    } catch (err) {
+        dbg.log1('bad range request', req.headers.range, req.path);
+        throw new S3Error(S3Error.InvalidArgument);
+    }
+
     const md_params = {
         bucket: req.params.bucket,
         key: req.params.key,
@@ -44,6 +52,13 @@ async function get_object(req, res) {
     }
     if (!part_number) {
         md_params.should_prefetch_mappings = true;
+        if (parsed_ranges && parsed_ranges.length === 1) {
+            const r = parsed_ranges[0];
+            if (r.start >= 0 && r.end !== undefined) {
+                md_params.range_start = r.start;
+                md_params.range_end = r.end;
+            }
+        }
     }
 
     const object_md = await req.object_sdk.read_object_md(md_params);
@@ -80,10 +95,7 @@ async function get_object(req, res) {
         params.part_number = part_number;
     }
     try {
-        const ranges = http_utils.normalize_http_ranges(
-            http_utils.parse_http_ranges(req.headers.range),
-            obj_size
-        );
+        const ranges = http_utils.normalize_http_ranges(parsed_ranges, obj_size);
         if (ranges) {
             // reply with HTTP 206 Partial Content
             res.statusCode = 206;
@@ -98,11 +110,6 @@ async function get_object(req, res) {
             dbg.log1('reading object', req.path, obj_size);
         }
     } catch (err) {
-        if (err.ranges_code === 400) {
-            // return http 400 Bad Request
-            dbg.log1('bad range request', req.headers.range, req.path, obj_size);
-            throw new S3Error(S3Error.InvalidArgument);
-        }
         if (err.ranges_code === 416) {
             // return http 416 Requested Range Not Satisfiable
             dbg.warn('invalid range', req.headers.range, req.path, obj_size);

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -921,12 +921,11 @@ function slice_buffers_in_range(chunks, start, end) {
 }
 
 /**
- * Filters prefetched chunk mappings to those overlapping [read_start, read_end) and
- * clears object_md.prefetched_mappings once all entries are consumed.
- * Returns the filtered chunks and the effective end the caller should use for the read range.
- * When matching mappings exist, effective_end is coverage_end capped to read_end.
- * When there are no mappings or none match, chunks is undefined and effective_end is read_end
- * so the normal DB path is used.
+ * Consumes prefetched chunk mappings from object_md, filtering to those overlapping
+ * [read_start, read_end), and clears prefetched_mappings.
+ * Returns the filtered chunks and the effective end capped to coverage_end.
+ * When no mappings exist or none overlap the range, returns read_end unchanged
+ * so the caller falls through to the normal DB path.
  * @param {Partial<nb.ObjectInfo>} object_md
  * @param {number} read_start - current stream position
  * @param {number} read_end - watermark-based requested end

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -2079,18 +2079,31 @@ class MDStore {
     }
 
     /**
-     * Single-query path: fetch object metadata and the first max_parts parts with
-     * their chunks and blocks in one round-trip. Replaces a read_object_md call
-     * followed by find_parts_chunks_blocks_by_range for the common GET case.
-     * Returns null if the object is not found.
+     * Single-query path: fetch object metadata and matching parts with their
+     * chunks and blocks in one round-trip.
      *
-     * @param {string} bucket_id
-     * @param {string} key
-     * @param {number} max_parts
-     * @param {(a: any, b: any) => number} [sorter]
+     * max_parts caps the number of returned parts in both cases below.
+     * When range params (start_gte, start_lt, end_gt) are provided, parts are
+     * first filtered to those overlapping the byte range, then limited to max_parts.
+     * When omitted, parts are fetched from the beginning, limited to max_parts.
+     *
+     * @param {object} params
+     * @param {string} params.bucket_id
+     * @param {string} params.key
+     * @param {number} params.max_parts
+     * @param {number} [params.start_gte] - lower bound on part start (inclusive)
+     * @param {number} [params.start_lt] - upper bound on part start (exclusive)
+     * @param {number} [params.end_gt] - parts must end after this offset
+     * @param {(a: any, b: any) => number} [params.sorter]
      * @returns {Promise<{ obj: nb.ObjectMD, parts: nb.PartSchemaDB[], chunks_db: nb.ChunkSchemaDB[] }|null>}
      */
-    async find_object_with_mapping_by_key(bucket_id, key, max_parts, sorter) {
+    async find_object_with_mapping_by_key({ bucket_id, key, max_parts, start_gte, start_lt, end_gt, sorter }) {
+        const has_range = start_gte !== undefined && start_lt !== undefined && end_gt !== undefined;
+        const range_clause = has_range ?
+            `AND (p.data->>'start')::bigint >= $4
+            AND (p.data->>'start')::bigint < $5
+            AND (p.data->>'end')::bigint > $6` :
+            '';
         const query = `
             WITH obj AS (
                 SELECT o._id, o.data
@@ -2109,6 +2122,7 @@ class MDStore {
                     AND p.data ? 'obj'
                     AND (p.data->'deleted' IS NULL OR p.data->'deleted' = 'null'::jsonb)
                     AND (p.data->'uncommitted' IS NULL OR p.data->'uncommitted' = 'null'::jsonb)
+                    ${range_clause}
                 ORDER BY (p.data->>'start')::bigint ASC
                 LIMIT $3
             )
@@ -2135,6 +2149,7 @@ class MDStore {
             GROUP BY obj._id, obj.data
         `;
         const values = [`${bucket_id}`, key, max_parts];
+        if (has_range) values.push(start_gte, start_lt, end_gt);
         const res = await db_client.instance().executeSQL(query, values, { preferred_pool: this._postgres_pool });
         if (!res.rows.length) return null;
         const row = res.rows[0];

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -953,7 +953,11 @@ function _convert_rpc_params_to_bucket_policy_req(rpc_params) {
  */
 async function read_object_md(req) {
     dbg.log1('object_server.read_object_md:', req.rpc_params);
-    const { bucket, key, md_conditions, adminfo, encryption, version_id, should_prefetch_mappings } = req.rpc_params;
+    const {
+        bucket, key, md_conditions, adminfo, encryption,
+        version_id, should_prefetch_mappings,
+        range_start, range_end,
+    } = req.rpc_params;
 
     if (adminfo && req.role !== 'admin') {
         throw new RpcError('UNAUTHORIZED', 'read_object_md: role should be admin');
@@ -970,9 +974,15 @@ async function read_object_md(req) {
     if (should_prefetch_mappings && !version_id && !req.rpc_params.obj_id && config.DB_TYPE === 'postgres') {
         load_bucket(req);
         const bucket_id = String(req.bucket._id);
-        const result = await MDStore.instance().find_object_with_mapping_by_key(
-            bucket_id, key, config.MAPPINGS_PREFETCH_NUM_PARTS
-        );
+        const query_params = {
+            bucket_id, key, max_parts: config.MAPPINGS_PREFETCH_NUM_PARTS,
+        };
+        if (range_start !== undefined && range_end !== undefined) {
+            query_params.start_gte = range_start - config.MAX_OBJECT_PART_SIZE;
+            query_params.start_lt = range_end;
+            query_params.end_gt = range_start;
+        }
+        const result = await MDStore.instance().find_object_with_mapping_by_key(query_params);
         if (!result) throw new RpcError('NO_SUCH_OBJECT', `object not found key=${key}`);
         obj = result.obj;
         prefetched_parts = result.parts;

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -1064,9 +1064,9 @@ mocha.describe('md_store', function() {
         });
 
         mocha.it('find_object_with_mapping_by_key - basic case', async function() {
-            const result = await md_store.find_object_with_mapping_by_key(
-                String(map_bucket_id), map_obj.key, 10
-            );
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id), key: map_obj.key, max_parts: 10,
+            });
             assert(result !== null, 'expected non-null result');
             assert.strictEqual(String(result.obj._id), String(map_obj._id));
             assert.strictEqual(result.parts.length, 1);
@@ -1079,9 +1079,9 @@ mocha.describe('md_store', function() {
 
         mocha.it('find_object_with_mapping_by_key - key not found returns null', async function() {
             if (config.DB_TYPE !== 'postgres') return;
-            const result = await md_store.find_object_with_mapping_by_key(
-                String(map_bucket_id), 'nonexistent-key-' + Date.now(), 10
-            );
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id), key: 'nonexistent-key-' + Date.now(), max_parts: 10,
+            });
             assert.strictEqual(result, null);
         });
 
@@ -1097,9 +1097,9 @@ mocha.describe('md_store', function() {
             };
             await md_store.insert_object(del_obj);
             await md_store.update_object_by_id(del_obj._id, { deleted: new Date() });
-            const result = await md_store.find_object_with_mapping_by_key(
-                String(map_bucket_id), del_obj.key, 10
-            );
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id), key: del_obj.key, max_parts: 10,
+            });
             assert.strictEqual(result, null);
         });
 
@@ -1114,9 +1114,9 @@ mocha.describe('md_store', function() {
                 content_type: 'application/octet-stream',
             };
             await md_store.insert_object(zero_part_obj);
-            const result = await md_store.find_object_with_mapping_by_key(
-                String(map_bucket_id), zero_part_obj.key, 10
-            );
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id), key: zero_part_obj.key, max_parts: 10,
+            });
             assert(result !== null, 'expected non-null result for existing zero-part object');
             assert.strictEqual(String(result.obj._id), String(zero_part_obj._id));
             assert.strictEqual(result.parts.length, 0, 'expected empty parts array');
@@ -1154,12 +1154,150 @@ mocha.describe('md_store', function() {
                 seq: i,
             }));
             await md_store.insert_parts(limited_parts);
-            const result = await md_store.find_object_with_mapping_by_key(
-                String(map_bucket_id), limited_obj.key, 1
-            );
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id), key: limited_obj.key, max_parts: 1,
+            });
             assert(result !== null, 'expected non-null result');
             assert.strictEqual(result.parts.length, 1, 'expected only 1 part due to max_parts limit');
             assert.strictEqual(Number(result.parts[0].start), 0, 'expected first (lowest-start) part');
+        });
+
+        mocha.it('find_object_with_mapping_by_key - range filters parts to matching byte range', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const range_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'range-filter-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(range_obj);
+            const range_chunks = [0, 1, 2, 3, 4].map(() => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                size: 10,
+                frag_size: 10,
+                frags: [{ _id: md_store.make_md_id() }],
+            }));
+            await md_store.insert_chunks(range_chunks);
+            const range_parts = range_chunks.map((c, i) => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                obj: range_obj._id,
+                chunk: c._id,
+                start: i * 10,
+                end: (i + 1) * 10,
+                seq: i,
+            }));
+            await md_store.insert_parts(range_parts);
+            // Range [15, 35) should match parts with start=10, start=20, start=30
+            // (start >= -HUGE, start < 35, end > 15)
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id),
+                key: range_obj.key,
+                max_parts: 100,
+                start_gte: -100,
+                start_lt: 35,
+                end_gt: 15,
+            });
+            assert(result !== null, 'expected non-null result');
+            assert.strictEqual(String(result.obj._id), String(range_obj._id));
+            assert.strictEqual(result.parts.length, 3, 'expected 3 parts in range [15, 35)');
+            const starts = result.parts.map(p => Number(p.start));
+            assert.deepStrictEqual(starts, [10, 20, 30]);
+        });
+
+        mocha.it('find_object_with_mapping_by_key - range outside all parts returns obj with empty mapping', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const empty_range_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'empty-range-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(empty_range_obj);
+            const er_chunk = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                size: 10,
+                frag_size: 10,
+                frags: [{ _id: md_store.make_md_id() }],
+            };
+            await md_store.insert_chunks([er_chunk]);
+            await md_store.insert_parts([{
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                obj: empty_range_obj._id,
+                chunk: er_chunk._id,
+                start: 0,
+                end: 10,
+                seq: 0,
+            }]);
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id),
+                key: empty_range_obj.key,
+                max_parts: 100,
+                start_gte: 500,
+                start_lt: 600,
+                end_gt: 500,
+            });
+            assert(result !== null, 'expected non-null result — object exists');
+            assert.strictEqual(String(result.obj._id), String(empty_range_obj._id));
+            assert.strictEqual(result.parts.length, 0, 'expected no parts in out-of-bounds range');
+            assert.strictEqual(result.chunks_db.length, 0, 'expected no chunks in out-of-bounds range');
+        });
+
+        mocha.it('find_object_with_mapping_by_key - max_parts limits within range', async function() {
+            if (config.DB_TYPE !== 'postgres') return;
+            const limit_range_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                key: 'limit-range-' + Date.now().toString(36),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(limit_range_obj);
+            const lr_chunks = [0, 1, 2, 3].map(() => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                size: 10,
+                frag_size: 10,
+                frags: [{ _id: md_store.make_md_id() }],
+            }));
+            await md_store.insert_chunks(lr_chunks);
+            const lr_parts = lr_chunks.map((c, i) => ({
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: map_bucket_id,
+                obj: limit_range_obj._id,
+                chunk: c._id,
+                start: i * 10,
+                end: (i + 1) * 10,
+                seq: i,
+            }));
+            await md_store.insert_parts(lr_parts);
+            // Range matches parts at start=10,20,30 but max_parts=1
+            // should return only the lowest-start part within the range (start=10)
+            const result = await md_store.find_object_with_mapping_by_key({
+                bucket_id: String(map_bucket_id),
+                key: limit_range_obj.key,
+                max_parts: 1,
+                start_gte: -100,
+                start_lt: 35,
+                end_gt: 15,
+            });
+            assert(result !== null, 'expected non-null result');
+            assert.strictEqual(result.parts.length, 1, 'expected 1 part due to max_parts limit within range');
+            assert.strictEqual(Number(result.parts[0].start), 10, 'expected lowest-start part within range');
         });
 
         mocha.it('find_parts_chunks_blocks_by_range - returns parts and blocks in range', async function() {

--- a/src/test/integration_tests/internal/test_object_io.js
+++ b/src/test/integration_tests/internal/test_object_io.js
@@ -440,6 +440,74 @@ coretest.describe_mapper_test_case({
         await rpc_client.object.delete_object({ bucket, key });
     });
 
+    mocha.it('read_object_md with range_start/range_end scopes prefetched_mappings to requested range', async function() {
+        this.timeout(600000); // eslint-disable-line no-invalid-this
+        const num_parts = 4;
+        const part_size = 61;
+        const size = num_parts * part_size;
+        const content_type = 'application/octet-stream';
+        const key = `${KEY}-range-prefetch-${key_counter}`;
+        key_counter += 1;
+        const data = generator.update(Buffer.alloc(size));
+
+        const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key, content_type });
+        const multiparts = [];
+        for (let i = 0; i < num_parts; i++) {
+            const mp = await object_io.upload_multipart({
+                client: rpc_client,
+                obj_id,
+                bucket,
+                key,
+                num: i + 1,
+                size: part_size,
+                source_stream: readable_buffer(data.slice(i * part_size, (i + 1) * part_size)),
+            });
+            multiparts.push(mp);
+        }
+        await rpc_client.object.complete_object_upload({
+            obj_id,
+            bucket,
+            key,
+            multiparts: multiparts.map((mp, i) => ({ num: i + 1, etag: mp.etag })),
+        });
+
+        // Request a range covering only the middle of the object (parts 1 and 2, 0-indexed).
+        // range_start/range_end are byte offsets the S3 layer extracts from the Range header.
+        const range_start = part_size;
+        const range_end = part_size * 3;
+        const object_md = await rpc_client.object.read_object_md({
+            bucket, key,
+            should_prefetch_mappings: true,
+            range_start,
+            range_end,
+        });
+
+        assert(Array.isArray(object_md.prefetched_mappings) && object_md.prefetched_mappings.length > 0,
+            'expected prefetched_mappings to be a non-empty array');
+
+        // Every prefetched part must overlap the requested [range_start, range_end) byte range
+        for (const chunk_info of object_md.prefetched_mappings) {
+            const part = chunk_info.parts?.[0];
+            assert(part, 'expected each prefetched chunk to have a part');
+            assert(part.end > range_start && part.start < range_end,
+                `prefetched part [${part.start}, ${part.end}) does not overlap range [${range_start}, ${range_end})`);
+        }
+
+        // Read back the ranged portion and verify data integrity
+        const read_buf = await object_io.read_entire_object({
+            client: rpc_client,
+            object_md,
+            start: range_start,
+            end: range_end,
+        });
+        assert.strictEqual(read_buf.length, range_end - range_start);
+        const expected_slice = data.slice(range_start, range_end);
+        for (let i = 0; i < read_buf.length; i++) {
+            assert.strictEqual(read_buf[i], expected_slice[i], `range read mismatch at byte ${i}`);
+        }
+        await rpc_client.object.delete_object({ bucket, key });
+    });
+
     async function upload_and_verify(size) {
         const data = generator.update(Buffer.alloc(size));
         const key = `${KEY}-${key_counter}`;


### PR DESCRIPTION
### Describe the Problem
The read_object_md prefetch optimization (introduced in #9514) fetches the first N parts of an object alongside the object metadata in a single DB round-trip. However, when the client issues a ranged GET request (e.g. Range: bytes=X-Y), the prefetched parts may not overlap the requested byte range at all, wasting the DB work and causing an unnecessary fallback to read_object_mapping for the actual range.

### Explain the Changes
1. find_object_with_mapping_by_key in md_store.js now accepts optional range parameters (start_gte, start_lt, end_gt). When provided, the SQL query filters parts to those overlapping the requested range before applying the max_parts limit. When omitted, the existing behavior (first N parts) is preserved.
2. _take_prefetched_chunks in object_io.js: Since the DB query already scopes the prefetched set to the correct byte range, the per-chunk client-side range filter is no longer needed. The function now simply consumes prefetched_mappings in one shot and computes coverage_end
3. new test in test_object_io.js verifies that prefetched mappings are scoped to the requested range and that data integrity holds for a ranged read. New test in test_md_store.js verifies max_parts interacts correctly with range filtering.


### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8845

### Gaps
1. Open-ended (bytes=N-) and suffix (bytes=-N) ranges cannot be scoped to the DB prefetch query because normalize_http_ranges requires the object size, which is only available after read_object_md returns. For these cases we will prefetch the first parts and filter them by range in _take_prefetched_chunks_for_range.

### Testing Instructions:
1. 



- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial object retrieval via optional `range_start` and `range_end` parameters in the object metadata API.
  * Improved HTTP Range header handling for S3-compatible object operations with better error reporting.

* **Tests**
  * Added integration tests for range-scoped object operations and prefetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9618)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->