### PR TITLE
[Backport into 5.17] Add error handler to the Azure stream to catch AbortError

### DIFF
--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -234,6 +234,12 @@ class NamespaceBlob {
                     inspect(_.omit(params, 'object_md.ns')),
                     'callback res', inspect(res)
                 );
+                // Add error handler to the Azure stream to catch AbortError
+                res.readableStreamBody?.on('error', stream_err => {
+                    dbg.error('NamespaceBlob.read_object_stream: Azure stream error:', stream_err.name, stream_err.message);
+                    // Destroy count_stream with error - properly cleans up and propagates error
+                    count_stream.destroy(stream_err);
+                });
                 if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 return resolve(res.readableStreamBody.pipe(count_stream));
             }).catch(err => {

--- a/src/sdk/namespace_blob.js
+++ b/src/sdk/namespace_blob.js
@@ -234,13 +234,13 @@ class NamespaceBlob {
                     inspect(_.omit(params, 'object_md.ns')),
                     'callback res', inspect(res)
                 );
+                if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 // Add error handler to the Azure stream to catch AbortError
-                res.readableStreamBody?.on('error', stream_err => {
+                res.readableStreamBody.on('error', stream_err => {
                     dbg.error('NamespaceBlob.read_object_stream: Azure stream error:', stream_err.name, stream_err.message);
                     // Destroy count_stream with error - properly cleans up and propagates error
                     count_stream.destroy(stream_err);
                 });
-                if (!res.readableStreamBody) throw new Error('NamespaceBlob.read_object_stream: download response is invalid');
                 return resolve(res.readableStreamBody.pipe(count_stream));
             }).catch(err => {
                     this._translate_error_code(err);


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. [Backport into 5.17] Add error handler to the Azure stream to catch AbortError

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6744

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
