### PR TITLE
vectors - handle NSS deleted scenario (df6947)

### DIFF
--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -2362,7 +2362,10 @@ function find_vector_index(req, vector_bucket_name, vector_index_name) {
 }
 
 function get_vector_bucket_info(vector_bucket) {
-    const nsr = pool_server.get_namespace_resource_info(vector_bucket.namespace_resource.resource);
+    //Access associated NSS only if it's available (it might have been deleted)
+    const nsr = vector_bucket.namespace_resource?.resource?._id ?
+        pool_server.get_namespace_resource_info(vector_bucket.namespace_resource.resource) :
+        null;
 
     const info = {
         name: vector_bucket.name,
@@ -2371,7 +2374,7 @@ function get_vector_bucket_info(vector_bucket) {
         vector_db_type: vector_bucket.vector_db_type,
         namespace_resource: {
             ...vector_bucket.namespace_resource,
-            resource: nsr.name,
+            resource: nsr?.name || '',
         },
         bucket_claim: vector_bucket.bucket_claim,
         tags: vector_bucket.tags,


### PR DESCRIPTION
### Describe the Problem
Vector bucket has an NSFS NSS associated with it.
This NSS is a kubernetes CRD object on its own.
Specifically, it can be deleted.
bucket_server.js.get_vector_bucket_info() should handle this gracefully.

### Explain the Changes
1. in get_vector_bucket_info(), don't assume vector bucket's NSS exists. Check before accessing it.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6947

### Testing Instructions:
1. Create NSFS NSS (requires PVC).
2. Create a vector bucket using above NSS.
3. Delete NSS.
4. Perform 'aws s3vectors list-vector-buckets'.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vector buckets when associated namespace information is missing or has been deleted.
  * UI and listing flows now display sensible defaults for missing namespace details, reducing errors and improving stability when accessing or listing vector buckets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->