### PR TITLE
fix null timing in nsfs op metrics

### DIFF
--- a/src/test/unit_tests/util_functions_tests/test_stats_collector_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_stats_collector_utils.test.js
@@ -1,0 +1,192 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const { update_nsfs_stats, op_names } = require('../../../util/stats_collector_utils');
+
+/** @param {Record<string, unknown>} entry */
+function expect_finite_timing(entry) {
+    for (const field of ['min_time_milisec', 'max_time_milisec', 'avg_time_milisec']) {
+        expect(entry[field]).not.toBeNull();
+        expect(entry[field]).not.toBeUndefined();
+        expect(Number.isFinite(entry[field])).toBe(true);
+    }
+}
+
+describe('stats_collector_utils.update_nsfs_stats', () => {
+
+    it('does not create stats for an error-only initial batch', () => {
+        const op_name = 'upload_object';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+        update_nsfs_stats(op_name, stats, {
+            count: 1,
+            error_count: 1,
+            min_time: undefined,
+            max_time: undefined,
+            sum_time: undefined,
+        });
+        expect(stats[op_name]).toBeUndefined();
+    });
+
+    it('initializes timing from a successful-only batch', () => {
+        const op_name = 'create_bucket';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+        update_nsfs_stats(op_name, stats, {
+            count: 2,
+            error_count: 0,
+            min_time: 10,
+            max_time: 50,
+            sum_time: 60,
+        });
+        expect(stats[op_name]).toEqual({
+            min_time_milisec: 10,
+            max_time_milisec: 50,
+            avg_time_milisec: 30, // (min_time + max_time) / 2
+            count: 2,
+            error_count: 0,
+        });
+        expect_finite_timing(stats[op_name]);
+    });
+
+    it('initializes timing from a mixed batch using successful-op count only', () => {
+        const op_name = 'list_objects';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+        update_nsfs_stats(op_name, stats, {
+            count: 3,
+            error_count: 1,
+            min_time: 10,
+            max_time: 50,
+            sum_time: 80,
+        });
+        expect(stats[op_name]).toEqual({
+            min_time_milisec: 10,
+            max_time_milisec: 50,
+            avg_time_milisec: 40, // (sum_time / (count - error_count))
+            count: 3,
+            error_count: 1,
+        });
+        expect_finite_timing(stats[op_name]);
+    });
+
+    it('keeps timing metrics when merging an error-only batch after successes', () => {
+        const op_name = 'create_bucket';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+
+        //initial batch with successful ops
+        update_nsfs_stats(op_name, stats, {
+            count: 2,
+            error_count: 0,
+            min_time: 10,
+            max_time: 50,
+            sum_time: 60,
+        });
+
+        //error-only batch - should not update the stats
+        update_nsfs_stats(op_name, stats, {
+            count: 1,
+            error_count: 1,
+            min_time: undefined,
+            max_time: undefined,
+            sum_time: undefined,
+        });
+
+        expect(stats[op_name]).toEqual({
+            min_time_milisec: 10,
+            max_time_milisec: 50,
+            avg_time_milisec: 30,
+            count: 3,
+            error_count: 1,
+        });
+        expect_finite_timing(stats[op_name]);
+    });
+
+    it('merges successive successful batches with a weighted average', () => {
+        const op_name = 'head_object';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+
+        //initial batch with successful ops
+        update_nsfs_stats(op_name, stats, {
+            count: 2,
+            error_count: 0,
+            min_time: 10,
+            max_time: 50,
+            sum_time: 60,
+        });
+
+        //second batch with successful ops
+        update_nsfs_stats(op_name, stats, {
+            count: 1,
+            error_count: 0,
+            min_time: 15,
+            max_time: 20,
+            sum_time: 20,
+        });
+
+        expect(stats[op_name]).toEqual({
+            min_time_milisec: 10,
+            max_time_milisec: 50,
+            avg_time_milisec: 26, // ((sum_time of initial batch + sum_time of second batch) / (count of initial batch + count of second batch))
+            count: 3,
+            error_count: 0,
+        });
+        expect_finite_timing(stats[op_name]);
+    });
+
+    it('merges a mixed batch into existing stats without NaN timing fields', () => {
+        const op_name = 'read_object';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+        update_nsfs_stats(op_name, stats, {
+            count: 2,
+            error_count: 0,
+            min_time: 10,
+            max_time: 50,
+            sum_time: 60,
+        });
+        update_nsfs_stats(op_name, stats, {
+            count: 2,
+            error_count: 1,
+            min_time: 5,
+            max_time: 100,
+            sum_time: 100,
+        });
+
+        expect(stats[op_name]).toEqual({
+            min_time_milisec: 5,
+            max_time_milisec: 100,
+            avg_time_milisec: 53, // ((sum_time of initial batch + sum_time of second batch) / (count of initial batch + count of second batch))
+            count: 4,
+            error_count: 1,
+        });
+        expect_finite_timing(stats[op_name]);
+    });
+
+    it('treats undefined sum_time in error-only batches as zero when recomputing average', () => {
+        const op_name = 'delete_object';
+        expect(op_names).toContain(op_name);
+        const stats = {};
+        update_nsfs_stats(op_name, stats, {
+            count: 1,
+            error_count: 0,
+            min_time: 100,
+            max_time: 100,
+            sum_time: 100,
+        });
+        update_nsfs_stats(op_name, stats, {
+            count: 1,
+            error_count: 1,
+            min_time: undefined,
+            max_time: undefined,
+            sum_time: undefined,
+        });
+
+        expect(stats[op_name].avg_time_milisec).toBe(100);
+        expect(stats[op_name].count).toBe(2);
+        expect(stats[op_name].error_count).toBe(1);
+        expect_finite_timing(stats[op_name]);
+    });
+});

--- a/src/util/stats_collector_utils.js
+++ b/src/util/stats_collector_utils.js
@@ -36,12 +36,17 @@ function update_nsfs_stats(op_name, stats, new_data) {
     if (stats[op_name]) {
         const count = stats[op_name].count + new_data.count;
         const error_count = stats[op_name].error_count + new_data.error_count;
-        const old_sum_time = stats[op_name].avg_time_milisec * stats[op_name].count;
+        const prev_success_count = stats[op_name].count - stats[op_name].error_count;
+        const old_sum_time = stats[op_name].avg_time_milisec * prev_success_count;
         //Min time and Max time are not being counted in the endpoint stat collector if it was error
-        const min_time_milisec = Math.min(stats[op_name].min_time_milisec, new_data.min_time);
-        const max_time_milisec = Math.max(stats[op_name].max_time_milisec, new_data.max_time);
+        const min_time_milisec = (new_data.count - new_data.error_count) > 0 ?
+                                    Math.min(stats[op_name].min_time_milisec, new_data.min_time) :
+                                    stats[op_name].min_time_milisec;
+        const max_time_milisec = (new_data.count - new_data.error_count) > 0 ?
+                                    Math.max(stats[op_name].max_time_milisec, new_data.max_time) :
+                                    stats[op_name].max_time_milisec;
         // At this point, as we populate only when there is at least one successful op, there must be old_sum_time
-        const avg_time_milisec = Math.floor((old_sum_time + new_data.sum_time) / (count - error_count));
+        const avg_time_milisec = Math.floor((old_sum_time + (new_data.sum_time ?? 0)) / (count - error_count));
         stats[op_name] = {
             min_time_milisec,
             max_time_milisec,
@@ -55,7 +60,7 @@ function update_nsfs_stats(op_name, stats, new_data) {
         stats[op_name] = {
             min_time_milisec: new_data.min_time,
             max_time_milisec: new_data.max_time,
-            avg_time_milisec: Math.floor(new_data.sum_time / new_data.count),
+            avg_time_milisec: Math.floor(new_data.sum_time / (new_data.count - new_data.error_count)),
             count: new_data.count,
             error_count: new_data.error_count,
         };


### PR DESCRIPTION
### Describe the Problem
https://redhat.atlassian.net/browse/DFBUGS-7012
Some of the metrics values were coming as null (in_time_milisec, max_time_milisec, avg_time_milisec)
Reason: In some error batches (no success), the min_time, max_time and sum_time are coming as undefined 
Hence, in update_nsfs_stats Math.min/Math.max with undefined produce NaN 

### Explain the Changes
1. Skip min/max updates when no success ops
2. Handle undefined values
3. Compute average over successful ops only (count - error_count) on first batch init and when deriving old_sum_time from previous stats.

### Issues: Fixed #DFBUGS-7012 / Gap #xxx
1. Fixed null NSFS op timing metrics when error-only stat batches are merged after successful operations.

### Testing Instructions:
1. Start NSFS 
`node --unhandled-rejections=warn src/cmd/nsfs.js --config_root $CONFIG_ROOT --debug=5`
2. Create 2 buckets successfully.
`aws s3 mb s3://mtest-a --endpoint-url 'https://[::1]:6443' --no-verify-ssl`
`aws s3 mb s3://mtest-b --endpoint-url 'https://[::1]:6443' --no-verify-ssl`
3. Wait ≥12s (stats flush interval).
4. Attempt to create one of the same buckets again (expect error).
`aws s3 mb s3://mtest-a --endpoint-url 'https://[::1]:6443' --no-verify-ssl`
5.Wait ≥12s, then scrape metrics:
`curl -sk 'https://<host>:9443/metrics/nsfs_stats' | jq '.op_stats_counters | with_entries(select(.key | startswith("noobaa_nsfs_op_create_bucket")))'
`


- [ ] Doc added/updated
- [x] Tests added
Specific file test run:
`npx jest src/test/unit_tests/util_functions_tests/test_stats_collector_utils.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Average operation times now exclude failed operations when computing aggregates for more accurate performance metrics.
  * Min/max timing updates only apply when incoming data includes at least one successful operation, preserving prior values otherwise.
  * Initial metric population computes averages using successful-operation counts to avoid skew from failures.

* **Tests**
  * Added unit tests covering initialization, merging, error-only batches, weighted averages, and handling of missing timing sums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->