### PR TITLE
A few lightweight improvements to replication cycles

### DIFF
--- a/config.js
+++ b/config.js
@@ -749,6 +749,7 @@ config.NS_MAX_ALLOWED_IO_ERRORS = 9;
 ////////////////////////////////
 
 config.BUCKET_REPLICATOR_DELAY = 5 * 60 * 1000;
+config.BUCKET_REPLICATOR_BUSY_DELAY = 60 * 1000;
 config.BUCKET_REPLICATOR_LIST_LIMIT = 1000;
 config.BUCKET_REPLICATION_MAX_RULES = 1000;
 config.BUCKET_REPLICATION_MAX_DST_BUCKETS = 100;
@@ -758,8 +759,14 @@ config.REPLICATION_ENABLED = true;
 config.LOG_REPLICATION_ENABLED = true;
 config.AWS_LOG_CANDIDATES_LIMIT = 10;
 config.BUCKET_LOG_REPLICATOR_DELAY = 5 * 60 * 1000;
+config.BUCKET_LOG_REPLICATOR_BUSY_DELAY = 5 * 1000;
 config.AZURE_QUERY_TRUNCATION_MAX_SIZE_IN_BITS = 10 * 1024 * 1024;
 config.BUCKET_DIFF_FOR_REPLICATION = true;
+// When true, skip the two HEAD calls per matching-ETag key for non-versioned buckets.
+// reduces API call overhead but metadata-only changes (same ETag, different x-amz-meta-*) will NOT trigger replication.
+config.BUCKET_REPLICATION_SKIP_METADATA_CHECK_NON_VERSIONED = false;
+config.LOG_REPLICATION_MAX_CONCURRENT_POLICIES = 10;
+config.LOG_REPLICATION_MAX_CONCURRENT_RULES = 10;
 
 ////////////////////////////////
 //      BUCKET LOGGING        //

--- a/src/server/bg_services/log_replication_scanner.js
+++ b/src/server/bg_services/log_replication_scanner.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const _ = require('lodash');
 const system_store = require('../system_services/system_store').get_instance();
 const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
@@ -36,16 +35,19 @@ class LogReplicationScanner {
     async run_batch() {
         if (!this._can_run()) return;
         dbg.log0('log_replication_scanner: starting scanning bucket replications');
+        let worked_last_batch = false;
         try {
             if (!this.noobaa_connection) {
                 this.noobaa_connection = cloud_utils.set_noobaa_s3_connection(system_store.data.systems[0]);
             }
-            await this.scan();
+            worked_last_batch = await this.scan();
         } catch (err) {
             dbg.error('log_replication_scanner:', err);
+            // Keep scanner responsive after partial progress or transient failures.
+            return config.BUCKET_LOG_REPLICATOR_BUSY_DELAY;
         }
 
-        return config.BUCKET_LOG_REPLICATOR_DELAY;
+        return worked_last_batch ? config.BUCKET_LOG_REPLICATOR_BUSY_DELAY : config.BUCKET_LOG_REPLICATOR_DELAY;
     }
 
     _can_run() {
@@ -65,9 +67,11 @@ class LogReplicationScanner {
         // Retrieve all replication policies with log-replication info from the DB
         const replications = await replication_store.find_log_based_replication_rules();
 
-        // Iterate over the policies in parallel
-        await P.all(_.map(replications, async repl => {
-            _.map(repl.rules, async rule => {
+        let worked_last_batch = false;
+
+        // Iterate over the policies in parallel with bounded concurrency
+        await P.map_with_concurrency(config.LOG_REPLICATION_MAX_CONCURRENT_POLICIES, replications, async repl => {
+            await P.map_with_concurrency(config.LOG_REPLICATION_MAX_CONCURRENT_RULES, repl.rules, async rule => {
                 const replication_id = repl._id;
                 const rule_id = rule.rule_id;
 
@@ -88,6 +92,7 @@ class LogReplicationScanner {
                 if (!candidates.items || !candidates.done) return;
 
                 const total = Object.keys(candidates.items).length;
+                if (total > 0) worked_last_batch = true;
                 if (!dst_bucket) {
                     dbg.error('log_replication_scanner: destination_bucket not found:', rule.destination_bucket, 'for replication_id:', replication_id);
                     const dst_bucket_name = await replication_utils.resolve_destination_bucket_name(rule.destination_bucket);
@@ -130,7 +135,9 @@ class LogReplicationScanner {
 
                 await replication_store.update_log_replication_status_by_id(replication_id, Date.now());
             });
-        }));
+        });
+
+        return worked_last_batch;
     }
 
     /**

--- a/src/server/bg_services/replication_log_parser.js
+++ b/src/server/bg_services/replication_log_parser.js
@@ -141,7 +141,7 @@ async function get_azure_log_candidates(source_bucket_id, rule_id, replication_c
 
     if (query_result.status === LogsQueryResultStatus.Success) {
         const tables_from_result = query_result.tables;
-        if (tables_from_result && tables_from_result[0].rows.length > 0) {
+        if (tables_from_result && tables_from_result.length > 0 && tables_from_result[0].rows.length > 0) {
             const result_rows = query_result.tables[0].rows;
             // @ts-ignore - Needed since the format of `rows` is changed in the Kusto query - project Time, Action, Key
             // So there's a mismatch between what the code expects and what it actually receives
@@ -158,10 +158,14 @@ async function get_azure_log_candidates(source_bucket_id, rule_id, replication_c
             dbg.log1("get_azure_log_candidates: candsidates", candidates);
         } else {
             dbg.log1("get_azure_log_candidates: No new Azure logs found to process");
-        }
-        if (tables_from_result.length === 0) {
-            dbg.log1(`get_azure_log_candidates: No results for Azure replication query '${kusto_query}'`);
-            return;
+            if (!tables_from_result || tables_from_result.length === 0) {
+                dbg.log1(`get_azure_log_candidates: No results for Azure replication query '${kusto_query}'`);
+                return { items: {}, done: async () => { /* no-op */ } };
+            }
+            // Rows are empty but a table was returned — advance the token to now so
+            // next cycle does not re-query the same time window.
+            continuation_token = Date.now().toString();
+            candidates = create_candidates([]);
         }
     } else {
         dbg.error(`get_azure_log_candidates: Error processing the Azure replication query '${kusto_query}' - ${query_result.partialError}`);

--- a/src/server/bg_services/replication_scanner.js
+++ b/src/server/bg_services/replication_scanner.js
@@ -35,15 +35,18 @@ class ReplicationScanner {
     async run_batch() {
         if (!this._can_run()) return;
         dbg.log0('replication_scanner: starting scanning bucket replications');
+        let worked_last_batch = false;
         try {
             if (!this.noobaa_connection) {
                 this.noobaa_connection = cloud_utils.set_noobaa_s3_connection(system_store.data.systems[0]);
             }
-            await this.scan();
+            worked_last_batch = await this.scan();
         } catch (err) {
             dbg.error('replication_scanner:', err, err.stack);
+            // Keep scanner responsive after partial progress or transient failures.
+            return config.BUCKET_REPLICATOR_BUSY_DELAY;
         }
-        return config.BUCKET_REPLICATOR_DELAY;
+        return worked_last_batch ? config.BUCKET_REPLICATOR_BUSY_DELAY : config.BUCKET_REPLICATOR_DELAY;
     }
 
     _can_run() {
@@ -63,6 +66,8 @@ class ReplicationScanner {
         await replication_utils.reconcile_replication_target_status();
         // find rule for each replication policy that was not updated for the longest period
         const least_recently_replicated_rules = await replication_store.find_rules_updated_longest_time_ago();
+
+        let worked_last_batch = false;
 
         await P.all(_.map(least_recently_replicated_rules, async replication_id_and_rule => {
             const { replication_id, rule } = replication_id_and_rule;
@@ -101,7 +106,8 @@ class ReplicationScanner {
                 second_bucket: dst_bucket.name,
                 version: sync_versions,
                 connection: this.noobaa_connection,
-                for_replication: config.BUCKET_DIFF_FOR_REPLICATION
+                for_replication: config.BUCKET_DIFF_FOR_REPLICATION,
+                skip_user_metadata_check: config.BUCKET_REPLICATION_SKIP_METADATA_CHECK_NON_VERSIONED,
             });
             dbg.log1(`scan:: cur_src_cont_token: ${cur_src_cont_token},cur_dst_cont_token: ${cur_dst_cont_token}`);
 
@@ -130,6 +136,10 @@ class ReplicationScanner {
             }
 
             dbg.log1('scan:: keys_sizes_map_to_copy:', keys_diff_map, 'src_cont_token:', src_cont_token, 'dst_cont_token', dst_cont_token);
+
+            // Mark that this cycle has work: objects to copy or more pages to scan.
+            if (Object.keys(keys_diff_map).length || src_cont_token) worked_last_batch = true;
+
             let copy_res = {
                 num_of_objects: 0,
                 size_of_objects: 0
@@ -168,6 +178,8 @@ class ReplicationScanner {
                 replication_utils.update_replication_prom_report(src_bucket.name, replication_id, rule_status, bucket_status);
             }
         }));
+
+        return worked_last_batch;
     }
 }
 

--- a/src/server/utils/bucket_diff.js
+++ b/src/server/utils/bucket_diff.js
@@ -19,6 +19,7 @@ class BucketDiff {
      *   connection?: import('@aws-sdk/client-s3').S3;
      *   for_replication: boolean;
      *   for_deletion: boolean;
+     *   skip_user_metadata_check?: boolean;
      * }} params
      */
     constructor(params) {
@@ -30,6 +31,7 @@ class BucketDiff {
             connection,
             for_replication,
             for_deletion,
+            skip_user_metadata_check = false,
         } = params;
         this.first_bucket = first_bucket;
         this.second_bucket = second_bucket;
@@ -46,6 +48,9 @@ class BucketDiff {
         this.for_replication = for_replication;
         // will set the bucket diff to return only the diff of delete markers.
         this.for_deletion = for_deletion;
+        // when true and versioning is disabled, skip the two HEAD calls per matching-ETag key.
+        // metadata-only changes (same ETag, different x-amz-meta-*) will not trigger replication.
+        this.skip_user_metadata_check = skip_user_metadata_check;
     }
 
     /**
@@ -446,6 +451,11 @@ class BucketDiff {
      * @param {any[]} second_bucket_curr_obj
      */
     async _is_same_user_metadata(pos, cur_first_bucket_key, first_bucket_curr_obj, second_bucket_curr_obj) {
+        // For non-versioned replication, skip HEAD calls when the caller opts in via
+        // skip_user_metadata_check (controlled by BUCKET_REPLICATION_SKIP_METADATA_CHECK_NON_VERSIONED).
+        // Metadata-only changes (same ETag, different x-amz-meta-*) will not trigger replication.
+        if (!this.version && this.skip_user_metadata_check) return true;
+
         let first_bucket_obj_version_id;
         let second_bucket_obj_version_id;
         if (this.version) {


### PR DESCRIPTION
### Describe the Problem
Replication velocity can turn pretty slow, try to adjust some minor flows to boost it a bit

### Explain the Changes
1. Shorten delay between bg worker runs if there was work done on last cycle (both scan and log)
2. Advance continuation token on Azure when empty table is returned (log)
3. Save HEAD calls on source and dest if versioning doesn't exist, use ETAG in such a case 


### Testing Instructions:
1. Verify cycle timing changes when idle vs/ has work


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure log replication to handle success responses with zero tables or zero rows without getting stuck, returning consistent candidate data and advancing the continuation window.

* **Performance**
  * Replication scheduling now uses adaptive “busy” vs normal delays based on whether the previous scan produced work, including faster recovery after errors.
  * Improved log replication scanning throughput with bounded concurrency.

* **New Features**
  * Added configurable delay and retry knobs for bucket and log replication.
  * Added an option to skip user metadata checks for non-versioned buckets during diffing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->