### PR TITLE
capped noobaa-bucket-size-quota to 100

### DIFF
--- a/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
+++ b/src/server/analytic_services/prometheus_reports/noobaa_core_report.js
@@ -610,7 +610,7 @@ class NooBaaCoreReport extends BasePrometheusReport {
                 this._metrics.bucket_tagging.set({ ...bucket_tagging_labels, tagging }, Date.now());
             }
             this._metrics.bucket_status.set(bucket_labels, Number(bucket_info.is_healthy));
-            this._metrics.bucket_size_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_size_percent);
+            this._metrics.bucket_size_quota.set({ bucket_name: bucket_info.bucket_name }, Math.min(100, bucket_info.quota_size_percent));
             this._metrics.bucket_quantity_quota.set({ bucket_name: bucket_info.bucket_name }, bucket_info.quota_quantity_percent);
             this._metrics.bucket_capacity.set({ bucket_name: bucket_info.bucket_name }, bucket_info.capacity_percent);
             this._metrics.bucket_used_bytes.set({ bucket_name: bucket_info.bucket_name }, bucket_info.bucket_used_bytes);


### PR DESCRIPTION
### Describe the Problem
Prometheus gauges NooBaa_bucket_size_quota  can exceed 100 when a bucket's usage surpasses its quota limit. This causes misleading metric values (e.g. 109%) in dashboards .

### Explain the Changes
1. Cap NooBaa_bucket_size_quota  at 100 when setting the Prometheus gauge in set_bucket_status using Math.min(100, percent). Enforcement logic is unchanged.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-5264

### Testing Instructions:
1. Create a bucket with a size or quantity quota set.
2. Upload objects until usage exceeds the quota limit.
3. Run `kubectl exec -it noobaa-core-0 -- curl -k -H "Authorization: Bearer ${JWT_TOKEN}" http://localhost:8080/metrics/web_server | grep -E 'quota' | grep 'quota-bucket'` and confirm the exported value is capped at 100 even when actual usage is higher.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket size quota metric now caps at 100%, preventing analytics from reporting values above 100% and ensuring quota gauges display accurate, bounded percentages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->