### PR TITLE
Several performance improvements

### DIFF
--- a/config.js
+++ b/config.js
@@ -457,6 +457,7 @@ config.CHUNK_CODER_EC_IS_DEFAULT = false;
 
 // DEDUP
 config.MIN_CHUNK_AGE_FOR_DEDUP = 60 * 60 * 1000; // 1 hour
+config.DEDUP_MIN_OBJ_SIZE = 2 * 1024 * 1024; // Skip dedup for small objects based on this threshold
 
 //////////////////////////
 // DEDUP INDEXER CONFIG //

--- a/config.js
+++ b/config.js
@@ -701,6 +701,9 @@ config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS = Number(process.env.ACCOUNTS_CACHE_EX
 // Accountspace_fs account id cache expiration time
 config.ACCOUNTS_ID_CACHE_EXPIRY = 3 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
 
+// Nodes identity cache (list_nodes_by_identity per-node entries)
+config.NODES_IDENTITY_CACHE_MAX = 100;
+config.NODES_IDENTITY_CACHE_EXPIRY_MS = 30000;
 
 // Object SDK bucket_namespace_cache allow stat of the config file
 config.NC_ENABLE_BUCKET_NS_CACHE_STAT_VALIDATION = true;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -530,11 +530,13 @@ class ObjectIO {
             // Defer DB put_mapping: either buffer chunks for small objects (complete),
             // or flush first batch with deferred_object_md for large objects (see below).
             const is_deferred = Boolean(params.defer_put_mapping);
+            // skip dedup for small objects and if using encryption
+            const check_dups = !is_using_encryption && params.size > config.DEDUP_MIN_OBJ_SIZE;
             const mc = new MapClient({
                 object_md,
                 chunks: map_chunks,
                 location_info: params.location_info,
-                check_dups: !is_using_encryption,
+                check_dups,
                 skip_put_mapping: is_deferred,
                 rpc_client: params.client,
                 desc: params.desc,
@@ -643,7 +645,7 @@ class ObjectIO {
                 return;
             }
             const { chunks: prefetched_chunks, effective_end } =
-               _take_prefetched_chunks_for_range(params.object_md, reader.pos, requested_end);
+            _take_prefetched_chunks_for_range(params.object_md, reader.pos, requested_end);
             const io_sem_size = _get_io_semaphore_size(effective_end - reader.pos);
             this._io_buffers_sem.surround_count(io_sem_size, async () => {
                 try {
@@ -949,6 +951,7 @@ function _take_prefetched_chunks_for_range(object_md, read_start, read_end) {
     if (!chunks.length) return { chunks: undefined, effective_end: read_end };
     return { chunks, effective_end: Math.min(coverage_end, read_end) };
 }
+
 function _get_io_semaphore_size(size) {
     // TODO: Currently we have a gap regarding chunked uploads
     // We assume that the chunked upload will take 1MB

--- a/src/server/node_services/nodes_client.js
+++ b/src/server/node_services/nodes_client.js
@@ -9,6 +9,26 @@ const auth_server = require('../common_services/auth_server');
 const db_client = require('../../util/db_client');
 const node_allocator = require('./node_allocator');
 const system_store = require('../system_services/system_store').get_instance();
+const LRUCache = require('../../util/lru_cache');
+const config = require('../../../config');
+
+// LRUCache requires a load callback, but nodes are fetched in batches by
+// list_nodes_by_identity and written with put_in_cache. This stub exists only
+// to satisfy the constructor; it must not be reached via get_with_cache.
+/** @returns {Promise<object>} */
+async function _nodes_cache_load_unsupported() {
+    throw new Error(
+        'NodesIdentityCache is populated by list_nodes_by_identity via put_in_cache and not by get_with_cache'
+    );
+}
+
+const nodes_by_identity_cache = new LRUCache({
+    name: 'NodesIdentityCache',
+    max_usage: config.NODES_IDENTITY_CACHE_MAX,
+    expiry_ms: config.NODES_IDENTITY_CACHE_EXPIRY_MS,
+    make_key: ({ node_id }) => node_id,
+    load: _nodes_cache_load_unsupported,
+});
 
 const NODE_FIELDS_FOR_MAP = Object.freeze([
     'name',
@@ -61,20 +81,36 @@ class NodesClient {
             });
     }
 
-    list_nodes_by_identity(system_id, nodes_identities, fields) {
-        return server_rpc.client.node.list_nodes({
-                query: { nodes: nodes_identities },
-                fields,
-            }, {
-                auth_token: auth_server.make_auth_token({
-                    system_id: system_id,
-                    role: 'admin'
-                })
+    async list_nodes_by_identity(system_id, nodes_identities) {
+        const cached_nodes = [];
+        let has_missing_ids = false;
+        for (const identity of nodes_identities) {
+            const node = nodes_by_identity_cache.peek_cache({ node_id: identity.id });
+            if (node) {
+                cached_nodes.push(node);
+            } else {
+                has_missing_ids = true;
+                break;
+            }
+        }
+        if (!has_missing_ids) {
+            return { nodes: cached_nodes };
+        }
+        const res = await server_rpc.client.node.list_nodes({
+            query: { nodes: nodes_identities },
+            fields: NODE_FIELDS_FOR_MAP,
+        }, {
+            auth_token: auth_server.make_auth_token({
+                system_id: system_id,
+                role: 'admin'
             })
-            .then(res => {
-                db_client.instance().fix_id_type(res.nodes);
-                return res;
-            });
+        });
+        db_client.instance().fix_id_type(res.nodes);
+        for (const node of res.nodes) {
+            const node_id = typeof node._id === 'string' ? node._id : node._id.toHexString();
+            nodes_by_identity_cache.put_in_cache({ node_id }, node);
+        }
+        return res;
     }
 
     get_nodes_stats_by_cloud_service(system_id, start_date, end_date) {

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -615,8 +615,7 @@ async function prepare_blocks(blocks) {
     const system_id = blocks[0].system._id;
     const { nodes } = await nodes_client.instance().list_nodes_by_identity(
         system_id,
-        node_ids.map(id => ({ id: id.toHexString() })),
-        nodes_client.NODE_FIELDS_FOR_MAP
+        node_ids.map(id => ({ id: id.toHexString() }))
     );
     const nodes_by_id = _.keyBy(nodes, '_id');
     for (const block of blocks) {

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -90,8 +90,10 @@ class GetMapping {
             if (!dedup_keys.length) return;
             dbg.log0('GetMapping.find_dups: found keys', dedup_keys.length);
             const dup_chunks_db = await MDStore.instance().find_chunks_by_dedup_key(bucket, dedup_keys);
+            if (dup_chunks_db.length === 0) return;
             const dup_chunks = dup_chunks_db.map(chunk_db => new ChunkDB(chunk_db));
-            dbg.log0('GetMapping.find_dups: dup_chunks', dup_chunks);
+            dbg.log0('GetMapping.find_dups: dup_chunk ids', dup_chunks.slice(0, 10).map(chunk => chunk._id.toString()),
+                dup_chunks.length > 10 ? `... truncated list. total dup_chunks.length=${dup_chunks.length}` : '');
             await _prepare_chunks_group({ chunks: dup_chunks, location_info: this.location_info });
             for (const dup_chunk of dup_chunks) {
                 if (mapper.is_chunk_good_for_dedup(dup_chunk)) {

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1947,7 +1947,8 @@ function get_etag(entity, updates) {
     const sha256_b64 = updates?.sha256_b64 || entity.sha256_b64;
     if (sha256_b64) return 'sha256-' + Buffer.from(sha256_b64, 'base64').toString('hex');
 
-    const id = updates?._id || entity._id;
+    let id = updates?._id || entity._id;
+    if (typeof id === 'string') id = make_md_id(id);
     if (id) return 'id-' + id.toHexString();
 
     return '';

--- a/src/test/integration_tests/internal/test_encryption.js
+++ b/src/test/integration_tests/internal/test_encryption.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const config = require('../../../../config.js');
 const { KeyRotator } = require('../../../server/bg_services/key_rotator');
+const { MDStore } = require('../../../server/object_services/md_store');
 
 let s3;
 let coretest_access_key;
@@ -1098,12 +1099,24 @@ async function compare_master_keys(master_keys) {
     assert.strictEqual(encrypted_secret_key.toString('base64'), db_system_master_key.cipher_key.toString('base64'));
 }
 
+async function get_db_chunks_for_object(bucket_name, key) {
+    const db_bucket = await db_client.collection('buckets').findOne({ name: bucket_name });
+    let obj = await MDStore.instance().find_object_null_version(db_bucket._id, key);
+    if (!obj) obj = await MDStore.instance().find_object_latest(db_bucket._id, key);
+    assert.ok(obj, `object not found for bucket=${bucket_name} key=${key}`);
+    const chunk_ids = await MDStore.instance().find_parts_chunk_ids(obj);
+    const chunk_id_set = new Set(chunk_ids.map(id => id.toString()));
+    const db_chunks_all = await db_client.collection('datachunks').find({ bucket: db_bucket._id, deleted: null });
+    const db_chunks = db_chunks_all.filter(c => chunk_id_set.has(c._id.toString()));
+    return { db_bucket, db_chunks };
+}
+
 async function compare_chunks(bucket_name, key, rpc_client) {
-    const db_bucket = await db_client.collection('buckets').findOne({name: bucket_name});
-    const db_chunks = await db_client.collection('datachunks').find({bucket: db_bucket._id, deleted: null});
+    const { db_bucket, db_chunks } = await get_db_chunks_for_object(bucket_name, key);
     const api_chunks = (await rpc_client.object.read_object_mapping_admin({ bucket: bucket_name, key})).chunks;
     await P.all(_.map(db_chunks, async db_chunk => {
         const chunk_api = api_chunks.find(api_chunk => api_chunk._id.toString() === db_chunk._id.toString());
+        assert.ok(chunk_api, `chunk ${db_chunk._id} not found in object mapping for key=${key}`);
         await check_master_key_in_db(db_chunk.master_key_id);
         assert.strictEqual(db_chunk.master_key_id.toString(), db_bucket.master_key_id.toString());
         assert.strictEqual(db_chunk.master_key_id.toString(), chunk_api.master_key_id.toString());
@@ -1280,13 +1293,13 @@ async function create_delete_external_connections(rpc_client) {
 }
 
 async function compare_chunks_disabled(rpc_client, bucket_name, key, db_chunks_before_dis) {
-    const db_bucket = await db_client.collection('buckets').findOne({name: bucket_name});
+    const { db_bucket, db_chunks } = await get_db_chunks_for_object(bucket_name, key);
     const db_master_key = await db_client.collection('master_keys').findOne({_id: db_bucket.master_key_id});
     assert.ok(db_master_key.disabled === true);
-    const db_chunks = await db_client.collection('datachunks').find({bucket: db_bucket._id, deleted: null});
     const api_chunks = (await rpc_client.object.read_object_mapping_admin({ bucket: bucket_name, key})).chunks;
     await P.all(_.map(db_chunks, async db_chunk => {
         const chunk_api = api_chunks.find(api_chunk => api_chunk._id.toString() === db_chunk._id.toString());
+        assert.ok(chunk_api, `chunk ${db_chunk._id} not found in object mapping for key=${key}`);
         assert.strictEqual(db_chunk.master_key_id, undefined);
         assert.notStrictEqual(db_chunk.master_key_id, db_bucket.master_key_id.toString());
         assert.strictEqual(db_chunk.master_key_id, chunk_api.master_key_id);

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -42,20 +42,21 @@ const INTERNAL_CA_CERTS = process.env.INTERNAL_CA_CERTS || '/var/run/secrets/kub
 const EXTERNAL_CA_CERTS = process.env.EXTERNAL_CA_CERTS || '/etc/ocp-injected-ca-bundle/ca-bundle.crt';
 
 const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
-const http_agent = new http.Agent();
+const http_agent = new http.Agent({ keepAlive: true });
 const https_agent = new https.Agent({
+    keepAlive: true,
     ca: (ca => (ca.length ? ca : undefined))([
         fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
         fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
     ].filter(Boolean))
 });
-const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false });
+const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false, keepAlive: true });
 const http_proxy_agent = HTTP_PROXY ?
-    new HttpProxyAgent(HTTP_PROXY) : null;
+    new HttpProxyAgent(HTTP_PROXY, { keepAlive: true }) : null;
 const https_proxy_agent = HTTPS_PROXY ?
-    new HttpsProxyAgent(HTTPS_PROXY) : null;
+    new HttpsProxyAgent(HTTPS_PROXY, { keepAlive: true }) : null;
 const unsecured_https_proxy_agent = HTTPS_PROXY ?
-    new HttpsProxyAgent(HTTPS_PROXY, { rejectUnauthorized: false }) : null;
+    new HttpsProxyAgent(HTTPS_PROXY, { rejectUnauthorized: false, keepAlive: true }) : null;
 
 const no_proxy_list = (NO_PROXY ? NO_PROXY.split(',') : []).map(addr => {
     let kind = 'FQDN';

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -225,7 +225,7 @@ class HttpNotificator {
     }
 
     connect() {
-        this.agent = new this.protocol.Agent(this.connect_obj.agent_request_object);
+        this.agent = new this.protocol.Agent({ ...this.connect_obj.agent_request_object, keepAlive: true });
     }
 
     promise_notify(notif, promise_failure_cb, failure_ctxt) {


### PR DESCRIPTION
### Describe the Problem

1. Upload and mapping hot paths incur avoidable overhead: HTTP clients open new connections per request.
2. Dedup runs for small objects where benefit is low
3. `list_nodes_by_identity` is called repeatedly for the same nodes during overlapping map/prepare work
4. Deferred uploads with MD5/SHA256 disabled can crash when `get_etag` falls back to an id-based etag because RPC returns `_id` as a hex string.

### Explain the Changes
1. Enable `keepAlive` on default HTTP/HTTPS agents, proxy agents, and notification HTTP agents to reuse outbound connections.
2. Skip dedup for objects at or below `DEDUP_MIN_OBJ_SIZE` (default 2 MiB). Reduce dedup logging noise in `map_server`.
3. Add a per-node LRU cache in `nodes_client.list_nodes_by_identity` (`NODES_IDENTITY_CACHE_MAX`, `NODES_IDENTITY_CACHE_EXPIRY_MS`) to avoid repeated management RPCs on full cache hits; partial misses still fetch the full identity set and warm the cache.
4. Normalize string `_id` in `get_etag` via `make_md_id` before formatting `id-<hex>` etags, fixing deferred `complete_object_upload` when digests are disabled.

### Issues: Fixed #xxx / Gap #xxx

### Testing Instructions:
1. Upload a small object (&lt; 2 MiB) without encryption and confirm upload succeeds without dedup index lookups.
2. Upload a large object (&gt; 2 MiB) without encryption and confirm dedup still runs when configured.
3. Upload with encryption enabled and confirm dedup remains skipped regardless of object size.
4. Run a deferred put-mapping upload with `IO_CALC_MD5_ENABLED=false` and verify `complete_object_upload` returns a valid `id-*` etag.
5. Run concurrent map/prepare requests targeting the same nodes and confirm reduced `list_nodes` RPC volume on cache hits.
6. Smoke-test outbound HTTP flows (e.g. notifications) with keep-alive enabled.


- [ ] Doc added/updated
- [ ] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable deduplication size threshold and per-node identity cache limits (max entries & expiry).

* **Bug Fixes**
  * Fixed ID handling when generating ETags.

* **Performance**
  * Cache-first identity lookups to reduce remote calls.
  * Enabled HTTP connection reuse (keep-alive) for notifications and proxy requests.
  * Skip deduplication for small or encrypted uploads.

* **Improvements**
  * Truncated duplicate-chunk logging for clearer output.

* **Tests**
  * Improved encryption tests to target relevant object/chunk mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->