### PR TITLE
Deep Archive | Bucket API & Schema changes

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -30,6 +30,7 @@ module.exports = {
                     tag: { type: 'string' },
                     object_lock_configuration: { $ref: 'common_api#/definitions/object_lock_configuration' },
                     namespace: { $ref: '#/definitions/namespace_bucket_config' },
+                    archive_policy: { $ref: '#/definitions/archive_policy' },
                     lock_enabled: {
                         type: 'boolean'
                     },
@@ -1264,6 +1265,7 @@ module.exports = {
                 owner_account: {$ref: '#/definitions/owner_account'},
                 versioning: { $ref: 'common_api#/definitions/versioning' },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
+                archive_policy: { $ref: '#/definitions/archive_policy' },
                 bucket_claim: { $ref: 'common_api#/definitions/bucket_claim' },
                 logging: { $ref: 'common_api#/definitions/bucket_logging' },
                 force_md5_etag: {
@@ -1676,6 +1678,13 @@ module.exports = {
             }
         },
 
+        archive_policy: {
+            type: 'object',
+            required: ['deep_archive_resource'],
+            properties: {
+                deep_archive_resource: { $ref: '#/definitions/namespace_resource_config' }
+            }
+        },
 
         replication_policy: {
             type: 'object',

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -354,6 +354,9 @@ async function create_bucket(req) {
                 should_create_underlying_storage
             };
         }
+        if (req.rpc_params.archive_policy) {
+            bucket.archive_policy = resolve_archive_policy(req);
+        }
         if (req.rpc_params.bucket_claim) {
             // TODO: Should implement validity checks
             bucket.bucket_claim = req.rpc_params.bucket_claim;
@@ -1001,6 +1004,25 @@ function get_bucket_changes_quota(req, bucket, quota_config, single_bucket_updat
 }
 
 /**
+ * Resolves an archive_policy from the API representation to the DB representation.
+ * deep_archive_resource is a namespace_resource_config {resource: name, path?} in the API,
+ * and an equivalent namespace resource db config {resource: ObjectId, path?} in the DB.
+ * Throws INVALID_ARCHIVE_RESOURCE if the named namespace resource does not exist.
+ */
+function resolve_archive_policy(req) {
+    const archive_policy = req.rpc_params.archive_policy;
+    if (!archive_policy.deep_archive_resource) {
+        throw new RpcError('INVALID_ARCHIVE_POLICY', `Archive policy missing deep archive resource`);
+    }
+    const { resource: resource_name, path: resource_path } = archive_policy.deep_archive_resource;
+    const nsr = req.system.namespace_resources_by_name && req.system.namespace_resources_by_name[resource_name];
+    if (!nsr) {
+        throw new RpcError('INVALID_ARCHIVE_RESOURCE', `Namespace resource not found: ${resource_name}`);
+    }
+    return { deep_archive_resource: { resource: nsr._id, path: resource_path } };
+}
+
+/**
  *
  * GET_BUCKET_UPDATE
  *
@@ -1624,6 +1646,12 @@ function get_bucket_info({
                 ({ resource: pool_server.get_namespace_resource_info(rs.resource).name, path: rs.path })
             ),
             should_create_underlying_storage: bucket.namespace.should_create_underlying_storage
+        } : undefined,
+        archive_policy: bucket.archive_policy ? {
+            deep_archive_resource: {
+                resource: pool_server.get_namespace_resource_info(bucket.archive_policy.deep_archive_resource.resource).name,
+                path: bucket.archive_policy.deep_archive_resource.path,
+            }
         } : undefined,
         tiering: tiering,
         tag: bucket.tag ? bucket.tag : '',

--- a/src/server/system_services/schemas/bucket_schema.js
+++ b/src/server/system_services/schemas/bucket_schema.js
@@ -120,6 +120,21 @@ module.exports = {
             }
         },
 
+        archive_policy: {
+            type: 'object',
+            required: ['deep_archive_resource'],
+            properties: {
+                deep_archive_resource: {
+                    type: 'object',
+                    required: ['resource'],
+                    properties: {
+                        resource: { objectid: true }, // namespace resource id
+                        path: { type: 'string' },
+                    }
+                },
+            }
+        },
+
         force_md5_etag: {
             type: 'boolean' // enable md5 calculation per bucket
         },


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Added archive_policy to bucket_schema and bucket_api.create_bucket().
2. Added archive_policy setting to bucket_server.create_bucket().

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buckets now support archive policies: specify a deep-archive resource and path when creating a bucket, and archive policy details (resource name and path) are returned in bucket info.
  * Bucket creation validates the referenced deep-archive resource and rejects invalid or missing references with clear error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->