### PR TITLE
[Backport to 5.18] db_cleaner, md_store - don't use executeSQL (df 6821)

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -889,7 +889,7 @@ class MDStore {
         FROM ${this._objects.name}
         WHERE (to_ts(data->>'deleted')<to_ts($1) and data ? 'deleted' and data ? 'reclaimed')
         LIMIT ${query_limit};`;
-        const result = await this._objects.executeSQL(query, [new Date(max_delete_time).toISOString()]);
+        const result = await this._objects.single_query(query, [new Date(max_delete_time).toISOString()]);
         return db_client.instance().uniq_ids(result.rows, '_id');
     }
 


### PR DESCRIPTION
see https://github.com/noobaa/noobaa-core/pull/9646