### PR TITLE
Replacing http/s-proxy-agent with nodeJS (>v24.5) native proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,6 @@
         "getos": "3.2.1",
         "glob-to-regexp": "0.4.1",
         "heapdump": "0.3.15",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
         "ldapts": "8.1.8",
@@ -226,6 +224,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
       "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -803,6 +802,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -864,6 +864,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -1081,6 +1082,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2938,7 +2940,6 @@
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3019,16 +3020,14 @@
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -3838,6 +3837,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3968,7 +3968,6 @@
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
@@ -3990,7 +3989,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4000,8 +3998,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4016,7 +4013,6 @@
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4438,6 +4434,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4638,7 +4635,6 @@
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -4825,7 +4821,6 @@
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -4842,7 +4837,6 @@
       "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -4859,7 +4853,6 @@
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -4870,7 +4863,6 @@
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -5424,6 +5416,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6052,7 +6045,6 @@
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -6107,8 +6099,7 @@
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
       "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -7343,6 +7334,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -7982,7 +7974,6 @@
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -8219,8 +8210,7 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -9274,6 +9264,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -11194,7 +11185,6 @@
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -11209,7 +11199,6 @@
       "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -11614,6 +11603,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11628,7 +11618,6 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11908,7 +11897,6 @@
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/package.json
+++ b/package.json
@@ -94,8 +94,6 @@
     "getos": "3.2.1",
     "glob-to-regexp": "0.4.1",
     "heapdump": "0.3.15",
-    "http-proxy-agent": "7.0.2",
-    "https-proxy-agent": "7.0.6",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "ldapts": "8.1.8",

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -4,8 +4,6 @@
 const _ = require('lodash');
 const http = require('http');
 const https = require('https');
-const { HttpProxyAgent } = require('http-proxy-agent');
-const { HttpsProxyAgent } = require('https-proxy-agent');
 const { S3ClientSDKV2 } = require('./noobaa_s3_client_sdkv2');
 const { S3ClientAutoRegion } = require('./noobaa_s3_client_sdkv3');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
@@ -90,11 +88,11 @@ function replace_field(params, remove_field, add_field) {
 // This function was created based on the use of http_utils.get_unsecured_agent
 function get_requestHandler_with_suitable_agent(endpoint) {
     const agent = http_utils.get_agent_by_endpoint(endpoint);
-    if (agent instanceof https.Agent || agent instanceof HttpsProxyAgent) {
+    if (agent instanceof https.Agent) {
         return new NodeHttpHandler({
             httpsAgent: agent
         });
-    } else if (agent instanceof http.Agent || agent instanceof HttpProxyAgent) {
+    } else if (agent instanceof http.Agent) {
         return new NodeHttpHandler({
             httpAgent: agent
         });

--- a/src/test/unit_tests/util_functions_tests/test_http_utils.proxy.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_http_utils.proxy.test.js
@@ -1,0 +1,153 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const http = require('http');
+const https = require('https');
+
+const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
+
+/**
+ * Load a fresh http_utils module after applying env overrides.
+ * Agents and no_proxy_list are built at require time.
+ * @param {Record<string, string|undefined>} env
+ */
+function load_http_utils_with_env(env) {
+    jest.resetModules();
+    for (const key of PROXY_ENV_KEYS) {
+        if (env[key] === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = env[key];
+        }
+    }
+    return require('../../../util/http_utils');
+}
+
+describe('http_utils - proxy and NO_PROXY', () => {
+    const original_env = {};
+
+    beforeAll(() => {
+        for (const key of PROXY_ENV_KEYS) {
+            original_env[key] = process.env[key];
+        }
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+        for (const key of PROXY_ENV_KEYS) {
+            if (original_env[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = original_env[key];
+            }
+        }
+        require('../../../util/http_utils');
+    });
+
+    describe('should_proxy', () => {
+        const cases = [
+            {
+                name: 'FQDN exact match bypasses proxy',
+                no_proxy: 'internal.example.com',
+                hostname: 'internal.example.com',
+                expect_proxy: false,
+            },
+            {
+                name: 'FQDN suffix match bypasses proxy',
+                no_proxy: '.suffix',
+                hostname: 'app.suffix',
+                expect_proxy: false,
+            },
+            {
+                name: 'CIDR match bypasses proxy for IP hostname',
+                no_proxy: '10.0.0.0/8',
+                hostname: '10.1.2.3',
+                expect_proxy: false,
+            },
+            {
+                name: 'IP exact match bypasses proxy',
+                no_proxy: '192.168.1.10',
+                hostname: '192.168.1.10',
+                expect_proxy: false,
+            },
+            {
+                name: 'host outside NO_PROXY uses proxy',
+                no_proxy: '10.0.0.0/8,internal.example.com',
+                hostname: 'external.example.com',
+                expect_proxy: true,
+            },
+            {
+                name: 'IP outside CIDR uses proxy',
+                no_proxy: '10.0.0.0/8',
+                hostname: '192.168.0.1',
+                expect_proxy: true,
+            },
+        ];
+
+        it.each(cases)('$name', ({ no_proxy, hostname, expect_proxy }) => {
+            const http_utils = load_http_utils_with_env({ NO_PROXY: no_proxy });
+            expect(http_utils.should_proxy(hostname)).toBe(expect_proxy);
+        });
+
+        it('returns true when NO_PROXY is unset', () => {
+            const http_utils = load_http_utils_with_env({ NO_PROXY: undefined });
+            expect(http_utils.should_proxy('any.example.com')).toBe(true);
+        });
+    });
+
+    describe('agent selection via proxyEnv', () => {
+        const http_proxy_url = 'http://proxy.test.invalid:8080';
+        const https_proxy_url = 'http://proxy.test.invalid:8443';
+
+        it('uses HTTP proxy agent when HTTP_PROXY is set and host is not bypassed', () => {
+            const http_utils = load_http_utils_with_env({
+                HTTP_PROXY: http_proxy_url,
+                NO_PROXY: undefined,
+            });
+            const agent = http_utils.get_default_agent('http://external.example.com');
+            expect(agent).toBeInstanceOf(http.Agent);
+            expect(agent.options.proxyEnv).toEqual({ HTTP_PROXY: http_proxy_url });
+        });
+
+        it('uses direct HTTP agent when host matches NO_PROXY', () => {
+            const http_utils = load_http_utils_with_env({
+                HTTP_PROXY: http_proxy_url,
+                NO_PROXY: 'external.example.com',
+            });
+            const agent = http_utils.get_default_agent('http://external.example.com');
+            expect(agent).toBeInstanceOf(http.Agent);
+            expect(agent.options.proxyEnv).toBeUndefined();
+        });
+
+        it('uses HTTPS proxy agent when HTTPS_PROXY is set and host is not bypassed', () => {
+            const http_utils = load_http_utils_with_env({
+                HTTPS_PROXY: https_proxy_url,
+                NO_PROXY: undefined,
+            });
+            const agent = http_utils.get_default_agent('https://external.example.com');
+            expect(agent).toBeInstanceOf(https.Agent);
+            expect(agent.options.proxyEnv).toEqual({ HTTPS_PROXY: https_proxy_url });
+        });
+
+        it('uses direct HTTPS agent when CIDR NO_PROXY matches IP hostname', () => {
+            const http_utils = load_http_utils_with_env({
+                HTTPS_PROXY: https_proxy_url,
+                NO_PROXY: '10.0.0.0/8',
+            });
+            const agent = http_utils.get_default_agent('https://10.1.2.3');
+            expect(agent).toBeInstanceOf(https.Agent);
+            expect(agent.options.proxyEnv).toBeUndefined();
+        });
+
+        it('uses unsecured HTTPS proxy agent for custom HTTPS host with HTTPS_PROXY', () => {
+            const http_utils = load_http_utils_with_env({
+                HTTPS_PROXY: https_proxy_url,
+                NO_PROXY: undefined,
+            });
+            const agent = http_utils.get_unsecured_agent('https://backend.test.invalid:9000');
+            expect(agent).toBeInstanceOf(https.Agent);
+            expect(agent.options.rejectUnauthorized).toBe(false);
+            expect(agent.options.proxyEnv).toEqual({ HTTPS_PROXY: https_proxy_url });
+        });
+    });
+});

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -11,8 +11,6 @@ const https = require('https');
 const crypto = require('crypto');
 const xml2js = require('xml2js');
 const querystring = require('querystring');
-const { HttpProxyAgent } = require('http-proxy-agent');
-const { HttpsProxyAgent } = require('https-proxy-agent');
 
 const dbg = require('./debug_module')(__filename);
 const config = require('../../config');
@@ -51,13 +49,40 @@ const https_agent = new https.Agent({
     ].filter(Boolean))
 });
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false, keepAlive: true });
-const http_proxy_agent = HTTP_PROXY ?
-    new HttpProxyAgent(HTTP_PROXY, { keepAlive: true }) : null;
-const https_proxy_agent = HTTPS_PROXY ?
-    new HttpsProxyAgent(HTTPS_PROXY, { keepAlive: true }) : null;
-const unsecured_https_proxy_agent = HTTPS_PROXY ?
-    new HttpsProxyAgent(HTTPS_PROXY, { rejectUnauthorized: false, keepAlive: true }) : null;
 
+/** proxyEnv map for native http.Agent when HTTP_PROXY is set, otherwise null */
+const proxy_env_http = HTTP_PROXY ? { HTTP_PROXY } : null;
+
+/** proxyEnv map for native https.Agent when HTTPS_PROXY is set, otherwise null */
+const proxy_env_https = HTTPS_PROXY ? { HTTPS_PROXY } : null;
+
+/** Shared http.Agent for proxied plain HTTP requests (null if HTTP_PROXY unset) */
+const http_proxy_agent = proxy_env_http ?
+    new http.Agent({ keepAlive: true, proxyEnv: proxy_env_http }) : null;
+
+/** Shared https.Agent for proxied HTTPS with the same CA bundle as https_agent */
+const https_proxy_agent = proxy_env_https ?
+    new https.Agent({
+        keepAlive: true,
+        ca: https_agent.options.ca,
+        proxyEnv: proxy_env_https,
+    }) : null;
+
+/** Shared https.Agent for proxied HTTPS without TLS verification on the target */
+const unsecured_https_proxy_agent = proxy_env_https ?
+    new https.Agent({
+        rejectUnauthorized: false,
+        keepAlive: true,
+        proxyEnv: proxy_env_https,
+    }) : null;
+
+/**
+ * Parsed bypass list from the NO_PROXY environment variable (comma-separated).
+ * Hostnames that match an entry are not sent through HTTP_PROXY or HTTPS_PROXY agents.
+ * Each entry is classified as exact FQDN, FQDN suffix (leading dot), literal IP, or CIDR.
+ * Matching is done in should_proxy() when _get_http_agent() selects direct vs proxy agents.
+ * NO_PROXY is not passed to native proxyEnv so NooBaa keeps CIDR and suffix rules here.
+ */
 const no_proxy_list = (NO_PROXY ? NO_PROXY.split(',') : []).map(addr => {
     let kind = 'FQDN';
     if (net.isIPv4(addr) || net.isIPv6(addr)) {
@@ -544,7 +569,7 @@ function get_unsecured_agent(endpoint) {
  * 
  * @param {string} endpoint 
  * @param {boolean} request_unsecured 
- * @returns {https.Agent | http.Agent | HttpsProxyAgent | HttpProxyAgent}
+ * @returns {https.Agent | http.Agent}
  */
 function _get_http_agent(endpoint, request_unsecured) {
     const { protocol, hostname } = url.parse(endpoint);


### PR DESCRIPTION
### Explain the Changes
Replacing http/s-proxy-agent with nodeJS (>v24.5) native proxy

- Removing "http-proxy-agent": "7.0.2",
- Removing"https-proxy-agent": "7.0.6"
- Adding some jest tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed proxy-agent dependencies and switched proxy handling to native Node HTTP/HTTPS agents for more consistent network behavior.
  * Expanded NO_PROXY semantics and documentation (CIDR, hostname suffix and exact-match rules).

* **Tests**
  * Added comprehensive unit tests for proxy/no-proxy behavior, CIDR/hostname matching, and agent selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->