### PR TITLE
[Glacier] Fix multi node concurrent runs issue

### DIFF
--- a/src/manage_nsfs/manage_nsfs_glacier.js
+++ b/src/manage_nsfs/manage_nsfs_glacier.js
@@ -12,30 +12,35 @@ const { is_desired_time, record_current_time } = require('./manage_nsfs_cli_util
 async function process_migrations() {
     const fs_context = native_fs_utils.get_process_fs_context();
     const backend = Glacier.getBackend();
+    const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_TIMESTAMP_FILE);
 
-    if (
-        await backend.low_free_space() ||
-        await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, Glacier.MIGRATE_TIMESTAMP_FILE) ||
-        await migrate_log_exceeds_threshold()
-    ) {
+    if (await backend.low_free_space()) {
         await backend.perform(prepare_galcier_fs_context(fs_context), "MIGRATION");
-        const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_TIMESTAMP_FILE);
         await record_current_time(fs_context, timestamp_file_path);
+        return;
     }
+
+    await backend.perform(prepare_galcier_fs_context(fs_context), "MIGRATION", {
+        should_run: async () => (
+            await time_exceeded(fs_context, config.NSFS_GLACIER_MIGRATE_INTERVAL, Glacier.MIGRATE_TIMESTAMP_FILE) ||
+            await migrate_log_exceeds_threshold()
+        ),
+        on_staged: async () => record_current_time(fs_context, timestamp_file_path),
+    });
 }
 
 async function process_restores() {
     const fs_context = native_fs_utils.get_process_fs_context();
     const backend = Glacier.getBackend();
-
-    if (
-        await backend.low_free_space() ||
-        !(await time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, Glacier.RESTORE_TIMESTAMP_FILE))
-    ) return;
-
-    await backend.perform(prepare_galcier_fs_context(fs_context), "RESTORE");
     const timestamp_file_path = path.join(config.NSFS_GLACIER_LOGS_DIR, Glacier.RESTORE_TIMESTAMP_FILE);
-    await record_current_time(fs_context, timestamp_file_path);
+
+    if (await backend.low_free_space()) return;
+
+    await backend.perform(prepare_galcier_fs_context(fs_context), "RESTORE", {
+        should_run: async () =>
+            time_exceeded(fs_context, config.NSFS_GLACIER_RESTORE_INTERVAL, Glacier.RESTORE_TIMESTAMP_FILE),
+        on_staged: async () => record_current_time(fs_context, timestamp_file_path),
+    });
 }
 
 async function process_expiry() {
@@ -105,13 +110,15 @@ async function time_exceeded(fs_context, interval, timestamp_file) {
 async function migrate_log_exceeds_threshold(threshold = config.NSFS_GLACIER_MIGRATE_LOG_THRESHOLD) {
     const log = new PersistentLogger(config.NSFS_GLACIER_LOGS_DIR, Glacier.MIGRATE_WAL_NAME, { locking: null });
     let log_size = Number.MAX_SAFE_INTEGER;
+    let fh;
     try {
-        const fh = await log._open();
-
+        fh = await log._open();
         const { size } = await fh.stat(log.fs_context);
         log_size = size;
     } catch (error) {
         console.error("failed to get size of", Glacier.MIGRATE_WAL_NAME, error);
+    } finally {
+        if (fh) await fh.close(log.fs_context);
     }
 
     return log_size > threshold;

--- a/src/sdk/glacier.js
+++ b/src/sdk/glacier.js
@@ -222,10 +222,16 @@ class Glacier {
     }
 
     /**
-     * @param {nb.NativeFSContext} fs_context 
-     * @param {"MIGRATION" | "RESTORE" | "EXPIRY" | "RECLAIM"} type 
+     * perform takes the type of action and "performs" it
+     * on any generic glacier backend type
+     * @param {nb.NativeFSContext} fs_context
+     * @param {"MIGRATION" | "RESTORE" | "EXPIRY" | "RECLAIM"} type
+     * @param {{
+     *   should_run?: () => Promise<boolean>,
+     *   on_staged?: () => Promise<void>,
+     * }} [options]
      */
-    async perform(fs_context, type) {
+    async perform(fs_context, type, options = {}) {
         const lock_path = lock_file => path.join(config.NSFS_GLACIER_LOGS_DIR, lock_file);
 
         if (type === 'EXPIRY') {
@@ -253,17 +259,28 @@ class Glacier {
         };
 
         /**
-         * @param {string} primary_log_ns 
-         * @param {string} staged_log_ns 
-         * @param {log_cb} process_staged_fn 
-         * @param {log_cb} process_primary_fn 
+         * @param {string} primary_log_ns
+         * @param {string} staged_log_ns
+         * @param {log_cb} process_staged_fn
+         * @param {log_cb} process_primary_fn
+         * @param {{
+         *   should_run?: () => Promise<boolean>,
+         *   on_staged?: () => Promise<void>,
+         * }} run_options
          */
-        const run_operation = async (primary_log_ns, staged_log_ns, process_staged_fn, process_primary_fn) => {
+        const run_operation = async (primary_log_ns, staged_log_ns, process_staged_fn, process_primary_fn, run_options = {}) => {
+            let should_proceed = true;
             // Acquire a cluster wide lock for all the operations for staging
             await native_fs_utils.lock_and_run(fs_context, lock_path(Glacier.GLACIER_CLUSTER_LOCK), async () => {
+                if (run_options.should_run && !(await run_options.should_run())) {
+                    should_proceed = false;
+                    return;
+                }
                 await process_glacier_logs(primary_log_ns, process_staged_fn);
+                if (run_options.on_staged) await run_options.on_staged();
             });
 
+            if (!should_proceed) return;
             await process_glacier_logs(staged_log_ns, process_primary_fn);
         };
 
@@ -273,6 +290,7 @@ class Glacier {
                 Glacier.MIGRATE_STAGE_WAL_NAME,
                 this.stage_migrate.bind(this),
                 this.migrate.bind(this),
+                options,
             );
         } else if (type === 'RESTORE') {
             await run_operation(
@@ -280,6 +298,7 @@ class Glacier {
                 Glacier.RESTORE_STAGE_WAL_NAME,
                 this.stage_restore.bind(this),
                 this.restore.bind(this),
+                options,
             );
         } else if (type === 'RECLAIM') {
             await process_glacier_logs(Glacier.RECLAIM_WAL_NAME, this.reclaim.bind(this));


### PR DESCRIPTION
### Describe the Problem
When multiple nodes try to run `manage_nsfs glacier migrate` concurrently, right now they all proceed to process the logs concurrently. This creates the problem that the log files are too small and not enough batching is being done by NooBaa.

### Explain the Changes
This PR adds the time and log size checks within the cluster lock to ensure that one node does the check at one time.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved staging and execution logic for migration and restore workflows to better coordinate when operations run.
  * Centralized operation orchestration now accepts optional gating and post-staging callbacks to control processing flow.

* **Bug Fixes**
  * Fixed a resource-management issue to ensure file descriptors are always released.
  * Added immediate low-space checks to avoid unnecessary work when storage is constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->