### PR TITLE
Fix replication_target_status metrics reset and stale series cleanup

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -705,15 +705,22 @@ class NooBaaCoreReport extends BasePrometheusReport {
         this._metrics.bucket_last_cycle_error_objects_num.set({ bucket_name }, repl_info.bucket_last_cycle_error_objects_num);
     }
 
-    reset_replication_target_status() {
-        if (!this._metrics) return;
-        this._metrics.replication_target_status.reset();
-    }
-
     set_replication_target_status(replication_id, source_bucket, target_bucket, is_reachable) {
         if (!this._metrics) return;
         this._metrics.replication_target_status.set({ replication_id, source_bucket, target_bucket }, Number(is_reachable));
     }
+
+    clear_replication_target_status_by_replication_id(replication_id) {
+        const gauge_hash_map = this._metrics?.replication_target_status?.hashMap;
+        if (!gauge_hash_map) return;
+
+        const id = String(replication_id);
+        for (const key of Object.keys(gauge_hash_map)) {
+            const entry = gauge_hash_map[key];
+            if (entry?.labels?.replication_id === id) delete gauge_hash_map[key];
+        }
+    }
+
 }
 
 exports.NooBaaCoreReport = NooBaaCoreReport;

--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -74,6 +74,7 @@ class LogReplicationScanner {
                 const { src_bucket, dst_bucket } = replication_utils.find_src_and_dst_buckets(rule.destination_bucket, replication_id);
                 if (!src_bucket) {
                     dbg.error('log_replication_scanner: src_bucket not found for replication_id:', replication_id);
+                    replication_utils.clear_replication_target_status_for_orphan_policy(replication_id);
                     return;
                 }
 
@@ -210,7 +211,6 @@ class LogReplicationScanner {
             // target bucket is reachable
             replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
-            // target bucket is unreachable
             dbg.error('log_replication_scanner: failed to get buckets diff, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
             replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);
@@ -229,7 +229,6 @@ class LogReplicationScanner {
             // target bucket is reachable
             replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
         } catch (err) {
-            // target bucket is unreachable
             dbg.error('log_replication_scanner: failed to head objects, target may be unreachable:',
                 src_bucket.name, dst_bucket.name, err);
             replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -60,8 +60,7 @@ class ReplicationScanner {
 
     async scan() {
         if (!this.noobaa_connection) throw new Error('noobaa endpoint connection is not started yet...');
-        // full reset of replication_target_status, then set reachability again for each policy for this scan cycle
-        replication_utils.reset_replication_target_status();
+        await replication_utils.reconcile_replication_target_status();
         // find rule for each replication policy that was not updated for the longest period
         const least_recently_replicated_rules = await replication_store.find_rules_updated_longest_time_ago();
 
@@ -72,12 +71,22 @@ class ReplicationScanner {
             const { src_bucket, dst_bucket } = replication_utils.find_src_and_dst_buckets(rule.destination_bucket, replication_id);
             if (!src_bucket || !dst_bucket) {
                 dbg.error('replication_scanner: can not find src_bucket or dst_bucket object', src_bucket, dst_bucket);
-                // mark target bucket as unreachable (resolve display name from id while bucket row still exists)
-                if (src_bucket && !dst_bucket) {
+                if (!src_bucket) {
+                    replication_utils.clear_replication_target_status_for_orphan_policy(replication_id);
+                    return;
+                }
+                if (!dst_bucket) {
                     const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
                     replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket_name, false);
                     replication_utils.report_failed_replication_cycle(src_bucket.name, replication_id,
                         rule.rule_id, _.get(src_bucket, 'storage_stats.objects_count', 0));
+                    // advance last_cycle_end for rule rotation; keep cont tokens so replication resumes where it left off
+                    await replication_store.update_replication_status_by_id(replication_id, rule.rule_id, {
+                        ...status,
+                        last_cycle_end: Date.now(),
+                        src_cont_token: (rule.rule_status && rule.rule_status.src_cont_token) || '',
+                        dst_cont_token: (rule.rule_status && rule.rule_status.dst_cont_token) || '',
+                    });
                 }
                 return;
             }
@@ -112,10 +121,8 @@ class ReplicationScanner {
                 src_cont_token = buckets_diff_result.first_bucket_cont_token;
                 dst_cont_token = buckets_diff_result.second_bucket_cont_token;
 
-                // target bucket is reachable
                 replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, true);
             } catch (err) {
-                // target bucket is unreachable
                 dbg.error('replication_scanner: failed to get buckets diff, target may be unreachable:',
                     src_bucket.name, dst_bucket.name, err);
                 replication_utils.update_replication_target_status(replication_id, src_bucket.name, dst_bucket.name, false);

--- a/src/server/system_services/replication_store.js
+++ b/src/server/system_services/replication_store.js
@@ -59,6 +59,10 @@ class ReplicationStore {
         return repl;
     }
 
+    async get_all_replication_configs() {
+        return this._replicationconfigs.find({});
+    }
+
     async find_deleted_rules(last_date_to_remove, limit) {
         const repl = this._replicationconfigs.find({
             deleted: {

--- a/src/server/utils/replication_utils.js
+++ b/src/server/utils/replication_utils.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const dbg = require('../../util/debug_module')(__filename);
 const SensitiveString = require('../../util/sensitive_string');
 const system_store = require('../system_services/system_store').get_instance();
+const replication_store = require('../system_services/replication_store').instance();
 const prom_reporting = require('../analytic_services/prometheus_reporting');
 const auth_server = require('../common_services/auth_server');
 
@@ -106,17 +107,70 @@ function report_failed_replication_cycle(bucket_name, replication_id, rule_id, t
         'replication_id:', replication_id, 'rule_id:', rule_id, 'total:', total);
 }
 
-function reset_replication_target_status() {
-    const core_report = prom_reporting.get_core_report();
-    core_report.reset_replication_target_status();
-}
-
 function update_replication_target_status(replication_id, source_bucket, target_bucket, is_reachable) {
     if (!replication_id) return;
     const core_report = prom_reporting.get_core_report();
     const src_name = source_bucket instanceof SensitiveString ? source_bucket.unwrap() : source_bucket;
     const dst_name = target_bucket instanceof SensitiveString ? target_bucket.unwrap() : target_bucket;
-    core_report.set_replication_target_status(replication_id, src_name, dst_name, is_reachable);
+    core_report.set_replication_target_status(String(replication_id), src_name, dst_name, is_reachable);
+}
+
+// clear target reachability metrics when the policy was deleted or has no source bucket (leftover series)
+// orphan policy: replication_id not in replication DB, or no source bucket references it
+function clear_replication_target_status_for_orphan_policy(replication_id) {
+    if (!replication_id) return;
+    const core_report = prom_reporting.get_core_report();
+    core_report.clear_replication_target_status_by_replication_id(String(replication_id));
+}
+
+// reconcile_replication_target_status reconciles target reachability metrics at replication scan start
+// drop stale replication_target_status series: one DB read, then clear gauge entries that no longer match active policies
+async function reconcile_replication_target_status() {
+    const hash_map = prom_reporting.get_core_report()._metrics?.replication_target_status?.hashMap;
+    if (!hash_map) return;
+
+    const keys = Object.keys(hash_map);
+    if (!keys.some(k => hash_map[k]?.labels?.replication_id)) return;
+
+    const replications = await replication_store.get_all_replication_configs();
+    if (!replications?.length) return;
+
+    const valid_label_keys = new Set();
+    const clear_all_ids = new Set();
+
+    // build allowed (replication_id|source|target) valid keys from DB and mark policies with no source for full clear
+    for (const repl of replications) {
+        const repl_id = String(repl._id);
+        if (repl.deleted) {
+            clear_all_ids.add(repl_id);
+            continue;
+        }
+        const rules = repl.rules;
+        if (!rules?.length) {
+            clear_all_ids.add(repl_id);
+            continue;
+        }
+        const { src_bucket } = find_src_and_dst_buckets(rules[0].destination_bucket, repl_id);
+        if (!src_bucket) {
+            clear_all_ids.add(repl_id);
+            continue;
+        }
+        const src_name = bucket_name_for_metrics(src_bucket);
+        // one valid series per rule destination for this policy
+        for (const rule of rules) {
+            const dst_name = await resolve_destination_bucket_name(rule.destination_bucket);
+            valid_label_keys.add(`${repl_id}|${src_name}|${dst_name}`);
+        }
+    }
+
+    // remove gauge samples that are orphaned, policy-less, or no longer match DB labels
+    for (const key of keys) {
+        const labels = hash_map[key]?.labels;
+        if (!labels?.replication_id) continue;
+        const repl_id = String(labels.replication_id);
+        const label_key = `${repl_id}|${labels.source_bucket}|${labels.target_bucket}`;
+        if (clear_all_ids.has(repl_id) || !valid_label_keys.has(label_key)) delete hash_map[key];
+    }
 }
 
 // remove the `-deleting-<timestamp>` suffix noobaa appends while a bucket is being deleted
@@ -265,8 +319,9 @@ async function delete_objects(scanner_semaphore, client, bucket_name, keys) {
 exports.get_rule_and_bucket_status = get_rule_and_bucket_status;
 exports.update_replication_prom_report = update_replication_prom_report;
 exports.report_failed_replication_cycle = report_failed_replication_cycle;
-exports.reset_replication_target_status = reset_replication_target_status;
 exports.update_replication_target_status = update_replication_target_status;
+exports.reconcile_replication_target_status = reconcile_replication_target_status;
+exports.clear_replication_target_status_for_orphan_policy = clear_replication_target_status_for_orphan_policy;
 exports.resolve_destination_bucket_name = resolve_destination_bucket_name;
 exports.get_object_md = get_object_md;
 exports.find_src_and_dst_buckets = find_src_and_dst_buckets;

--- a/src/test/unit_tests/internal/test_replication_metrics.test.js
+++ b/src/test/unit_tests/internal/test_replication_metrics.test.js
@@ -1,0 +1,199 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+jest.mock('../../../../config', () => ({
+    PROMETHEUS_ENABLED: true,
+    PROMETHEUS_PREFIX: 'NooBaa_',
+}));
+jest.mock('../../../util/debug_module', () => () => ({
+    set_module_level: () => undefined,
+    log0: () => undefined,
+    log1: () => undefined,
+    log2: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+}));
+
+const SensitiveString = require('../../../util/sensitive_string');
+const { NooBaaCoreReport } = require('../../../server/analytic_services/prometheus_reports/noobaa_core_report');
+
+const mock_get_all_replication_configs = jest.fn();
+jest.mock('../../../server/system_services/replication_store', () => ({
+    instance: () => ({ get_all_replication_configs: mock_get_all_replication_configs }),
+}));
+
+const mock_store = { buckets: [], deleted: new Map(),
+    get_by_id(id) { return this.buckets.find(doc => String(doc._id) === String(id)); },
+    get_by_id_include_deleted(id, col) {
+        if (col !== 'buckets') return null;
+        const live = this.get_by_id(id);
+        if (live) return { record: live };
+        const d = this.deleted.get(String(id));
+        return d ? { record: d } : null;
+    },
+};
+jest.mock('../../../server/system_services/system_store', () => ({ get_instance: () => ({ data: mock_store }) }));
+
+const mock_core = jest.fn();
+jest.mock('../../../server/analytic_services/prometheus_reporting', () => ({ get_core_report: () => mock_core() }));
+
+const u = require('../../../server/utils/replication_utils');
+const DST = 'dst-a'; const R1 = 'repl-1'; const R2 = 'repl-2'; const
+SRC = 'src-bucket';
+const b = ({ _id, name, replication_policy_id, deleting }) => ({
+    _id: String(_id), name: new SensitiveString(name), replication_policy_id, deleting,
+});
+
+let report;
+const g = () => report._metrics.replication_target_status;
+const reset = () => { const h = g()?.hashMap; g()?.reset?.(); Object.keys(h || {}).forEach(k => delete h[k]); };
+const tgts = r => Object.values(g().hashMap).filter(e => e.labels?.replication_id === String(r)).map(e => e.labels.target_bucket);
+const probe = (r, s, d, ok = true) => u.update_replication_target_status(r, s, d, ok);
+const reconcile = () => u.reconcile_replication_target_status();
+
+const seed = (rid, dsts, o = {}) => {
+    const rules = dsts.map((n, i) => ({ rule_id: `r${i}`, destination_bucket: `dst-id-${n}` }));
+    mock_store.buckets = [
+        b({ _id: 'src-id', name: SRC, replication_policy_id: rid, deleting: o.del_src && new Date() }),
+        ...dsts.map(n => b({ _id: `dst-id-${n}`, name: o.del_dst === n ? `${n}-deleting-9` : n, deleting: o.del_dst === n && new Date() })),
+    ];
+    mock_get_all_replication_configs.mockResolvedValue([{ _id: rid, rules }]);
+};
+
+describe('NooBaa_replication_target_status', () => {
+    beforeAll(() => { report = new NooBaaCoreReport(); mock_core.mockReturnValue(report); });
+    beforeEach(() => {
+        reset();
+        mock_store.buckets = [];
+        mock_store.deleted.clear();
+        mock_store.get_by_id = id => mock_store.buckets.find(doc => String(doc._id) === String(id));
+        mock_get_all_replication_configs.mockReset();
+        mock_core.mockReturnValue(report);
+    });
+
+    it.each([
+        [
+            'clears leftover reachability metrics when replication_id is not in replication DB',
+            () => mock_get_all_replication_configs.mockResolvedValue([{
+                _id: R2,
+                rules: [{ rule_id: 'r0', destination_bucket: 'dst-id-a' }],
+            }]),
+            [],
+        ],
+        [
+            'removes all metrics when no source bucket references replication_id (source bucket removed)',
+            () => {
+                mock_get_all_replication_configs.mockResolvedValue([{ _id: R1, rules: [{ rule_id: 'r0', destination_bucket: 'dst-id-a' }] }]);
+                mock_store.buckets = [b({ _id: 'dst-id-a', name: DST })];
+            },
+            [],
+        ],
+        [
+            'keeps reachability metrics when deleting destination name strips to label already on the gauge',
+            () => seed(R1, [DST], { del_dst: DST }),
+            [DST],
+        ],
+    ])('reconcile at scan start: %s', async (_desc, setup, want) => {
+        probe(R1, SRC, DST);
+        setup();
+        await reconcile();
+        expect(tgts(R1)).toEqual(want);
+    });
+
+    it('reconcile clears reachability metrics for soft-deleted replication policies', async () => {
+        probe(R1, SRC, DST);
+        mock_get_all_replication_configs.mockResolvedValue([{
+            _id: R1,
+            rules: [{ rule_id: 'r0', destination_bucket: 'dst-id-a' }],
+            deleted: new Date(),
+        }]);
+        await reconcile();
+        expect(tgts(R1)).toEqual([]);
+    });
+
+    it('reconcile removes leftover reachability metrics when source/destination labels no longer match replication DB', async () => {
+        probe(R1, SRC, DST);
+        probe(R1, SRC, 'dst-b');
+        probe(R1, SRC, 'stale');
+        g().hashMap.bad = { labels: null, value: 0 };
+        seed(R1, [DST, 'dst-b']);
+        await reconcile();
+        expect(tgts(R1).sort()).toEqual([DST, 'dst-b'].sort());
+        expect(g().hashMap.bad).toBeDefined();
+    });
+
+    it('clear_replication_target_status_for_orphan_policy clears one policy only; missing replication_id is ignored', () => {
+        u.update_replication_target_status(undefined, SRC, DST, true);
+        expect(Object.keys(g().hashMap)).toHaveLength(0);
+        probe(R1, SRC, DST);
+        probe(R2, SRC, DST);
+        u.clear_replication_target_status_for_orphan_policy(undefined);
+        u.clear_replication_target_status_for_orphan_policy(R1);
+        expect(tgts(R1)).toHaveLength(0);
+        expect(tgts(R2)).toHaveLength(1);
+    });
+
+    it.each([
+        ['sets gauge to 1 when replication scanner bucket diff succeeds (target reachable)', true, 1],
+        ['sets gauge to 0 when replication scanner bucket diff fails (target unreachable)', false, 0],
+    ])('%s', (_desc, ok, want) => {
+        probe(R1, SRC, DST, ok);
+        expect(Object.values(g().hashMap).find(e => e.labels?.target_bucket === DST)?.value).toBe(want);
+    });
+
+    it.each([
+        [
+            'does not query replication DB when prometheus gauge is not initialized',
+            () => mock_core.mockReturnValueOnce({ _metrics: null }),
+        ],
+        [
+            'does not query replication DB when gauge has no series with replication_id labels',
+            () => { g().hashMap.bad = { labels: null, value: 0 }; },
+        ],
+    ])('reconcile early exit: %s', async (_desc, prep) => {
+        prep();
+        await reconcile();
+        expect(mock_get_all_replication_configs).not.toHaveBeenCalled();
+    });
+
+    it('NooBaaCoreReport set and clear do nothing when _metrics is null (prometheus disabled)', () => {
+        const m = report._metrics;
+        report._metrics = null;
+        report.set_replication_target_status(R1, SRC, DST, 1);
+        report.clear_replication_target_status_by_replication_id(R1);
+        report._metrics = m;
+        expect(Object.keys(g().hashMap)).toHaveLength(0);
+    });
+
+    it.each([
+        [
+            'returns bucket name via get_by_id_include_deleted DB has no bucket row, but soft-deleted row exists',
+            () => mock_store.deleted.set('d', b({ _id: 'd', name: DST, deleting: new Date() })),
+            'd',
+            DST,
+        ],
+        [
+            'falls back to bucket id when DB has no bucket row (including soft-deleted row)',
+            () => undefined,
+            'gone',
+            'gone',
+        ],
+        [
+            'falls back to bucket id when system_store lookup throws error',
+            () => { mock_store.get_by_id = () => { throw new Error('db'); }; },
+            'err',
+            'err',
+        ],
+        [
+            'strips -deleting-<timestamp> suffix from bucket name while bucket is deleting',
+            () => { mock_store.buckets = [b({ _id: 'd', name: `${DST}-deleting-9`, deleting: new Date() })]; },
+            'd',
+            DST,
+        ],
+    ])('resolve_destination_bucket_name: %s', async (_desc, prep, id, want) => {
+        prep();
+        await expect(u.resolve_destination_bucket_name(id)).resolves.toBe(want);
+    });
+});


### PR DESCRIPTION
### Describe the Problem
Each scan called `reset()` on replication_target_status but only republished one rule per policy, so multi-rule policies lost metric series every cycle (flapping/absent alerts). Stale series also remained after policy delete or rule changes.

### Explain the Changes
1. Removed per-scan `reset()`
2. bg_workers only — reachability is set to 0/1 per (replication_id, source, target) after each scan; web clears do not affect scraped metrics.
3. Reconcile at scan start — drops stale series for deleted policies, missing source, or outdated rules/labels (no full gauge reset).
4. Helpers — `set_replication_target_status` and `clear_replication_target_status_by_replication_id` in noobaa_core_report, used via replication_utils (update, clear_orphan, reconcile).

### Issues: Fixed #xxx / Gap #xxx
1. Fixed: https://redhat.atlassian.net/browse/DFBUGS-6398
2. Gap: #9593 

### Testing Instructions:
1.  To run unit tests: `npx jest src/test/unit_tests/internal/test_replication_metrics.test.js`

Manual testing steps:
1. Create 4 destination/target buckets obcs dst-n,dst-s,dst-w and dst-e.
2. Create two policies policy1.json and policy2.json, and put two buckets in each replication policy.

> $ cat policy.json 
{
  "rules": [
    {
      "rule_id": "rule-1",
      "destination_bucket": "<dst-n-name>"
    },
    {
      "rule_id": "rule-2",
      "destination_bucket": "<dst-s-name>"
    }
  ]
}


3. Create two src buckets obcs src-ns and src-we by using above policies.
4. Verify if replication is working fine, and also check the replication_target_status metrics using below commands (It should contain 4 metrics for each replication rule_id having reachable state).                                                                          
`$ JWT_TOKEN=$(kubectl get secret/noobaa-metrics-auth-secret -o jsonpath={.data.metrics_token} | base64 -d)`
`$ kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/bg_workers | grep replication_target_status`
5. Try deleting 1 destination bucket, and check the metrics (it will take time to update as replication cycle execute one rule in every `5 min~can_be_changed` by default) --> for that particular src and dst bucket flag should be unreachable/0
6. Now, try deleting replication on src bucket or delete the any of the source bucket, and check the metrics --> all the rows should be removed container that replication_id or src bucket
7. You can try different combinations and check if the metrics are reflecting correct values.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of replication target status for orphaned policies when source buckets are missing.
  * More accurate reachability updates and failure reporting during replication scans.
  * Metric operations now safely no-op when metrics are unavailable.

* **Refactor**
  * Replaced bulk-reset with a targeted reconciliation flow that prunes stale replication metrics and validates against current policies.

* **Tests**
  * Added unit tests covering reconciliation, cleanup, deleted/dangling buckets, and edge cases in metric handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->