### PR TITLE
GetObjectRetention date handling fix

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1520,7 +1520,7 @@ module.exports = {
                     type: 'object',
                     properties: {
                         mode: { type: 'string' },
-                        retain_until_date: { date: true },
+                        retain_until_date: { idate: true },
                     }
                 },
                 legal_hold: {

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1320,7 +1320,7 @@ module.exports = {
                                 type: 'string',
                                 enum: ['GOVERNANCE', 'COMPLIANCE'],
                             },
-                            retain_until_date: { date: true },
+                            retain_until_date: { idate: true },
                         },
                     }
                 }

--- a/src/endpoint/s3/ops/s3_get_object_retention.js
+++ b/src/endpoint/s3/ops/s3_get_object_retention.js
@@ -18,6 +18,9 @@ async function get_object_retention(req) {
         version_id: s3_utils.parse_version_id(req.query.versionId)
     });
 
+    if (object_retention.retention && object_retention.retention.retain_until_date) {
+        object_retention.retention.retain_until_date = new Date(object_retention.retention.retain_until_date).toISOString();
+    }
     const parsed = s3_utils.parse_to_camel_case(object_retention);
     return parsed;
 }

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -316,7 +316,7 @@ function set_response_object_md(res, object_md) {
         }
         if (object_md.lock_settings.retention) {
             res.setHeader('x-amz-object-lock-mode', object_md.lock_settings.retention.mode);
-            res.setHeader('x-amz-object-lock-retain-until-date', object_md.lock_settings.retention.retain_until_date);
+            res.setHeader('x-amz-object-lock-retain-until-date', new Date(object_md.lock_settings.retention.retain_until_date).toISOString());
         }
     }
     if (object_md.version_id) res.setHeader('x-amz-version-id', object_md.version_id);

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -321,7 +321,7 @@ async function get_object_retention(req) {
 
     return {
         retention: {
-            retain_until_date: info.lock_settings.retention.retain_until_date,
+            retain_until_date: new Date(info.lock_settings.retention.retain_until_date).getTime(),
             mode: info.lock_settings.retention.mode
         }
     };


### PR DESCRIPTION
- Change RPC schema retain_until_date from { date: true } to { idate: true } in object_api.js and common_api.js to handle Postgres date serialization
- Return epoch ms via .getTime() from object_server.js get_object_retention
- Convert epoch ms to RFC3339 ISO string in s3_get_object_retention.js for XML response
- Format x-amz-object-lock-retain-until-date header as ISO string in s3_utils.js

Fixes: RHSTOR-7487

### Describe the Problem
1. Date format not RFC3339
AWS expects the x-amz-object-lock-retain-until-date header to look like 2026-06-10T00:00:00.000Z
The old code was returning the raw value from the database (could be a timestamp number like 1780746962889 or a Date object) directly into the HTTP header. Clients (like AWS SDK) couldn't parse this because it's not a valid date string.
2. When data comes from Postgres, retain_until_date is stored as a string or timestamp, not a native JS Date object. The RPC layer either silently corrupts it or throws a validation error
Fix: Change to { idate: true } which means "expect an integer (epoch milliseconds)". Then:
object_server.js does new Date(value).getTime() → sends a clean integer like 1780746962889
RPC serializes it fine (just a number, no type confusion)
s3_get_object_retention.js receives the integer and does new Date(integer).toISOString() → produces the RFC3339 string for the XML response


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized object retention `retain-until-date` handling so responses and the `retain-until-date` header consistently use ISO 8601 formatting.
  * Updated the object retention API schema to reflect the new date-format interpretation.
  * Adjusted returned retention values to match the expected timestamp representation across the object retention retrieval flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->