### PR TITLE
vectors - prevent deletion of NSS if it used by a vector bucket (df 6947, take 2)

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1296,7 +1296,8 @@ function check_resource_pool_deletion(pool) {
 function check_namespace_resource_deletion(ns) {
     //Verify namespace resource is not used by any namespace bucket
     const buckets = get_associated_buckets_ns(ns);
-    if (buckets.length) {
+    const vector_buckets = get_associated_vector_buckets_ns(ns);
+    if (buckets.length || vector_buckets.length) {
         return 'IN_USE';
     }
 }
@@ -1309,6 +1310,14 @@ function get_associated_buckets_ns(ns) {
     });
 
     return _.map(associated_buckets, 'name');
+}
+
+function get_associated_vector_buckets_ns(ns) {
+    const associated_vector_buckets = _.filter(ns.system.vector_buckets_by_name, vector_bucket =>
+        (String(vector_bucket.namespace_resource?.resource?._id) === String(ns._id))
+    );
+
+    return _.map(associated_vector_buckets, 'name');
 }
 
 function _is_cloud_pool(pool) {


### PR DESCRIPTION
### Describe the Problem
NSS that is used by a vector bucket can be deleted.
Check that NSS is not used by a vector bucket before deletion.
If it used, don't delete.
This is similar behaviour to trying to delete NSS that is used by an object bucket.

This is a second fix for 6947.
(first was https://github.com/noobaa/noobaa-core/pull/9643)

### Explain the Changes
1. Check if NSS is being used by a vector bucket. If so, don't delete.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-6947

### Testing Instructions:
1. Create NSS.
2. Create vector bucket using above NSS.
3. Delete NSS, should fail.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace deletion safety: deletion is now blocked when a namespace is referenced by any bucket type (including associated vector buckets), preventing accidental removal and providing clearer feedback (marked as in-use).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->