### PR TITLE
[Backport to 5.16] db_cleaner, md_store - don't use executeSQL (df 6821)

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -878,7 +878,7 @@ class MDStore {
         FROM ${this._objects.name}
         WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed') 
         LIMIT ${query_limit};`;
-        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()]);
+        const result = await this._objects.single_query(query, [new Date(max_delete_time).toISOString()]);
         return db_client.instance().uniq_ids(result.rows, '_id');
     }
 


### PR DESCRIPTION
### Describe the Problem
Commit https://github.com/noobaa/noobaa-core/commit/ef2b2583b72eebc068aa3a73dea4827a5462f96f uses executeSQL(), but this new function was added in 22 and was not part of the cherry-picked backport.

Symptom is that db_cleaner fails to clean md_store.

### Explain the Changes
1. Switch executeSQL() to single_query().

### Issues: Fixed #xxx / Gap #xxx
1. [DFBUGS-7030](https://redhat.atlassian.net/browse/DFBUGS-7030)

### Testing Instructions:
1. Tested by removing db_cleaner limitations to clean md_store and then just running core pod.


- [ ] Doc added/updated
- [ ] Tests added
