### PR TITLE
GCP WIF (STS) | Updated Enums and  Consts and Create GCP Client

### DIFF
--- a/config.js
+++ b/config.js
@@ -526,7 +526,7 @@ config.STATISTICS_COLLECTOR_EXPIRATION = 31 * 24 * 60 * 60 * 1000; // 1 month
 ///////////////////
 // USAGE REPORTS //
 ///////////////////
-config.SERVICES_TYPES = Object.freeze(['AWS', 'AWSSTS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'IBM_COS']);
+config.SERVICES_TYPES = Object.freeze(['AWS', 'AWSSTS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'IBM_COS']);
 config.USAGE_AGGREGATOR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 
 config.BLOCK_STORE_USAGE_INTERVAL = 1 * 60 * 1000; // 1 minute

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -125,10 +125,13 @@ class Agent {
                     };
                     this.node_type = 'BLOCK_STORE_AZURE';
                     this.block_store = new BlockStoreAzure(block_store_options);
-                } else if (params.cloud_info.endpoint_type === 'GOOGLE') {
+                } else if (params.cloud_info.endpoint_type === 'GOOGLE' ||
+                    params.cloud_info.endpoint_type === 'GOOGLE_STS') {
                     this.node_type = 'BLOCK_STORE_GOOGLE';
-                    const { project_id, private_key, client_email } = JSON.parse(params.cloud_info.access_keys.secret_key.unwrap());
-                    block_store_options.cloud_info.google = { project_id, private_key, client_email };
+                    block_store_options.cloud_info.google = cloud_utils.build_google_cloud_info(
+                        params.cloud_info.endpoint_type,
+                        params.cloud_info.access_keys.secret_key.unwrap()
+                    );
                     this.block_store = new BlockStoreGoogle(block_store_options);
                 }
             } else if (params.mongo_info) {
@@ -266,8 +269,10 @@ class Agent {
             };
             this.block_store = new BlockStoreAzure(block_store_options);
         } else if (this.node_type === 'BLOCK_STORE_GOOGLE') {
-            const { project_id, private_key, client_email } = JSON.parse(this.cloud_info.access_keys.secret_key.unwrap());
-            block_store_options.cloud_info.google = { project_id, private_key, client_email };
+            block_store_options.cloud_info.google = cloud_utils.build_google_cloud_info(
+                this.cloud_info.endpoint_type,
+                this.cloud_info.access_keys.secret_key.unwrap()
+            );
             this.block_store = new BlockStoreGoogle(block_store_options);
         }
 

--- a/src/agent/block_store_services/block_store_client.js
+++ b/src/agent/block_store_services/block_store_client.js
@@ -4,7 +4,6 @@
 const AWS = require('aws-sdk');
 const _ = require('lodash');
 
-const Storage = require('../../util/google_storage_wrap');
 const azure_storage = require('../../util/azure_storage_wrap');
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -101,13 +100,7 @@ class BlockStoreClient {
                 const google_params = bs_info.connection_params;
                 const block_id = block_md.id;
                 const block_dir = get_block_internal_dir(block_id);
-                const google = new Storage({
-                    projectId: google_params.project_id,
-                    credentials: {
-                        client_email: google_params.client_email,
-                        private_key: google_params.private_key
-                    }
-                });
+                const google = this._create_google_storage(google_params);
                 bucket = google.bucket(bs_info.target_bucket);
                 const block_key = `${bs_info.blocks_path}/${block_dir}/${block_id}`;
                 const target_file = bucket.file(block_key);
@@ -161,13 +154,7 @@ class BlockStoreClient {
                 const google_params = bs_info.connection_params;
                 const block_id = block_md.id;
                 const block_dir = get_block_internal_dir(block_id);
-                const google = new Storage({
-                    projectId: google_params.project_id,
-                    credentials: {
-                        client_email: google_params.client_email,
-                        private_key: google_params.private_key
-                    }
-                });
+                const google = this._create_google_storage(google_params);
                 bucket = google.bucket(bs_info.target_bucket);
                 const block_key = `${bs_info.blocks_path}/${block_dir}/${block_id}`;
                 const file = bucket.file(block_key);
@@ -599,13 +586,7 @@ class BlockStoreClient {
                 const bs_info = await block_store_info_cache.get_with_cache({ options, rpc_client });
                 if (!bs_info) throw new Error('couldn\'t resolve cloud credentials');
                 const google_params = bs_info.connection_params;
-                const google = new Storage({
-                    projectId: google_params.project_id,
-                    credentials: {
-                        client_email: google_params.client_email,
-                        private_key: google_params.private_key
-                    }
-                });
+                const google = this._create_google_storage(google_params);
                 const bucket = google.bucket(bs_info.target_bucket);
                 dbg.log1('_delegate_delete_blocks_google: deleting', block_ids.length, 'blocks from', bs_info.target_bucket);
 
@@ -716,6 +697,11 @@ class BlockStoreClient {
                 }
             }));
         }
+    }
+
+    _create_google_storage(google_params) {
+        // use the STS when present, otherwise use the service account
+        return cloud_utils.create_google_storage_from_connection(google_params.credentials_json || google_params);
     }
 }
 

--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -9,7 +9,7 @@ const buffer_utils = require('../../util/buffer_utils');
 const size_utils = require('../../util/size_utils');
 const BlockStoreBase = require('./block_store_base').BlockStoreBase;
 const { RpcError } = require('../../rpc');
-const Storage = require('../../util/google_storage_wrap');
+const cloud_utils = require('../../util/cloud_utils');
 
 
 class BlockStoreGoogle extends BlockStoreBase {
@@ -27,13 +27,15 @@ class BlockStoreGoogle extends BlockStoreBase {
             count: 0
         };
 
-        this.cloud = new Storage({
-            projectId: this.cloud_info.google.project_id,
-            credentials: {
+        if (this.cloud_info.endpoint_type === 'GOOGLE_STS') {
+            this.cloud = cloud_utils.create_google_storage_from_connection(this.cloud_info.google.credentials_json);
+        } else {
+            this.cloud = cloud_utils.create_google_storage_from_connection({
+                project_id: this.cloud_info.google.project_id,
                 client_email: this.cloud_info.google.client_email,
-                private_key: this.cloud_info.google.private_key
-            }
-        });
+                private_key: this.cloud_info.google.private_key,
+            });
+        }
         this.bucket = this.cloud.bucket(this.cloud_info.target_bucket);
         this.usage_file = this.bucket.file(this.usage_path);
     }
@@ -78,11 +80,18 @@ class BlockStoreGoogle extends BlockStoreBase {
     }
 
     _get_block_store_info() {
-        const connection_params = {
-            project_id: this.cloud_info.google.project_id,
-            client_email: this.cloud_info.google.client_email,
-            private_key: this.cloud_info.google.private_key
-        };
+        let connection_params;
+        if (this.cloud_info.endpoint_type === 'GOOGLE_STS') {
+            connection_params = {
+                credentials_json: this.cloud_info.google.credentials_json,
+            };
+        } else {
+            connection_params = {
+                project_id: this.cloud_info.google.project_id,
+                client_email: this.cloud_info.google.client_email,
+                private_key: this.cloud_info.google.private_key,
+            };
+        }
         return {
             connection_params,
             target_bucket: this.cloud_info.target_bucket,

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -882,7 +882,7 @@ module.exports = {
 
         endpoint_type: {
             type: 'string',
-            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
         },
 
         block_md: {

--- a/src/api/node_api.js
+++ b/src/api/node_api.js
@@ -175,7 +175,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -243,7 +243,7 @@ module.exports = {
                     properties: {
                         service: {
                             type: 'string',
-                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                            enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                         },
                         read_count: {
                             type: 'integer'

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -67,7 +67,8 @@ class NamespaceMonitor {
                     await this.test_s3_resource(nsr);
                 } else if (['AZURE', 'AZURESTS' ].includes(endpoint_type)) {
                     await this.test_blob_resource(nsr);
-                } else if (endpoint_type === 'GOOGLE') {
+                } else if (endpoint_type === 'GOOGLE' || endpoint_type === 'GOOGLE_STS') {
+                    // GOOGLE_STS namespace resources are not supported yet (test_gcs_resource expects service_account JSON).
                     await this.test_gcs_resource(nsr);
                 } else {
                     dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -5,7 +5,6 @@ const P = require('../../util/promise');
 const _ = require('lodash');
 const net = require('net');
 const chance = require('chance')();
-const GoogleStorage = require('../../util/google_storage_wrap');
 const server_rpc = require('../server_rpc');
 
 const config = require('../../../config');
@@ -725,7 +724,8 @@ async function _check_external_connection_internal(connection) {
         case 'NET_STORAGE': {
             return check_net_storage_connection(connection);
         }
-        case 'GOOGLE': {
+        case 'GOOGLE':
+        case 'GOOGLE_STS': {
             return check_google_connection(connection);
         }
 
@@ -871,16 +871,21 @@ const net_storage_error_mapping = Object.freeze({
 
 async function check_google_connection(params) {
     try {
-        const key_file = JSON.parse(params.secret.unwrap());
-        const credentials = _.pick(key_file, 'client_email', 'private_key');
-        const storage = new GoogleStorage({ credentials, projectId: key_file.project_id });
-        await storage.getBuckets();
+        const storage = cloud_utils.create_google_storage_from_connection(params.secret.unwrap());
+        const timeout_err = Object.assign(new Error('TIMEOUT'), { code: 'TIMEOUT' });
+        await P.timeout(check_connection_timeout, storage.getBuckets(), () => timeout_err);
         return { status: 'SUCCESS' };
     } catch (err) {
-        // Currently we treat all errors as invalid credentials errors,
+        dbg.warn('check_google_connection:', _.omit(params, 'secret'),
+            `code: ${err.code}, message: ${err.message}`);
+        if (err.code === 403) {
+            dbg.warn('check_google_connection: GCP returned permission denied (auth may have succeeded; check IAM roles on the service account)');
+        }
+        // Currently we treat all errors as invalid credentials errors (except timeout),
         // because all information should exists in the keys file.
+        const status = err.code === 'TIMEOUT' ? 'TIMEOUT' : 'INVALID_CREDENTIALS';
         return {
-            status: 'INVALID_CREDENTIALS',
+            status,
             error: {
                 code: String(err.code),
                 message: String(err.message)

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -7,7 +7,6 @@
 const _ = require('lodash');
 const net = require('net');
 const fs = require('fs');
-const GoogleStorage = require('../../util/google_storage_wrap');
 
 const P = require('../../util/promise');
 const dbg = require('../../util/debug_module')(__filename);
@@ -1422,21 +1421,16 @@ async function get_cloud_buckets(req) {
                     const buckets = _.map(files.filter(f => f.type === 'dir'), prefix => ({ name: prefix.name }));
                     return buckets.map(bucket => _inject_usage_to_cloud_bucket(bucket.name, connection.endpoint, used_cloud_buckets));
                 });
-        } else if (connection.endpoint_type === 'GOOGLE') {
-            const used_cloud_buckets = cloud_utils.get_used_cloud_targets(['GOOGLE'],
+        } else if (connection.endpoint_type === 'GOOGLE' || connection.endpoint_type === 'GOOGLE_STS') {
+            const used_cloud_buckets = cloud_utils.get_used_cloud_targets(['GOOGLE', 'GOOGLE_STS'],
                 system_store.data.buckets, system_store.data.pools, system_store.data.namespace_resources);
-            let key_file;
+            let storage;
             try {
-                key_file = JSON.parse(connection.secret_key.unwrap());
+                storage = cloud_utils.create_google_storage_from_connection(connection.secret_key.unwrap());
             } catch (err) {
-                throw new RpcError('BAD_REQUEST', 'connection does not contain a key_file in json format');
+                throw new RpcError('BAD_REQUEST', err.message || 'connection secret is not valid credentials JSON');
             }
-            const credentials = _.pick(key_file, 'client_email', 'private_key');
-            const storage = new GoogleStorage({
-                projectId: key_file.project_id,
-                credentials
-            });
-            return storage.getBuckets()
+            return P.timeout(EXTERNAL_BUCKET_LIST_TO, storage.getBuckets())
                 .then(data => data[0].map(bucket =>
                     _inject_usage_to_cloud_bucket(bucket.name, connection.endpoint, used_cloud_buckets)));
         } else { // else if AWS(s3-compatible/aws/sts-aws)/Flashblade/IBM_COS

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -424,7 +424,8 @@ async function create_cloud_pool(req) {
         IBM_COS: 'BLOCK_STORE_S3',
         AZURE: 'BLOCK_STORE_AZURE',
         AZURESTS: 'BLOCK_STORE_AZURE',
-        GOOGLE: 'BLOCK_STORE_GOOGLE'
+        GOOGLE: 'BLOCK_STORE_GOOGLE',
+        GOOGLE_STS: 'BLOCK_STORE_GOOGLE',
     };
 
     const pool_node_type = map_pool_type[connection.endpoint_type];

--- a/src/server/system_services/schemas/account_schema.js
+++ b/src/server/system_services/schemas/account_schema.js
@@ -98,7 +98,7 @@ module.exports = {
                     cp_code: { type: 'string' },
                     endpoint_type: {
                         type: 'string',
-                        enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                        enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                     },
                 }
             }

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -35,7 +35,7 @@ module.exports = {
                 },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 auth_method: {
                     type: 'string',

--- a/src/server/system_services/schemas/pool_schema.js
+++ b/src/server/system_services/schemas/pool_schema.js
@@ -117,7 +117,7 @@ module.exports = {
                 },
                 endpoint_type: {
                     type: 'string',
-                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
+                    enum: ['AWSSTS', 'AWS', 'AZURE', 'AZURESTS', 'S3_COMPATIBLE', 'GOOGLE', 'GOOGLE_STS', 'FLASHBLADE', 'NET_STORAGE', 'IBM_COS']
                 },
                 agent_info: {
                     type: 'object',

--- a/src/server/system_services/stats_aggregator.js
+++ b/src/server/system_services/stats_aggregator.js
@@ -301,6 +301,7 @@ async function get_partial_providers_stats(req) {
         'AZURESTS',
         'S3_COMPATIBLE',
         'GOOGLE',
+        'GOOGLE_STS',
     ];
     try {
         for (const bucket of system_store.data.buckets) {
@@ -771,6 +772,7 @@ async function get_cloud_pool_stats(req) {
                     }
                     break;
                 case 'GOOGLE':
+                case 'GOOGLE_STS':
                     cloud_pool_stats.pool_target.gcp += 1;
                     if (!_.includes(OPTIMAL_MODES, pool_info.mode)) {
                         cloud_pool_stats.unhealthy_pool_target.gcp_unhealthy += 1;

--- a/src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js
@@ -1,0 +1,372 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+jest.mock('../../../util/google_storage_wrap');
+
+/*
+GoogleStorage is a Jest mock of the real Storage constructor (via jest.mock('../../../util/google_storage_wrap')).
+Every time the code runs new GoogleStorage(options), Jest records that call. mock.calls is the list of those calls:
+  - mock.calls[0] — first call (first new GoogleStorage(...))
+  - mock.calls[0][0] — first argument to that call (the options object: { credentials, projectId })
+*/
+
+const GoogleStorage = jest.mocked(require('../../../util/google_storage_wrap'));
+const cloud_utils = require('../../../util/cloud_utils');
+
+const ENDPOINT_TYPE_GOOGLE = 'GOOGLE';
+const ENDPOINT_TYPE_GOOGLE_STS = 'GOOGLE_STS';
+const ENDPOINT_TYPE_AWS = 'AWS';
+
+const CREDENTIAL_TYPE_SERVICE_ACCOUNT = 'service_account';
+const CREDENTIAL_TYPE_EXTERNAL_ACCOUNT = 'external_account';
+
+const PROJECT_ID = 'my-project';
+const CLIENT_EMAIL = 'sa@my-project.iam.gserviceaccount.com';
+const PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n';
+const PRIVATE_KEY_ID = 'key-id';
+const INVALID_JSON = 'not-json';
+const TEST_SA_EMAIL = 'sa@test.iam.gserviceaccount.com';
+const TEST_AUDIENCE = 'aud';
+
+const WIF_AUDIENCE = '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider';
+const WIF_SUBJECT_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:jwt';
+const WIF_TOKEN_URL = 'https://sts.googleapis.com/v1/token';
+const WIF_CREDENTIAL_SOURCE_FILE = '/var/run/secrets/openshift/serviceaccount/token';
+const WIF_CREDENTIAL_SOURCE_FORMAT = 'text';
+const WIF_SERVICE_ACCOUNT_IMPERSONATION_URL =
+    'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com:generateAccessToken';
+const EXAMPLE_TOKEN_URL = 'https://example.com/token';
+const EXECUTABLE_CMD = '/path/to/cmd';
+const ENVIRONMENT_ID_AWS1 = 'aws1';
+
+const INVALID_GOOGLE_ENDPOINT_TYPE_ERROR = /Invalid Google endpoint type: AWS/;
+
+// Sample GCP key-file shapes used as test inputs (not real credentials).
+const SERVICE_ACCOUNT_JSON_FIXTURE = {
+    type: CREDENTIAL_TYPE_SERVICE_ACCOUNT,
+    project_id: PROJECT_ID,
+    client_email: CLIENT_EMAIL,
+    private_key: PRIVATE_KEY,
+    private_key_id: PRIVATE_KEY_ID,
+};
+
+const EXTERNAL_ACCOUNT_JSON_FIXTURE = {
+    type: CREDENTIAL_TYPE_EXTERNAL_ACCOUNT,
+    audience: WIF_AUDIENCE,
+    subject_token_type: WIF_SUBJECT_TOKEN_TYPE,
+    token_url: WIF_TOKEN_URL,
+    credential_source: {
+        file: WIF_CREDENTIAL_SOURCE_FILE,
+        format: WIF_CREDENTIAL_SOURCE_FORMAT,
+    },
+    service_account_impersonation_url: WIF_SERVICE_ACCOUNT_IMPERSONATION_URL,
+};
+
+describe('parse_google_secret_json', () => {
+    it('parses a valid JSON string', () => {
+        const parsed = cloud_utils.parse_google_secret_json(JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE));
+        expect(parsed).toEqual(SERVICE_ACCOUNT_JSON_FIXTURE);
+    });
+
+    it('returns the same object when input is already parsed', () => {
+        const parsed = cloud_utils.parse_google_secret_json(SERVICE_ACCOUNT_JSON_FIXTURE);
+        expect(parsed).toBe(SERVICE_ACCOUNT_JSON_FIXTURE);
+    });
+
+    it('throws on invalid JSON string', () => {
+        expect(() => cloud_utils.parse_google_secret_json(INVALID_JSON)).toThrow(SyntaxError);
+    });
+});
+
+describe('build_google_cloud_info', () => {
+    it('extracts service account fields for GOOGLE', () => {
+        expect(cloud_utils.build_google_cloud_info(
+            ENDPOINT_TYPE_GOOGLE,
+            JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE)
+        )).toEqual({
+            project_id: PROJECT_ID,
+            client_email: CLIENT_EMAIL,
+            private_key: PRIVATE_KEY,
+        });
+    });
+
+    it('keeps full credentials_json for GOOGLE_STS', () => {
+        expect(cloud_utils.build_google_cloud_info(
+            ENDPOINT_TYPE_GOOGLE_STS,
+            JSON.stringify(EXTERNAL_ACCOUNT_JSON_FIXTURE)
+        )).toEqual({
+            credentials_json: EXTERNAL_ACCOUNT_JSON_FIXTURE,
+        });
+    });
+
+    it('rejects unsupported endpoint types', () => {
+        expect(() => cloud_utils.build_google_cloud_info(
+            ENDPOINT_TYPE_AWS,
+            JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE)
+        )).toThrow(INVALID_GOOGLE_ENDPOINT_TYPE_ERROR);
+    });
+});
+
+describe('_is_valid_google_wif_credential_source (via create_google_storage_from_connection)', () => {
+    const CREDENTIAL_SOURCE_ERROR = /expected file path for projected token/;
+
+    beforeEach(() => {
+        GoogleStorage.mockImplementation(() => /** @type {import('../../../util/google_storage_wrap')} */ (
+            /** @type {unknown} */ ({ mockClient: true })
+        ));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('accepts credential_source with file path', () => {
+        cloud_utils.create_google_storage_from_connection(EXTERNAL_ACCOUNT_JSON_FIXTURE);
+        expect(GoogleStorage).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts file path without optional format', () => {
+        cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: {
+                file: WIF_CREDENTIAL_SOURCE_FILE,
+                // format: 'text' is missing -> is valid because it's optional and can be omitted.
+            },
+        });
+        expect(GoogleStorage).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects null credential_source', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: null,
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing credential_source', () => {
+        const { credential_source, ...credentials_without_source } = EXTERNAL_ACCOUNT_JSON_FIXTURE;
+        expect(credential_source).toBeDefined();
+
+        expect(() => cloud_utils.create_google_storage_from_connection(credentials_without_source))
+            .toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-object credential_source', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: '',
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: [],
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty credential_source object', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: {},
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects credential_source when file is missing or empty', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: { format: WIF_CREDENTIAL_SOURCE_FORMAT },
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: { file: '' },
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects other GCP credential_source types without file', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: { url: EXAMPLE_TOKEN_URL },
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: { executable: { command: EXECUTABLE_CMD } },
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: { environment_id: ENVIRONMENT_ID_AWS1 },
+        })).toThrow(CREDENTIAL_SOURCE_ERROR);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+});
+
+describe('is_google_wif_credentials', () => {
+    it('returns true for external_account credentials', () => {
+        expect(cloud_utils.is_google_wif_credentials(EXTERNAL_ACCOUNT_JSON_FIXTURE)).toBe(true);
+    });
+
+    it('returns false for service_account credentials', () => {
+        expect(cloud_utils.is_google_wif_credentials(SERVICE_ACCOUNT_JSON_FIXTURE)).toBe(false);
+    });
+
+    it('returns false for null, undefined, and empty object', () => {
+        expect(cloud_utils.is_google_wif_credentials(null)).toBe(false);
+        expect(cloud_utils.is_google_wif_credentials(undefined)).toBe(false);
+        expect(cloud_utils.is_google_wif_credentials({})).toBe(false);
+    });
+});
+
+describe('create_google_storage_from_connection', () => {
+    beforeEach(() => {
+        GoogleStorage.mockImplementation(() => /** @type {import('../../../util/google_storage_wrap')} */ (
+            /** @type {unknown} */ ({ mockClient: true })
+        ));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('creates a Storage client for service_account JSON string', () => {
+        cloud_utils.create_google_storage_from_connection(JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE));
+
+        expect(GoogleStorage).toHaveBeenCalledTimes(1);
+        expect(GoogleStorage).toHaveBeenCalledWith({
+            credentials: {
+                client_email: SERVICE_ACCOUNT_JSON_FIXTURE.client_email,
+                private_key: SERVICE_ACCOUNT_JSON_FIXTURE.private_key,
+            },
+            projectId: SERVICE_ACCOUNT_JSON_FIXTURE.project_id,
+        });
+    });
+
+    it('creates a Storage client for service_account parsed object', () => {
+        cloud_utils.create_google_storage_from_connection(SERVICE_ACCOUNT_JSON_FIXTURE);
+
+        expect(GoogleStorage).toHaveBeenCalledWith({
+            credentials: {
+                client_email: SERVICE_ACCOUNT_JSON_FIXTURE.client_email,
+                private_key: SERVICE_ACCOUNT_JSON_FIXTURE.private_key,
+            },
+            projectId: SERVICE_ACCOUNT_JSON_FIXTURE.project_id,
+        });
+    });
+
+    it('does not pass extra service_account fields into credentials', () => {
+        cloud_utils.create_google_storage_from_connection(SERVICE_ACCOUNT_JSON_FIXTURE);
+
+        const call = GoogleStorage.mock.calls[0][0];
+        expect(Object.keys(call.credentials).sort()).toEqual(['client_email', 'private_key']);
+    });
+
+    it('creates a Storage client for external_account (WIF) JSON string', () => {
+        cloud_utils.create_google_storage_from_connection(JSON.stringify(EXTERNAL_ACCOUNT_JSON_FIXTURE));
+
+        expect(GoogleStorage).toHaveBeenCalledWith({
+            credentials: EXTERNAL_ACCOUNT_JSON_FIXTURE,
+        });
+        const call = GoogleStorage.mock.calls[0][0];
+        expect(call).not.toHaveProperty('projectId');
+    });
+
+    it('creates a Storage client for external_account (WIF) parsed object', () => {
+        cloud_utils.create_google_storage_from_connection(EXTERNAL_ACCOUNT_JSON_FIXTURE);
+
+        expect(GoogleStorage).toHaveBeenCalledWith({
+            credentials: EXTERNAL_ACCOUNT_JSON_FIXTURE,
+        });
+    });
+
+    it('returns the Storage client instance', () => {
+        const client = /** @type {import('../../../util/google_storage_wrap')} */ (
+            /** @type {unknown} */ ({ mockClient: true })
+        );
+        GoogleStorage.mockReturnValue(client);
+
+        expect(cloud_utils.create_google_storage_from_connection(SERVICE_ACCOUNT_JSON_FIXTURE)).toBe(client);
+    });
+
+    it('creates a Storage client for flat service_account connection_params (block store delegation)', () => {
+        const flat_params = {
+            project_id: SERVICE_ACCOUNT_JSON_FIXTURE.project_id,
+            client_email: SERVICE_ACCOUNT_JSON_FIXTURE.client_email,
+            private_key: SERVICE_ACCOUNT_JSON_FIXTURE.private_key,
+        };
+        cloud_utils.create_google_storage_from_connection(flat_params);
+
+        expect(GoogleStorage).toHaveBeenCalledWith({
+            credentials: {
+                client_email: flat_params.client_email,
+                private_key: flat_params.private_key,
+            },
+            projectId: flat_params.project_id,
+        });
+    });
+
+    it('rejects incomplete service_account credentials', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            type: CREDENTIAL_TYPE_SERVICE_ACCOUNT,
+            client_email: TEST_SA_EMAIL,
+        })).toThrow(/missing required fields/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects credentials without type and without client_email/private_key', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            type: CREDENTIAL_TYPE_SERVICE_ACCOUNT,
+            project_id: PROJECT_ID,
+        })).toThrow(/missing required fields/);
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            project_id: PROJECT_ID,
+        })).toThrow(/expected type field or client_email\/private_key/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects incomplete external_account credentials (missing GCP WIF (STS) fields)', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            type: CREDENTIAL_TYPE_EXTERNAL_ACCOUNT,
+            audience: TEST_AUDIENCE,
+        })).toThrow(/missing required GCP WIF \(STS\) fields/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects external_account credentials with empty credential_source', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection({
+            ...EXTERNAL_ACCOUNT_JSON_FIXTURE,
+            credential_source: {},
+        })).toThrow(/expected file path for projected token/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects external_account credentials without credential_source', () => {
+        const { credential_source, ...without_source } = EXTERNAL_ACCOUNT_JSON_FIXTURE;
+        expect(credential_source).toBeDefined();
+
+        expect(() => cloud_utils.create_google_storage_from_connection(without_source))
+            .toThrow(/expected file path for projected token/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects external_account credentials without service_account_impersonation_url', () => {
+        const { service_account_impersonation_url, ...without_impersonation } = EXTERNAL_ACCOUNT_JSON_FIXTURE;
+        expect(service_account_impersonation_url).toBeDefined();
+
+        expect(() => cloud_utils.create_google_storage_from_connection(without_impersonation))
+            .toThrow(/missing service_account_impersonation_url/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-object credentials', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection(null))
+            .toThrow(/expected object/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+
+    it('rejects array credentials', () => {
+        expect(() => cloud_utils.create_google_storage_from_connection([]))
+            .toThrow(/expected object/);
+        expect(GoogleStorage).not.toHaveBeenCalled();
+    });
+});

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -14,6 +14,7 @@ const { NodeHttpHandler } = require('@smithy/node-http-handler');
 const config = require('../../config');
 const noobaa_s3_client = require('../sdk/noobaa_s3_client/noobaa_s3_client');
 const azure_storage = require('./azure_storage_wrap');
+const GoogleStorage = require('./google_storage_wrap');
 const { WorkloadIdentityCredential } = require("@azure/identity");
 
 const projectedServiceAccountToken = "/var/run/secrets/openshift/serviceaccount/token";
@@ -288,6 +289,131 @@ function create_azure_blob_client(azure_params) {
     return blob;
 }
 
+
+/**
+ * Normalize a Google credential secret to a parsed key-file object.
+ * @param {string|object} secret_json JSON string or already-parsed key file (returned as-is)
+ * @returns {object} secret_json parsed key file object
+ */
+function parse_google_secret_json(secret_json) {
+    return typeof secret_json === 'string' ? JSON.parse(secret_json) : secret_json;
+}
+
+/**
+ * Build cloud_info.google from endpoint_type and secret_key JSON.
+ * GOOGLE_STS keeps the full credentials_json; GOOGLE extracts service-account fields.
+ * @param {string} endpoint_type
+ * @param {string|object} secret_key JSON string or parsed key file object
+ * @returns {{ credentials_json: object } | { project_id: string, client_email: string, private_key: string }}
+ */
+function build_google_cloud_info(endpoint_type, secret_key) {
+    const credentials_json = parse_google_secret_json(secret_key);
+    if (endpoint_type === 'GOOGLE_STS') {
+        return { credentials_json };
+    }
+    if (endpoint_type === 'GOOGLE') {
+        const { project_id, client_email, private_key } = credentials_json;
+        return { project_id, client_email, private_key };
+    }
+    throw new Error(`Invalid Google endpoint type: ${endpoint_type}`);
+}
+
+/**
+ * Check if the Google secret is a WIF (STS)
+ * There are two types:
+ *   1. Long lived token with type 'service_account'
+ *   2. Short-lived token (WIF, STS) with type 'external_account'
+ * @param {object} credentials_json
+ * @returns {boolean}
+ */
+function is_google_wif_credentials(credentials_json) {
+    return Boolean(credentials_json && credentials_json.type === 'external_account');
+}
+
+/**
+ * Create a Google (GCP) client
+ * Supports:
+ *   1. Long lived token using Google Service Account.
+ *   2. Short-lived token (WIF, STS) using Workload Identity Federation and impersonation of Google service account.
+ * Infers auth mode from credentials_json.type (service_account vs external_account).
+ * Validates required fields before constructing GoogleStorage to avoid ADC (application default credentials) fallback on incomplete JSON secrets
+ * and help debugging issues with invalid credentials.
+ * @param {string|object} secret_json JSON string or parsed key file object
+ * @returns {import('./google_storage_wrap')}
+ */
+function create_google_storage_from_connection(secret_json) {
+    const credentials_json = parse_google_secret_json(secret_json);
+    _validate_google_credentials(credentials_json);
+    if (is_google_wif_credentials(credentials_json)) {
+        return new GoogleStorage({ credentials: credentials_json });
+    }
+    return new GoogleStorage({
+        credentials: _.pick(credentials_json, 'client_email', 'private_key'),
+        projectId: credentials_json.project_id,
+    });
+}
+
+/**
+ * Validate parsed Google credentials before GoogleStorage is constructed.
+ *
+ * 1) GCP WIF (STS). external_account: checks two groups of fields:
+ *   1. STS exchange: audience, subject_token_type, token_url, and credential_source.file (NooBaa
+ *      GOOGLE_STS uses a projected token file, e.g. OpenShift service account). An empty credential_source
+ *      object passes a truthy check but the auth library rejects it with "A credential source or subject
+ *      token supplier must be specified."
+ *      Other missing STS fields surface as STS invalid_request errors (e.g. subject_token_type must be nonempty).
+ *   2. service_account_impersonation_url: optional in AIP-4117 but required for NooBaa GOOGLE_STS.
+ *      Without it, federation may obtain a token that cannot access the target bucket; GCP then
+ *      returns 403 "The caller does not have permission" on the first API call.
+ * 2) GCP (no STS):
+ *    With type: service_account: requires client_email and private_key with type service_account.
+ *    Without type: Flat block-store params: client_email and private_key without type (GOOGLE backing store delegation).
+ * @param {object} credentials_json Parsed GCP key file object
+ */
+function _validate_google_credentials(credentials_json) {
+    // Arrays are typeof 'object'; reject them so [] does not pass as credentials.
+    if (!credentials_json || typeof credentials_json !== 'object' || Array.isArray(credentials_json)) {
+        throw new Error('Invalid Google credentials JSON: expected object');
+    }
+    if (credentials_json.type === 'external_account') {
+        if (!credentials_json.audience || !credentials_json.subject_token_type ||
+            !credentials_json.token_url) {
+            throw new Error('Invalid Google external_account credentials JSON: missing required GCP WIF (STS) fields (audience, subject_token_type, token_url)');
+        }
+        if (!_is_valid_google_wif_credential_source(credentials_json.credential_source)) {
+            throw new Error('Invalid Google external_account credentials JSON: missing or invalid credential_source (expected file path for projected token)');
+        }
+        if (!credentials_json.service_account_impersonation_url) {
+            throw new Error('Invalid Google external_account credentials JSON: missing service_account_impersonation_url');
+        }
+    } else if (credentials_json.type === 'service_account') {
+        if (!credentials_json.client_email || !credentials_json.private_key) {
+            throw new Error('Invalid Google service_account credentials JSON: missing required fields (client_email, private_key)');
+        }
+    } else if (!credentials_json.type && credentials_json.client_email && credentials_json.private_key) {
+        // flat block-store params (GOOGLE backing store delegation path)
+    } else if (credentials_json.type) {
+        throw new Error(`Invalid Google credentials JSON: unsupported type ${credentials_json.type}`);
+    } else {
+        throw new Error('Invalid Google credentials JSON: expected type field or client_email/private_key');
+    }
+}
+
+/**
+ * Validate credential_source.file is a file path for projected token.
+ * credential_source can have other required fields, but we only validate file path for projected token.
+ * the full list of properties except file can be found in AIP-4117 External Account Credentials (Workload Identity Federation)
+ * @param {object} credential_source credential_source from external_account JSON
+ * @returns {boolean}
+ */
+function _is_valid_google_wif_credential_source(credential_source) {
+    if (!credential_source || typeof credential_source !== 'object' || Array.isArray(credential_source)) {
+        return false;
+    }
+    return typeof credential_source.file === 'string' && credential_source.file.length > 0;
+}
+
+
 exports.find_cloud_connection = find_cloud_connection;
 exports.get_azure_connection_string = get_azure_connection_string;
 exports.get_azure_new_connection_string = get_azure_new_connection_string;
@@ -301,3 +427,7 @@ exports.generate_access_keys = generate_access_keys;
 exports.createSTSS3SDKv3Client = createSTSS3SDKv3Client;
 exports.generate_aws_sdkv3_sts_creds = generate_aws_sdkv3_sts_creds;
 exports.create_azure_blob_client = create_azure_blob_client;
+exports.parse_google_secret_json = parse_google_secret_json;
+exports.build_google_cloud_info = build_google_cloud_info;
+exports.is_google_wif_credentials = is_google_wif_credentials;
+exports.create_google_storage_from_connection = create_google_storage_from_connection;


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and starts implementing code changes in parts of the flows related to the GCP WIF (STS) backing store.

### Explain the Changes
1. Add `GOOGLE_STS` as const/enum in all the places where we had `GOOGLE`.
2. In `cloud_utils.js` add helper functions for mutual code for creating the GCP client for types of `GOOGLE` and `GOOGLE_STS` (like we have for Azure).
Update: I added validation to the JSON after a comment from CodeRabbit - [link](https://github.com/noobaa/noobaa-core/pull/9644#discussion_r3303699417).
4. In `account_server` add the changes needed for the type `GOOGLE_STS` and add logs in level `warn` with the error (to align with Azure log level).
5. Add unit tests for the new functions in `cloud_utils.js` with the Jest framework (generated by AI).
6. Added a timeout for the list buckets on GCP (`GOOGLE` and `GOOGLE_STS`) after a comment from CodeRabbit - [link1](https://github.com/noobaa/noobaa-core/pull/9644#discussion_r3304836574), [link2](https://github.com/noobaa/noobaa-core/pull/9644#discussion_r3304836585) (reusing constants that were defined in the files). 

Note: in the code comments, I mentioned "AIP-4117 External Account Credentials (Workload Identity Federation)" - attaching the [link](https://google.aip.dev/auth/4117).

### Issues:
List of GAPs:
1. All the files that are related to GCP WIF have not been changed yet:
- `object_sdk.js` - this part was not updated yet
https://github.com/noobaa/noobaa-core/blob/06da0fae5cc9f66c9f30fe2bd2e5c62f918b87fc/src/sdk/object_sdk.js#L563-L574
- `namespace_monitor` did update the new type yet, currently added a comment in this PR
 https://github.com/noobaa/noobaa-core/blob/06da0fae5cc9f66c9f30fe2bd2e5c62f918b87fc/src/server/bg_services/namespace_monitor.js#L70-L71
2. Backingstore changes were not tested yet, and would need additional PR in the operator, and then can be tested, meaning these files: `agent.js`, `block_store_client.js`, `block_store_google.js`.
3. As part of testing the permission, I found an `UnhandledPromiseRejectionWarning` that is addressed in PR #9664 .

### Testing Instructions:
#### Unit Tests
1. Please run: `npx jest src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js`

#### Manual Tests
More details can be found in [comment](https://github.com/noobaa/noobaa-core/pull/9644#issuecomment-4542098238.)
1. Deploy NooBaa on Minikube after adding GCP WIF configurations - see guide "Create GCP WIF (STS) Setup On Minikube With NooBaa" ([link](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/create_gcp_wif_setup_on_minikube_with_noobaa.md)).
2. Test the API of `check_external_connection`:
a. Using a created secret file (with external account) on `GOOGLE_STS` type (should succeed).
b. Using downloaded keys from Google service account (regression test) on type `GOOGLE` (should succeed).
4. Test the newly added timeout on GCP WIF (STS)
a. Account Server
(1) Retest the account server api call `check_external_connection` with the suggested timeout (should succeed).
(2) Change the timeout to 3 seconds and retest (should fail).
b. Bucket Server
(1) Retest the account server api method `get_cloud_buckets` with the suggested timeout (should succeed).
(2) Change the timeout to 3 seconds and retest (should fail).


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Workload Identity Federation (GOOGLE_STS) and mapped it into existing Google block storage flows.
  * Added a configurable external-bucket listing timeout setting.

* **Schema Updates**
  * Extended config and API schemas to validate and expose GOOGLE_STS across pools, namespaces, accounts, endpoints, and stats.

* **Improvements**
  * Unified Google credential handling to accept both service-account and external-account (STS/WIF) credentials; unified connection checks and bucket listing with timeout handling.

* **Tests**
  * Added unit tests for Google credential parsing, detection, and client construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noobaa/noobaa-core/pull/9644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->