### PR TITLE
KeyCloak | assume role with web identity KeyCloak

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,6 +94,11 @@ config.TLS_GROUPS = process.env.TLS_GROUPS || '';
 // LDAP CONFIG //
 /////////////////
 config.LDAP_CONFIG_PATH = '/etc/noobaa-server/ldap_config';
+//////////////////
+// OIDC CONFIG  //
+//////////////////
+config.KEYCLOAK_CONFIG_PATH = '/etc/noobaa-server/oidc_config/config.json';
+config.KEYCLOAK_RELOAD_CONFIG_INTERVAL = 10 * 1000;
 
 //////////////////
 // NODES CONFIG //

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "jsonwebtoken": "9.0.3",
+        "jwks-rsa": "4.0.1",
         "ldapts": "8.1.8",
         "linux-blockutils": "0.2.0",
         "lodash": "4.18.1",
@@ -225,7 +226,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
       "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -803,7 +803,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -865,7 +864,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -1083,7 +1081,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2941,6 +2938,7 @@
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3021,14 +3019,16 @@
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -3093,6 +3093,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -3110,6 +3120,12 @@
       "dependencies": {
         "mongodb": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.12.4",
@@ -3822,7 +3838,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3953,6 +3968,7 @@
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
@@ -3974,6 +3990,7 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3983,7 +4000,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3998,6 +4016,7 @@
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4419,7 +4438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4620,6 +4638,7 @@
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -4806,6 +4825,7 @@
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -4822,6 +4842,7 @@
       "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -4838,6 +4859,7 @@
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -4848,6 +4870,7 @@
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -5401,7 +5424,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6030,6 +6052,7 @@
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -6084,7 +6107,8 @@
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
       "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -7319,7 +7343,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -7903,6 +7926,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7950,6 +7982,7 @@
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -8046,6 +8079,45 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.0.1.tgz",
+      "integrity": "sha512-poXwUA8S4cP9P5N8tZS3xnUDJH8WmwSGfKK9gIaRPdjLHyJtd9iX/cngX9CUIe0Caof5JhK2EbN7N5lnnaf9NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^6.1.3",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^3.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
@@ -8102,6 +8174,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8142,7 +8219,14 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -8224,6 +8308,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
@@ -9171,7 +9274,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -11092,6 +11194,7 @@
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -11106,6 +11209,7 @@
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -11510,7 +11614,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11525,6 +11628,7 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11804,6 +11908,7 @@
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "http-proxy-agent": "7.0.2",
     "https-proxy-agent": "7.0.6",
     "jsonwebtoken": "9.0.3",
+    "jwks-rsa": "4.0.1",
     "ldapts": "8.1.8",
     "linux-blockutils": "0.2.0",
     "lodash": "4.18.1",

--- a/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
@@ -18,7 +18,8 @@ async function assume_role_with_web_identity(req) {
     const expiration_time = Date.now() + duration_ms;
     let assumed_role;
     try {
-        assumed_role = await req.sts_sdk.get_assumed_ldap_user(req);
+        // CHANGED: Use unified method that supports both LDAP and OIDC/Keycloak
+        assumed_role = await req.sts_sdk.get_assumed_web_identity_role(req);
     } catch (err) {
         if (err.rpc_code === 'ACCESS_DENIED') {
             throw new StsError(StsError.AccessDeniedException);
@@ -29,12 +30,23 @@ async function assume_role_with_web_identity(req) {
         if (err.rpc_code === 'INVALID_WEB_IDENTITY_TOKEN') {
             throw new StsError({ ...StsError.InvalidIdentityToken, message: err.message });
         }
-        dbg.error('get_assumed_ldap_user error:', err);
+        dbg.error('get_assumed_web_identity_role error:', err);
         throw new StsError(StsError.InternalFailure);
     }
     // Temporary credentials are NOT stored in noobaa
     // The generated session token will store in it the temporary credentials and expiry and the role's access key
     const access_keys = await req.sts_sdk.generate_temp_access_keys();
+
+    // CHANGED: Include session tags in session token if present (for OIDC/Keycloak)
+    const session_token_data = {
+        access_key: access_keys.access_key.unwrap(),
+        secret_key: access_keys.secret_key.unwrap(),
+        assumed_role_access_key: assumed_role.access_key
+    };
+    // Add session tags if present (from Keycloak/OIDC tokens)
+    if (assumed_role.session_tags && Object.keys(assumed_role.session_tags).length > 0) {
+        session_token_data.session_tags = assumed_role.session_tags;
+    }
 
     return {
         AssumeRoleWithWebIdentityResponse: {
@@ -49,13 +61,9 @@ async function assume_role_with_web_identity(req) {
                     AccessKeyId: access_keys.access_key.unwrap(),
                     SecretAccessKey: access_keys.secret_key.unwrap(),
                     Expiration: s3_utils.format_s3_xml_date(expiration_time),
-                    SessionToken: sts_utils.generate_session_token({
-                        access_key: access_keys.access_key.unwrap(),
-                        secret_key: access_keys.secret_key.unwrap(),
-                        assumed_role_access_key: assumed_role.access_key
-                    }, duration_sec)
+                    SessionToken: sts_utils.generate_session_token(session_token_data, duration_sec)
                 },
-                SourceIdentity: assumed_role.dn,
+                SourceIdentity: assumed_role.dn || assumed_role.email || assumed_role.sub,
                 Provider: assumed_role.iss,
             }
         }

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -9,6 +9,8 @@ const { account_cache, dn_cache } = require('./object_sdk');
 const BucketSpaceNB = require('./bucketspace_nb');
 const jwt = require('jsonwebtoken');
 const ldap_client = require('../util/ldap_client');
+const keycloak_client = require('../util/keycloak_client');
+const { extract_session_tags } = require('../util/keycloak_utils');
 
 class StsSDK {
 
@@ -96,7 +98,10 @@ class StsSDK {
             role_config: account.role_config
         };
     }
-
+    /**
+     * Get assumed LDAP user
+     * @param {Object} req - Request object
+     */
     async get_assumed_ldap_user(req) {
         dbg.log1('sts_sdk.get_assumed_ldap_user body', req.body);
         let web_token;
@@ -147,10 +152,110 @@ class StsSDK {
         };
     }
 
+    /**
+     * Get assumed role for OIDC/Keycloak user
+     * Validates JWT token using introspection with client_id, client_secret, and access_token
+     * @param {Object} req - Request object
+     * @returns {Promise<Object>} - Assumed role info with session tags
+     */
+    async get_assumed_oidc_user(req) {
+        dbg.log1('sts_sdk.get_assumed_oidc_user body', req.body.role_arn);
+
+        try {
+            // Initialize OIDC client if not already done
+            const keycloak_instance = keycloak_client.get_instance();
+            if (!keycloak_instance.initialized) {
+                await keycloak_instance.initialize();
+            }
+            // Also verify the JWT signature for additional security
+            const verified_token = await keycloak_instance.verify_token(
+                req.body.web_identity_token
+            );
+
+            // Introspect token with Keycloak using client_id, client_secret, and access_token
+            // This is the key implementation for Keycloak - validates token is active and not revoked
+            const introspection_resp = await keycloak_instance.introspect_token(
+                req.body.web_identity_token
+            );
+
+            // Extract session tags from verified token (not from introspection)
+            const session_tags = extract_session_tags(verified_token);
+            // Assume role
+            const account = await this._assume_role(req.body.role_arn);
+            dbg.log1('sts_sdk.get_assumed_oidc_user _assume_role res', account,
+                'account.role_config:', account.role_config,
+                'session_tags:', session_tags);
+
+            return {
+                access_key: req.body.role_arn.split(':')[4],
+                role_config: account.role_config,
+                sub: introspection_resp.sub,
+                aud: introspection_resp.client_id || introspection_resp.aud,
+                iss: introspection_resp.iss,
+                session_tags,
+                // Store additional claims for audit
+                email: introspection_resp.email || verified_token.email,
+                name: introspection_resp.name || verified_token.name || verified_token.preferred_username,
+            };
+        } catch (err) {
+            dbg.error('get_assumed_oidc_user error:', err);
+            if (err.name === 'TokenExpiredError') {
+                throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN', err.message);
+            }
+            if (err.name === 'JsonWebTokenError') {
+                throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', err.message);
+            }
+            if (err.message && err.message.includes('No KeyCloak provider')) {
+                throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', err.message);
+            }
+            if (err.message && err.message.includes('Token is not active')) {
+                throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN', 'Token has been revoked or is inactive');
+            }
+            throw new RpcError('ACCESS_DENIED', 'Issue with KeyCloak authentication');
+        }
+    }
+
+    /**
+     * Unified method to get assumed user (LDAP or OIDC/Keycloak)
+     * Detects token type and routes to appropriate handler
+     * @param {Object} req - Request object
+     * @returns {Promise<Object>} - Assumed role info
+     */
+    async get_assumed_web_identity_role(req) {
+        const decoded = jwt.decode(req.body.web_identity_token, { json: true });
+        if (!decoded) {
+            throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', 'jwt malformed');
+        }
+        // Check if OIDC is configured and token is from OIDC provider
+        if (await keycloak_client.is_keycloak_configured()) {
+            const keycloak_instance = keycloak_client.get_instance();
+            const provider = keycloak_instance.get_provider(decoded.iss);
+            if (provider) {
+                dbg.log1('Routing to KeyCloak handler for issuer:', decoded.iss);
+                return await this.get_assumed_oidc_user(req);
+            } else {
+                dbg.log0('Routing to Web Identity handler missing', decoded.iss);
+            }
+        }
+
+        // Fall back to LDAP Web Identity handler
+        dbg.log0('Routing to LDAP handler');
+        return await this.get_assumed_ldap_user(req);
+    }
+
+    /**
+     * Generates a temporary access key for the requesting account
+     * @returns {Object} - Access token and secret object
+     */
     generate_temp_access_keys() {
         return cloud_utils.generate_access_keys();
     }
 
+    /**
+     * Authorizes request account
+     * @param {Object} req - Request object
+     * @throws {RpcError} - If the request is not signed or the requesting account is not authorized
+     */
     authorize_request_account(req) {
         const token = this.get_auth_token();
         // If the request is signed (authenticated)

--- a/src/util/keycloak_client.js
+++ b/src/util/keycloak_client.js
@@ -1,0 +1,152 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const { KeyCloakProvider } = require('./keycloak_utils');
+const config = require('../../config');
+const dbg = require('./debug_module')(__filename);
+const fs = require('fs');
+
+/**
+ * Singleton KeyCloak client manager
+ * Manages multiple KeyCloak OIDC providers (e.g., Keycloak instances)
+ */
+class KeyCloakClientManager {
+    constructor() {
+        this.providers = new Map();
+        this.config_path = config.KEYCLOAK_CONFIG_PATH;
+        this.initialized = false;
+        fs.watchFile(this.config_path, {
+            interval: config.KEYCLOAK_RELOAD_CONFIG_INTERVAL
+        }, () => this.initialize()).unref();
+    }
+
+    /**
+     * Initialize KeyCloak OIDC providers from config file
+     */
+    async initialize() {
+        if (this.initialized) return;
+        try {
+            if (fs.existsSync(this.config_path)) {
+                const config_data = JSON.parse(fs.readFileSync(this.config_path, 'utf8'));
+                for (const provider of config_data.providers || []) {
+                    await this.add_provider(provider);
+                }
+                this.initialized = true;
+                dbg.log0('KeyCloak client initialized with', this.providers.size, 'providers');
+            } else {
+                dbg.log0('No KeyCloak config found at', this.config_path);
+            }
+        } catch (err) {
+            dbg.error('Failed to initialize KeyCloak client:', err);
+            // Don't throw - allow system to continue without KeyCloak
+        }
+    }
+
+    /**
+     * Add KeyCloak provider (e.g., Keycloak)
+     */
+    async add_provider(provider_config) {
+        try {
+            // Auto-discover endpoints if only issuer is provided
+            if (!provider_config.jwks_uri && provider_config.issuer) {
+                dbg.log0('Discovering KeyCloak configuration for:', provider_config.issuer);
+                const discovery = await KeyCloakProvider.discover(provider_config.issuer);
+                provider_config.jwks_uri = discovery.jwks_uri;
+                provider_config.token_introspection_endpoint = discovery.introspection_endpoint;
+            }
+            const provider = new KeyCloakProvider(provider_config);
+            this.providers.set(provider_config.issuer, provider);
+            dbg.log0('Added KeyCloak provider:', provider_config.issuer);
+        } catch (err) {
+            dbg.error('Failed to add KeyCloak provider:', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Get provider by issuer
+     * @param {String} issuer - issuer
+     * @returns {KeyCloakProvider} - provider
+     */
+    get_provider(issuer) {
+        return this.providers.get(issuer);
+    }
+
+    /**
+     * Verify token and return provider + verified token
+     * This method uses JWT signature verification first, then optionally introspects
+     * @param {String} token - token
+     * @returns {Promise<Object>} - provider + verified token
+     */
+    async verify_token(token) {
+        const decoded = require('jsonwebtoken').decode(token);
+        if (!decoded || !decoded.iss) {
+            throw new Error('Invalid token: missing issuer');
+        }
+
+        const provider = this.get_provider(decoded.iss);
+        if (!provider) {
+            throw new Error(`No KeyCloak provider configured for issuer: ${decoded.iss}`);
+        }
+
+        const verified = await provider.verify_token(token);
+        return verified;
+    }
+
+    /**
+     * Introspect token with Keycloak (validates with authorization server)
+     * This is the recommended approach for Keycloak as it checks token revocation
+     * @param {String} token - token
+     * @returns {Promise<Object>} - introspection result
+     */
+    async introspect_token(token) {
+        const decoded = require('jsonwebtoken').decode(token);
+        if (!decoded || !decoded.iss) {
+            throw new Error('Invalid token: missing issuer');
+        }
+
+        const provider = this.get_provider(decoded.iss);
+        if (!provider) {
+            throw new Error(`No KeyCloak provider configured for issuer: ${decoded.iss}`);
+        }
+
+        return await provider.introspect_token(token);
+    }
+
+    /**
+     * Check if KeyCloak is configured
+     */
+    is_configured() {
+        return this.initialized && this.providers.size > 0;
+    }
+}
+
+// Singleton instance
+let instance = null;
+
+/**
+ * Get KeyCloak client manager instance
+ * @returns {KeyCloakClientManager} - KeyCloak client manager instance
+ */
+function get_instance() {
+    if (!instance) {
+        instance = new KeyCloakClientManager();
+    }
+    return instance;
+}
+
+/**
+ * Get KeyCloak client manager instance configured or not
+ * @returns {Promise<Boolean>} - true if KeyCloak is configured, false otherwise
+ */
+
+async function is_keycloak_configured() {
+    const client = get_instance();
+    if (!client.initialized) {
+        await client.initialize();
+    }
+    return client.is_configured();
+}
+
+exports.get_instance = get_instance;
+exports.is_keycloak_configured = is_keycloak_configured;

--- a/src/util/keycloak_utils.js
+++ b/src/util/keycloak_utils.js
@@ -1,0 +1,148 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const jwt = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
+const { make_https_request } = require('./http_utils');
+const { read_stream_join } = require('./buffer_utils');
+const dbg = require('./debug_module')(__filename);
+
+/**
+ * KeyCloak Provider Configuration
+ * Handles JWT verification and token introspection for Keycloak/OIDC providers
+ */
+class KeyCloakProvider {
+    constructor(config) {
+        this.issuer = config.issuer;
+        this.client_id = config.client_id;
+        this.client_secret = config.client_secret;
+        this.jwks_uri = config.jwks_uri;
+        this.token_introspection_endpoint = config.token_introspection_endpoint;
+        this.jwks_client = null;
+
+        if (this.jwks_uri) {
+            this.jwks_client = jwksClient({
+                jwksUri: this.jwks_uri,
+                cache: true,
+                cacheMaxAge: 600000, // 10 minutes
+                rateLimit: true,
+                jwksRequestsPerMinute: 10
+            });
+        }
+    }
+
+    /**
+     * Get signing key for JWT verification
+     *  @param {String} kid - kid
+     * @returns {Promise} - signing key
+     */
+    async get_signing_key(kid) {
+        if (!this.jwks_client) {
+            throw new Error('JWKS client not configured');
+        }
+        return new Promise((resolve, reject) => {
+            this.jwks_client.getSigningKey(kid, (err, key) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    const signingKey = key.getPublicKey();
+                    resolve(signingKey);
+                }
+            });
+        });
+    }
+
+    /**
+     * Verify token using JWT signature verification
+     * @param {String} token - kid
+     * @returns {Promise<Object>} - verified token object
+     */
+    async verify_token(token) {
+        try {
+            // Decode header to get kid
+            const decoded_header = jwt.decode(token, { complete: true });
+            if (!decoded_header) {
+                throw new Error('Invalid token format');
+            }
+            const signing_key = await this.get_signing_key(decoded_header.header.kid);
+            const verified = jwt.verify(token, signing_key, {
+                issuer: this.issuer,
+                algorithms: ['RS256']
+            });
+            return verified;
+        } catch (err) {
+            dbg.error('KeyCloak token verification failed:', err);
+            throw err;
+        }
+    }
+
+    /**
+     * Introspect token with OIDC provider (Keycloak)
+     * This is the key method for Keycloak integration - validates token with the authorization server
+     * @param {string} token - The access token to introspect
+     * @returns {Promise<Object>} - Introspection response with token details
+     */
+    async introspect_token(token) {
+        // TODO: Implement introspect_token method buy calling the OIDC provider's introspect endpoint or one that validate token
+        // http://${KC_SERVER}/realms/${KC_REALM}/protocol/openid-connect/token/introspect or anyother endpoint
+        // Dummy value
+        const introspection_result = {
+            sub: "0692a620-de3c-4002-9e50-e317dccfc53d",
+            aud: "noobaa-client",
+            iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
+            email: "test@email.com",
+            name: "test",
+            client_id: "noobaa-client",
+        };
+        return introspection_result;
+    }
+
+    /**
+     * Discover KeyCloak configuration from well-known endpoint
+     * @param {string} issuer_url - The access token to introspect
+     * @returns {Promise<Object>} - .well-known OIDC provider configuration object
+     */
+    static async discover(issuer_url) {
+        const well_known_url = new URL('.well-known/openid-configuration', issuer_url);
+        try {
+            const response = await make_https_request(
+                {
+                    method: 'GET',
+                    hostname: well_known_url.hostname,
+                    port: well_known_url.port || '443',
+                    path: well_known_url.pathname,
+                    rejectUnauthorized: true
+                },
+                null,
+                'utf8'
+            );
+            if (response && response.statusCode === 200) {
+                const buffer = await read_stream_join(response);
+                return JSON.parse(buffer.toString('utf8'));
+            } else {
+                throw new Error(`KeyCloak discovery failed: ${well_known_url} returned ${response?.statusCode}`);
+            }
+        } catch (err) {
+            dbg.error('KeyCloak discovery failed:', err);
+            throw err;
+        }
+    }
+}
+
+/**
+ * Extract AWS session tags from KeyCloak token
+ * Session tags can be used for attribute-based access control (ABAC)
+ * @param {string} token - The access token to get the session tags from
+ * @returns {Object} - Session tags object
+ */
+function extract_session_tags(token) {
+    // TODO: validate tags against the policy
+    const aws_tags_claim = 'https://aws.amazon.com/tags';
+    if (token[aws_tags_claim] && token[aws_tags_claim].principal_tags) {
+        return token[aws_tags_claim].principal_tags;
+    }
+    return {};
+}
+
+exports.KeyCloakProvider = KeyCloakProvider;
+exports.extract_session_tags = extract_session_tags;


### PR DESCRIPTION
### Describe the Problem
 Initial commit for Support Keycloak with MCG client STS
Its create a skelton for the KeyCloak integration with nessesary files and design

### Explain the Changes
1. Refactor assume_role_with_web_identity method to include both LDAP and KeyCloak
2. KeyCloak configuration mounted in endpoint pod
3. Create KeyCloak clinet and providers using KeyCloak configuration from mounted path
4. Verify KeyCloak access token inside noobaa endpoint
5. Return temporary access tokens and session token

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-8075

### Testing Instructions:
1. Will do later with mode 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keycloak/OIDC-based authentication for STS web-identity role assumption
  * Support for multiple OIDC providers with auto-discovery and runtime config reload
  * Session tags from OIDC tokens are extracted and included in generated credentials
  * Source identity now uses email/sub when available, not just DN
* **Chores**
  * Added JWKS handling dependency for OIDC token verification
* **Behavior**
  * Falls back to existing LDAP flow when no matching OIDC provider is configured
<!-- end of auto-generated comment: release notes by coderabbit.ai -->