### PR TITLE
[NC | NSFS] Fix list_uploads crash on buckets with no multipart uploads

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1744,7 +1744,21 @@ class NamespaceFS {
         await this._load_bucket(params, fs_context);
         const mpu_root_path = this._mpu_root_path();
         await this._check_path_in_bucket_boundaries(fs_context, mpu_root_path);
-        const multipart_upload_dirs = await nb_native().fs.readdir(fs_context, mpu_root_path);
+        let multipart_upload_dirs;
+        try {
+            multipart_upload_dirs = await nb_native().fs.readdir(fs_context, mpu_root_path);
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                return {
+                    objects: [],
+                    common_prefixes: [],
+                    is_truncated: false,
+                    next_marker: undefined,
+                    next_upload_id_marker: undefined,
+                };
+            }
+            throw err;
+        }
         const common_prefixes_set = new Set();
         const multipart_uploads = await P.map(multipart_upload_dirs, async obj => {
             const create_path = path.join(mpu_root_path, obj.name, 'create_object_upload');


### PR DESCRIPTION
### Describe the Problem
  - list_uploads() in namespace_fs.js crashes with a 500 InternalError when called on a bucket that has never had a multipart upload, because the multipart-uploads directory doesn't exist yet
  - The directory is only created lazily by create_object_upload(), so readdir() throws ENOENT on empty buckets

### Explain the Changes
Wraps the `readdir` call with an ENOENT guard that returns an empty listing instead of crashing.

### Issues: Fixed #xxx / Gap #xxx
1. https://github.ibm.com/Tier2/Test-Issue/issues/328

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload listing resilience: when the multipart-uploads root is missing, the system now returns an empty, non-truncated listing (no objects or prefixes and no next markers) instead of raising an error. Other errors still surface as before — preventing unnecessary failures in upload-listing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->