### PR TITLE
add nc_corestest to test_sts

### DIFF
--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -8,6 +8,7 @@ const js_utils = require('../../util/js_utils');
 const http_utils = require('../../util/http_utils');
 const signature_utils = require('../../util/signature_utils');
 const system_store = require('../../server/system_services/system_store').get_instance();
+const { is_nc_environment } = require('../../nc/nc_utils');
 
 const STS_MAX_BODY_LEN = 4 * 1024 * 1024;
 
@@ -137,8 +138,8 @@ async function authorize_request_policy(req) {
     const method = _get_method_from_req(req);
     const cur_account_email = req.sts_sdk.requesting_account && req.sts_sdk.requesting_account.email.unwrap();
     // system owner by design can always assume role policy of any account
-    if ((cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) return;
-
+    // skip for NC environments since system owner is not applicable
+    if (!is_nc_environment() && (cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) return;
     const permission = has_assume_role_permission(assume_role_policy, method, cur_account_email);
     dbg.log0('sts_rest.authorize_request_policy permission is: ', permission);
     if (permission === 'DENY' || permission === 'IMPLICIT_DENY') {
@@ -148,7 +149,8 @@ async function authorize_request_policy(req) {
 }
 
 function _get_system_owner() {
-    const system = system_store.data.systems[0];
+    const system = system_store.data && system_store.data.systems && system_store.data.systems[0];
+    if (!system) return null;
     return system.owner.email;
 }
 

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -582,6 +582,15 @@ function validate_role_config(user_input) {
             throw_cli_error(ManageCLIError.InvalidRoleConfig,
                 'each statement in assume_role_policy must have "effect", "action" (array) and "principal" (array)');
         }
+        if (statement.effect !== 'allow' && statement.effect !== 'deny') {
+            throw_cli_error(ManageCLIError.InvalidRoleConfig, 'effect must be "allow" or "deny"');
+        }
+        const valid_actions = ['*', 'sts:AssumeRole', 'sts:AssumeRoleWithWebIdentity', 'sts:AssumeRoleWithSAML', 'sts:*'];
+        for (const action of statement.action) {
+            if (!valid_actions.includes(action)) {
+                throw_cli_error(ManageCLIError.InvalidRoleConfig, 'Policy has invalid action');
+            }
+        }
     }
 }
 

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -2,10 +2,13 @@
 'use strict';
 
 // setup coretest first to prepare the env
-const coretest = require('../../../utils/coretest/coretest');
+const { require_coretest, is_nc_coretest } = require('../../../system_tests/test_utils');
+const coretest = require_coretest();
 coretest.setup();
 const AWS = require('aws-sdk');
 const https = require('https');
+const path = require('path');
+const fs = require('fs');
 const mocha = require('mocha');
 const assert = require('assert');
 const jwt = require('jsonwebtoken');
@@ -17,7 +20,6 @@ const jwt_utils = require('../../../../util/jwt_utils');
 const config = require('../../../../../config');
 const ldap_client = require('../../../../util/ldap_client');
 const { S3Error } = require('../../../../endpoint/s3/s3_errors');
-
 const defualt_expiry_seconds = Math.ceil(config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS / 1000);
 
 const errors = {
@@ -69,6 +71,13 @@ const errors = {
         rpc_code: 'MALFORMED_POLICY',
         message_principal: 'Invalid principal in policy',
         message_action: 'Policy has invalid action'
+    },
+    invalid_role_config: { // NC CLI error
+        rpc_code: 'InvalidRoleConfig',
+        message_invalid_effect: 'effect must be "allow" or "deny"',
+        message_role_name: 'role_config must have a non-empty string "role_name"',
+        message_assume_role_policy: 'role_config.assume_role_policy must have a non-empty "statement" array',
+        message_invalid_action: 'Policy has invalid action'
     }
 };
 
@@ -105,6 +114,13 @@ mocha.describe('STS tests', function() {
             s3DisableBodySigning: false,
         };
         const account = { has_login: false, s3_access: true };
+        if (is_nc_coretest) {
+            account.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: coretest.NC_CORETEST_STORAGE_PATH,
+            };
+        }
         admin_keys = (await rpc_client.account.read_account({ email: EMAIL })).access_keys;
         sts_admin = new AWS.STS({
             ...sts_creds,
@@ -113,15 +129,16 @@ mocha.describe('STS tests', function() {
         });
         account.name = user_a;
         account.email = user_a;
+        // In NC mode, the system owner bypass in sts_rest.js is skipped (no system_store).
+        // Add the admin email to the principal list so the admin can assume role b.
         const policy = {
             version: '2012-10-17',
             statement: [{
                 effect: 'allow',
-                principal: [user_c],
+                principal: is_nc_coretest ? [user_c, EMAIL] : [user_c],
                 action: ['sts:AssumeRole'],
             }]
         };
-
         const user_a_keys = (await rpc_client.account.create_account(account)).access_keys;
         account_info_a = await rpc_client.account.read_account({ email: user_a });
         const user_c_keys = (await rpc_client.account.create_account({ ...account, email: user_c, name: user_c })).access_keys;
@@ -141,7 +158,8 @@ mocha.describe('STS tests', function() {
             Version: '2012-10-17',
             Statement: [{
                 Effect: 'Allow',
-                Principal: { AWS: [`arn:aws:iam::${account_info_a._id.toString()}:root`, `arn:aws:iam::${account_info_b._id.toString()}:root`,
+                Principal: { AWS: is_nc_coretest ? [user_a, user_b, user_c] : [`arn:aws:iam::${account_info_a._id.toString()}:root`, // existing gap in config_fs.is_account_exists_by_principal for NC, adding all users to be consistent with non-NC mode
+                    `arn:aws:iam::${account_info_b._id.toString()}:root`,
                     `arn:aws:iam::${account_info_c._id.toString()}:root`] },
                 Action: ['s3:*'],
                 Resource: ['arn:aws:s3:::first.bucket/*', 'arn:aws:s3:::first.bucket'],
@@ -488,6 +506,13 @@ mocha.describe('Session token tests', function() {
             s3DisableBodySigning: false,
         };
         const account_defaults = { has_login: false, s3_access: true };
+        if (is_nc_coretest) {
+            account_defaults.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: coretest.NC_CORETEST_STORAGE_PATH,
+            };
+        }
 
         for (const account of accounts) {
             account.access_keys = (await rpc_client.account.create_account({
@@ -531,7 +556,7 @@ mocha.describe('Session token tests', function() {
             Version: '2012-10-17',
             Statement: [{
                 Effect: 'Allow',
-                Principal: { AWS: `arn:aws:iam::${account_info_alice._id.toString()}:root` },
+                Principal: { AWS: is_nc_coretest ? alice2 : `arn:aws:iam::${account_info_alice._id.toString()}:root` },
                 Action: ['s3:*'],
                 Resource: [
                     'arn:aws:s3:::first.bucket/*',
@@ -759,54 +784,57 @@ mocha.describe('Session token tests', function() {
             errors.invalid_token.code, errors.invalid_token.message);
     });
 
-    mocha.it('user b assume role of user a - expiry 0 - list s3 - should be rejected', async function() {
-        config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 0;
-        const user_a_key = accounts[0].access_keys[0].access_key.unwrap();
-        const params = {
-            RoleArn: `arn:aws:sts::${user_a_key}:role/${role_alice}`,
-            RoleSessionName: 'just_a_dummy_session_name'
-        };
+    // In NC mode the server (nsfs.js) is a separate process - hence expiry not set to 0,token never expires.  Skip these two tests.
+    if (!is_nc_coretest) {
+        mocha.it('user b assume role of user a - expiry 0 - list s3 - should be rejected', async function() {
+            config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 0;
+            const user_a_key = accounts[0].access_keys[0].access_key.unwrap();
+            const params = {
+                RoleArn: `arn:aws:sts::${user_a_key}:role/${role_alice}`,
+                RoleSessionName: 'just_a_dummy_session_name'
+            };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+            const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+                `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3_with_session_token = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token
+            const temp_s3_with_session_token = new AWS.S3({
+                ...sts_creds,
+                endpoint: coretest.get_https_address(),
+                accessKeyId: result_obj.access_key,
+                secretAccessKey: result_obj.secret_key,
+                sessionToken: result_obj.session_token
+            });
+
+            await assert_throws_async(temp_s3_with_session_token.listBuckets().promise(),
+                errors.expired_token_s3.code, errors.expired_token_s3.message);
         });
 
-        await assert_throws_async(temp_s3_with_session_token.listBuckets().promise(),
-            errors.expired_token_s3.code, errors.expired_token_s3.message);
-    });
+        mocha.it('user b assume role of user a - expiry 0 - assume role sts - should be rejected', async function() {
+            config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 0;
 
-    mocha.it('user b assume role of user a - expiry 0 - assume role sts - should be rejected', async function() {
-        config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = 0;
+            const user_a_key = accounts[0].access_keys[0].access_key.unwrap();
+            const params = {
+                RoleArn: `arn:aws:sts::${user_a_key}:role/${role_alice}`,
+                RoleSessionName: 'just_a_dummy_session_name'
+            };
 
-        const user_a_key = accounts[0].access_keys[0].access_key.unwrap();
-        const params = {
-            RoleArn: `arn:aws:sts::${user_a_key}:role/${role_alice}`,
-            RoleSessionName: 'just_a_dummy_session_name'
-        };
+            const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+                `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+            const temp_sts_with_session_token = new AWS.STS({
+                ...sts_creds,
+                endpoint: coretest.get_https_address_sts(),
+                accessKeyId: result_obj.access_key,
+                secretAccessKey: result_obj.secret_key,
+                sessionToken: result_obj.session_token
+            });
 
-        const temp_sts_with_session_token = new AWS.STS({
-            ...sts_creds,
-            endpoint: coretest.get_https_address_sts(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token
+            await assert_throws_async(temp_sts_with_session_token.assumeRole(params).promise(),
+                errors.expired_token.code, errors.expired_token.message);
         });
-
-        await assert_throws_async(temp_sts_with_session_token.assumeRole(params).promise(),
-            errors.expired_token.code, errors.expired_token.message);
-    });
+    }
 });
 
 
@@ -821,30 +849,45 @@ mocha.describe('Assume role policy tests', function() {
         }]
     };
     const account_defaults = { has_login: false, s3_access: true };
-
     mocha.it('create account with role policy - missing role_config', async function() {
+        if (is_nc_coretest) {
+            account_defaults.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: coretest.NC_CORETEST_STORAGE_PATH,
+            };
+        }
         const empty_role_config = {};
         const email = 'assume_email1';
+        const expected_error = is_nc_coretest ? errors.invalid_role_config.rpc_code : errors.invalid_schema_params.code;
+        const expected_error_message = is_nc_coretest ? errors.invalid_role_config.message_role_name : errors.invalid_schema_params.message;
         await assert_throws_async(rpc_client.account.create_account({
             ...account_defaults,
             email,
             name: email,
             role_config: empty_role_config
-        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+        }), expected_error, expected_error_message);
     });
 
     mocha.it('create account with role policy - missing assume role policy', async function() {
         const empty_assume_role_policy = { role_name: 'role_name2' };
         const email = 'assume_email2';
+
+        const expected_error = is_nc_coretest ? errors.invalid_role_config.rpc_code : errors.invalid_schema_params.code;
+        const expected_message = is_nc_coretest ?
+                                    errors.invalid_role_config.message_assume_role_policy :
+                                    errors.invalid_schema_params.message;
+
         await assert_throws_async(rpc_client.account.create_account({
             ...account_defaults,
             email,
             name: email,
             role_config: empty_assume_role_policy
-        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+        }), expected_error, expected_message);
     });
 
     mocha.it('create account with role policy- invalid principal', async function() {
+        if (is_nc_coretest) return; // NC mode does not support invalid principal in role policy
         const invalid_action = { principal: ['non_existing_email'] };
         const email = 'assume_email3';
         const assume_role_policy = {
@@ -875,6 +918,8 @@ mocha.describe('Assume role policy tests', function() {
                 ...invalid_action
             }]
         };
+        const expected_error = is_nc_coretest ? errors.invalid_role_config.rpc_code : errors.invalid_schema_params.code;
+        const expected_message = is_nc_coretest ? errors.invalid_role_config.message_invalid_effect : errors.invalid_schema_params.message;
         await assert_throws_async(rpc_client.account.create_account({
             ...account_defaults,
             email,
@@ -883,7 +928,7 @@ mocha.describe('Assume role policy tests', function() {
                 role_name: 'role_name3',
                 assume_role_policy
             }
-        }), errors.invalid_schema_params.code, errors.invalid_schema_params.message);
+        }), expected_error, expected_message);
     });
 
     mocha.it('create account with role policy - invalid action', async function() {
@@ -896,6 +941,10 @@ mocha.describe('Assume role policy tests', function() {
                 ...invalid_action
             }]
         };
+        const expected_error = is_nc_coretest ? errors.invalid_role_config.rpc_code : errors.malformed_policy.rpc_code;
+        const expected_message = is_nc_coretest ?
+                                    errors.invalid_role_config.message_invalid_action :
+                                    errors.malformed_policy.message_action;
         await assert_throws_async(rpc_client.account.create_account({
             ...account_defaults,
             email,
@@ -904,7 +953,7 @@ mocha.describe('Assume role policy tests', function() {
                 role_name: 'role_name3',
                 assume_role_policy
             }
-        }), errors.malformed_policy.rpc_code, errors.malformed_policy.message_action);
+        }), expected_error, expected_message);
     });
 });
 
@@ -928,9 +977,24 @@ mocha.describe('Assume role with web indentity tests', function() {
             signatureVersion: 'v4',
             s3DisableBodySigning: false,
         });
+        if (is_nc_coretest) {
+            // nsfs.js is a separate process — inject jwt_secret via the LDAP config file
+            // so the server's ldap_client picks it up via fs.watchFile reload.
+            await fs.promises.mkdir(path.dirname(config.LDAP_CONFIG_PATH), { recursive: true });
+            await fs.promises.writeFile(config.LDAP_CONFIG_PATH, JSON.stringify({ jwt_secret: "TEST_SECRET" }));
+        }
         ldap_client.instance().ldap_params = {
             jwt_secret: "TEST_SECRET"
         };
+    });
+
+    mocha.after(async function() {
+        if (is_nc_coretest) {
+            // Clean up the LDAP config file written in before()
+            await fs.promises.unlink(config.LDAP_CONFIG_PATH).catch(() => {
+                dbg.log1("Failed to unlink LDAP config file");
+            });
+        }
     });
 
     mocha.it('anonymous user a with bad jwt - should be rejected', async function() {

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -275,7 +275,7 @@ async function exec_manage_cli(type, action, options, is_silent, env) {
                 flags += `--user ${options[key]} `;
                 continue;
             }
-            if (key === 'bucket_policy') {
+            if (key === 'bucket_policy' || key === 'role_config') {
                 value = typeof options[key] === 'string' ? `'${options[key]}'` : `'${JSON.stringify(options[key])}'`;
             } else if (key === 'fs_backend' || key === 'ips') {
                 value = `'${options[key]}'`;

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -1,6 +1,14 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
+// dotenv should be loaded before config.js is loaded to set JWT_SECRET for nsfs.js
+process.env.DEBUG_MODE = 'true';
+// process.env.ACCOUNTS_CACHE_EXPIRY = '1'; In NC we check if the config file was changed as validation
+process.env.NC_CORETEST = 'true';
+
+require('../../../util/dotenv').load();
+require('../../../util/panic');
+require('../../../util/fips');
 const fs = require('fs');
 const p = require('path');
 const _ = require('lodash');
@@ -18,13 +26,6 @@ const NC_CORETEST = 'nc_coretest';
 const config_dir_name = 'nc_coretest_config_root_path';
 const master_key_location = `${TMP_PATH}/${config_dir_name}/master_keys.json`;
 const NC_CORETEST_CONFIG_DIR_PATH = `${TMP_PATH}/${config_dir_name}`;
-process.env.DEBUG_MODE = 'true';
-// process.env.ACCOUNTS_CACHE_EXPIRY = '1'; In NC we check if the config file was changed as validation
-process.env.NC_CORETEST = 'true';
-
-require('../../../util/dotenv').load();
-require('../../../util/panic');
-require('../../../util/fips');
 
 const config = require('../../../../config.js');
 config.test_mode = true;
@@ -51,10 +52,12 @@ const http_port = 6001;
 const https_port = 6443;
 const https_port_iam = 7005;
 const https_port_vectors = 7006;
+const https_port_sts = 7443;
 const http_address = `http://localhost:${http_port}`;
 const https_address = `https://localhost:${https_port}`;
 const https_address_iam = `https://localhost:${https_port_iam}`;
 const https_address_vectors = `https://localhost:${https_port_vectors}`;
+const https_address_sts = `https://localhost:${https_port_sts}`;
 
 const FIRST_BUCKET = 'first.bucket';
 const NC_CORETEST_STORAGE_PATH = p.join(TMP_PATH, 'nc_coretest_storage_root_path/');
@@ -307,6 +310,10 @@ function get_https_address_vectors() {
     return https_address_vectors;
 }
 
+function get_https_address_sts() {
+    return https_address_sts;
+}
+
 ///////////////////////////////////
 ///////// HELPER FUNCTIONS ////////
 ///////////////////////////////////
@@ -317,7 +324,8 @@ function get_https_address_vectors() {
  * manage_nsfs account commands identified by name  
  */
 const get_name_by_email = email => {
-    const name = email === NC_CORETEST ? NC_CORETEST : email.slice(0, email.indexOf('@'));
+    const email_name = email.includes('@') ? email.slice(0, email.indexOf('@')) : email;
+    const name = email_name === NC_CORETEST ? NC_CORETEST : email_name;
     return name;
 };
 
@@ -359,8 +367,25 @@ async function create_account_manage(options) {
         secret_key: options.secret_key,
         custom_bucket_path_allowed_list: options.nsfs_account_config.custom_bucket_path_allowed_list,
         allow_bypass_governance: options.nsfs_account_config.allow_bypass_governance,
+        role_config: options.role_config,
     };
-    const res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, cli_options);
+    let res;
+    try {
+        res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, cli_options);
+    } catch (err) {
+        // format the error to be like the rpc error
+        try {
+            const json_err = JSON.parse(err.stdout || '');
+            if (json_err && json_err.error) {
+                const rpc_err = new Error(json_err.error.detail || json_err.error.message);
+                rpc_err.rpc_code = json_err.error.code;
+                throw rpc_err;
+            }
+        } catch (parse_err) {
+            if (parse_err.rpc_code) throw parse_err;
+        }
+        throw err;
+    }
     const json_account = JSON.parse(res);
     const account = json_account.response.reply;
     if (account.access_keys.length > 0) {
@@ -461,6 +486,21 @@ async function update_account_s3_access_manage(options) {
     await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, cli_options);
 }
 
+/**
+ * update_account_manage updates an account using manage_nsfs
+ * currently handles role_config updates needed for STS tests
+ * @param {object} options
+ * @returns {Promise<void>}
+ */
+async function update_account_manage(options) {
+    const cli_options = { name: get_name_by_email(options.email) };
+    if (options.role_config !== undefined) {
+        cli_options.role_config = options.role_config;
+    }
+    await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.UPDATE, cli_options);
+}
+
+
 ////////////////////////////////////
 ///// NAMESPACE RESOURCE MOCKS /////
 ////////////////////////////////////
@@ -548,7 +588,8 @@ const rpc_cli_funcs_to_manage_nsfs_cli_cmds = {
         delete_account: async options => delete_account_manage(options),
         delete_account_by_property: async options => delete_account_by_property_manage(options),
         list_accounts: async options => list_accounts_manage(options),
-        update_account_s3_access: async options => update_account_s3_access_manage(options)
+        update_account_s3_access: async options => update_account_s3_access_manage(options),
+        update_account: async options => update_account_manage(options)
     },
     pool: {
         read_namespace_resource: options => read_namespace_resource_mock(options),
@@ -582,3 +623,5 @@ exports.get_https_address_vectors = get_https_address_vectors;
 exports.get_admin_mock_account_details = get_admin_mock_account_details;
 exports.NC_CORETEST_CONFIG_DIR_PATH = NC_CORETEST_CONFIG_DIR_PATH;
 exports.NC_CORETEST_CONFIG_FS = NC_CORETEST_CONFIG_FS;
+exports.get_https_address_sts = get_https_address_sts;
+exports.NC_CORETEST_STORAGE_PATH = NC_CORETEST_STORAGE_PATH;

--- a/src/test/utils/index/nc_index.js
+++ b/src/test/utils/index/nc_index.js
@@ -25,6 +25,7 @@ require('../../integration_tests/api/s3/test_public_access_block');
 require('../../integration_tests/nc/lifecycle/test_nc_lifecycle_expiration');
 require('../../integration_tests/api/s3/test_chunked_upload');
 require('../../integration_tests/api/s3/test_s3_worm.js');
+require('../../integration_tests/api/sts/test_sts');
 
 // running with vectors port
 require('../../integration_tests/api/vectors/test_vectors_ops'); // please notice that we use a different setup

--- a/src/util/ldap_client.js
+++ b/src/util/ldap_client.js
@@ -55,11 +55,12 @@ class LdapClient extends EventEmitter {
             this.tls_options = this.ldap_params.tls_options || {
                 'rejectUnauthorized': false,
             };
+            const was_connected = this.is_connected();
             this.admin_client = new ldap.Client({
                 url: this.ldap_params.uri,
                 tlsOptions: this.tls_options,
             });
-            if (this.is_connected) {
+            if (was_connected) {
                 await this.reconnect();
             }
         } catch (err) {


### PR DESCRIPTION
### Describe the Problem
test_sts.js was not part of the nc_coretest suite. NC mode has architectural differences (separate nsfs.js process, file-based config, no system_store) that required several fixes to make the STS tests run.

### Explain the Changes
1. Registered test_sts.js in the nc_coretest suite.
2. Added NC-specific account config (uid, gid, new_buckets_path) and policy adjustments across all test suites.
3. Fixed JWT secret mismatch between test process and nsfs.js by loading .env before any config imports.
4. Fixed CLI error propagation so test assertions can correctly match error codes from manage_nsfs.
5. Added null-guard for system_store in STS request handling to prevent server crashes in NC mode.
6. Added semantic validation for effect and action fields in role config validation.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. For testing locally
`sudo -E NC_CORETEST=true node node_modules/.bin/mocha --timeout 60000 \
  src/test/utils/index/nc_index.js \
  --grep "STS tests|Session token tests|Assume role policy tests|Assume role with web indentity tests" \
  2>&1 | tee sts_test_output.log`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP reconnection behavior corrected and STS system-owner lookup made null-safe.
  * STS authorization bypass now correctly respects NC environment.

* **New Features**
  * Stricter role configuration validation: only allowed effects and a whitelisted set of STS actions accepted.

* **Tests**
  * Expanded STS tests for NC coretest mode (NC-specific setup, expectations, skips) and improved test CLI argument handling and coretest helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->