### PR TITLE
STS | Azure error code check for connevction

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -800,8 +800,14 @@ async function _check_azure_connection_internal(params) {
             throw err_to_status(err, 'TIME_SKEW');
         } else if (err.code === 'ENOTFOUND') {
             throw err_to_status(err, 'UNKNOWN_FAILURE');
+        } else if (err.name?.toLowerCase().includes('authentication') || err.code?.toLowerCase().includes('authorization')) {
+            /* 
+                For AuthenticationRequiredError err.code is undefined, err.name is AuthenticationRequiredError, 
+                In case of AuthorizationPermissionMismatch err.code is AuthorizationPermissionMismatch and err.name is RestError
+            */
+            throw err_to_status(err, 'INVALID_CREDENTIALS');
         } else {
-            throw err_to_status(err, err.code === 'AuthenticationFailed' ? 'INVALID_CREDENTIALS' : 'INVALID_ENDPOINT');
+            throw err_to_status(err, 'INVALID_ENDPOINT');
         }
     }
 


### PR DESCRIPTION
### Describe the Problem

Misleading INVALID_ENDPOINT error when Azure STS managed identity lacks permissions on target storage account

### Explain the Changes
1. When the error code or name is startswith() 'Authentication') or 'Authorization' then return INVALID_CREDENTIALS error.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6948

### Testing Instructions:
1. Try to create backingstore with invalid client or tenant or
2. remove storage account or blob access for the managed identity and try to create azure sts backingstore


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Azure connection failures so authentication and authorization errors are more accurately identified and reported, providing clearer feedback when credentials or permissions are the cause.
  * Preserved existing special-case handling for time skew and other unknown failures to keep current diagnostics intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->