### PR TITLE
Wait for async operations to complete in db_cleaner

### DIFF
--- a/src/server/bg_services/db_cleaner.js
+++ b/src/server/bg_services/db_cleaner.js
@@ -67,13 +67,25 @@ async function clean_md_store(last_date_to_remove) {
         await P.map_with_concurrency(10, objects_to_remove, obj => db_delete_object_parts(obj));
         await MDStore.instance().db_delete_objects(objects_to_remove);
     }
-    const blocks_to_remove = await MDStore.instance().find_deleted_blocks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
+    let blocks_to_remove = await MDStore.instance().find_deleted_blocks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
+    blocks_to_remove = blocks_to_remove.filter(block => {
+        const reclaimed = Boolean(block?.data?.reclaimed);
+        if (!reclaimed) {
+            dbg.warn("DB_CLEANER: found block which is not reclaimed yet, ", JSON.stringify(block?.data));
+        }
+        return reclaimed;
+    });
+    blocks_to_remove = db_client.instance().uniq_ids(blocks_to_remove, '_id');
     dbg.log2('DB_CLEANER: list blocks:', blocks_to_remove);
     if (blocks_to_remove.length) await MDStore.instance().db_delete_blocks(blocks_to_remove);
     const chunks_to_remove = await MDStore.instance().find_deleted_chunks(last_date_to_remove, config.DB_CLEANER_DOCS_LIMIT);
-    const filtered_chunks = chunks_to_remove.filter(async chunk =>
-        !(await MDStore.instance().has_any_blocks_for_chunk(chunk)) &&
-        !(await MDStore.instance().has_any_parts_for_chunk(chunk)));
+    const filtered_chunks = (
+        await Promise.all(chunks_to_remove.map(async chunk => {
+            const has_blocks_or_parts = await MDStore.instance().has_any_blocks_or_parts_for_chunk(chunk);
+            return has_blocks_or_parts ? null : chunk;
+        }))
+    ).filter(Boolean);
+
     dbg.log2('DB_CLEANER: list chunks with no blocks and no parts to be removed from DB', filtered_chunks);
     if (filtered_chunks.length) await MDStore.instance().db_delete_chunks(filtered_chunks);
     dbg.log0(`DB_CLEANER: removed ${objects_to_remove.length + blocks_to_remove.length + filtered_chunks.length} documents from md-store`);
@@ -157,10 +169,25 @@ async function clean_system_store(last_date_to_remove) {
     dbg.log2('DB_CLEANER: list vector_buckets:', vector_buckets);
     dbg.log2('DB_CLEANER: list vector_indices:', vector_indices);
     dbg.log2('DB_CLEANER: list pools:', pools);
-    const filtered_buckets = buckets.filter(async bucket =>
-        !(await MDStore.instance().has_any_objects_for_bucket_including_deleted(bucket)));
-    const filtered_pools = pools.filter(async pool =>
-        !(await nodes_store.has_any_nodes_for_pool(pool)));
+    const filtered_buckets = (
+        await Promise.all(
+            buckets.map(async bucket => {
+                const hasObjects =
+                    await MDStore.instance().has_any_objects_for_bucket_including_deleted(bucket);
+                return hasObjects ? null : bucket;
+            })
+        )
+    ).filter(Boolean);
+
+    const filtered_pools = (
+        await Promise.all(
+            pools.map(async pool => {
+                const hasNodes = await nodes_store.has_any_nodes_for_pool(pool);
+                return hasNodes ? null : pool;
+            })
+        )
+    ).filter(Boolean);
+
     if (accounts.length || filtered_buckets.length || filtered_pools.length || vector_buckets.length || vector_indices.length) {
         await system_store.make_changes({
             db_delete: {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1959,6 +1959,20 @@ class MDStore {
             .then(obj => Boolean(obj));
     }
 
+    async has_any_blocks_or_parts_for_chunk(chunk_id) {
+        const query = `
+        SELECT
+            EXISTS (SELECT 1 FROM ${this._parts.name} WHERE data ? 'chunk' AND data->>'chunk' = $1)
+            OR
+            EXISTS (SELECT 1 FROM ${this._blocks.name} WHERE data ? 'chunk' AND data->>'chunk' = $2)
+        AS has_reference;
+        `;
+        const result = await db_client.instance().executeSQL(query, [chunk_id, chunk_id], {
+            preferred_pool: 'read_only',
+        });
+        return Boolean(result.rows[0]?.has_reference);
+    }
+
 
     has_any_parts_for_object(obj) {
         return this._parts.findOne({
@@ -2320,7 +2334,7 @@ class MDStore {
 
     async find_deleted_blocks(max_delete_time, limit) {
         const query_limit = limit || 1000;
-        const query = `SELECT _id
+        const query = `SELECT *
             FROM ${this._blocks.name}
             WHERE to_ts(data->>'deleted') < to_ts($1)
               AND data ? 'deleted'
@@ -2328,7 +2342,7 @@ class MDStore {
         const result = await db_client.instance().executeSQL(query, [new Date(max_delete_time).toISOString()], {
             preferred_pool: 'read_only',
         });
-        return db_client.instance().uniq_ids(result.rows, '_id');
+        return result.rows;
     }
 
     db_delete_blocks(block_ids) {


### PR DESCRIPTION
### Describe the Problem
In db_cleaner, we have multiple instances where `filter` function is used with an `async` callback but we don't wait for the promise to resolve. The callbacks return a promise which is always a `true` for `filter`. The resultant array is invalid as the conditions were never checked.

To test this scenario,  update datachunks with `deleted` timestamp. db_cleaner still deletes the chunks with entries in objectparts table for it.

Initial state:
```text
nbcore=# SELECT COUNT(*)
            FROM datachunks d 
            where data->'deleted' is NULL;
 count 
-------
 12800
(1 row)
```

Datachunk with its corresponding objectpart:
```text
nbcore=# select _id from datachunks d where _id='6a0aa1d0846bb90022557f6a';
           _id            
--------------------------
 6a0aa1d0846bb90022557f6a
(1 row)

nbcore=#   select * from objectparts o where data->>'chunk'='6a0aa1d0846bb90022557f6a';
           _id            |                                                                                                                   data                         
                                                                                           
--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------
 6a0aa1d0846bb90022557f6b | {"_id": "6a0aa1d0846bb90022557f6b", "end": 133169152, "obj": "6a0aa1d0846bb90022557b67", "seq": 126, "chunk": "6a0aa1d0846bb90022557f6a", "star
t": 132120576, "bucket": "6a060c82868e31002276144d", "system": "6a060c82868e310022761445"}
```

Final state after db_cleaner runs:
```text
nbcore=# SELECT COUNT(*)
            FROM datachunks d 
            where data->'deleted' is not NULL;
 count 
-------
     0
(1 row)
```

db_cleaner log for each cycle:
`May-15 7:23:02.372 [BGWorkers/1042]    [L0] core.server.bg_services.db_cleaner:: DB_CLEANER: removed 1000 documents from md-store`

### Explain the Changes
1. Refactor the code for datachunks, pools and buckets to wait for the promise to resolve, so that the conditional expressions can be evaluated.
2. Use a single DB query for checking whether blocks or parts are present for a chunk. This removes an extra round trip for additional DB call.
3. Skip deleting block records whose blocks are unreclaimed even after they have expired and log such blocks.

db_cleaner only removes chunks which don't have reference:
<img width="1176" height="40" alt="image" src="https://github.com/user-attachments/assets/736173a5-bb0e-4049-85f9-565c1f43991d" />


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background database cleanup to more reliably identify blocks/chunks and buckets/pools that are safe to remove.
  * Added a more accurate eligibility check to ensure candidates still have no remaining block/part references before deletion.
* **Refactor**
  * Updated cleanup selection to compute deletion candidates up front and avoid async predicate patterns.
  * De-duplicated deletion targets prior to applying database changes, reducing unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->