### PR TITLE
[Backport into 5.20] NooBaa upgrade failure due to remove_mongo_pool.js error

### DIFF
--- a/src/test/integration_tests/internal/test_upgrade_scripts.js
+++ b/src/test/integration_tests/internal/test_upgrade_scripts.js
@@ -143,7 +143,12 @@ mocha.describe('test upgrade scripts', async function() {
             if (e.name.startsWith(internal_storage_pool_name)) internal_pool_id = e._id;
             return e.name;
         });
-        dbg.info("Start : List all the pools in system @@@@: ", before_names, internal_pool_id);
+        try {
+            await remove_mongo_pool.run({ dbg, system_store });
+        } catch (err) {
+             assert(!err, 'There shouldnt be an error when there is no mongo_pool');
+        }
+
         if (!before_names.includes(internal_name)) {
             internal_pool_id = system_store.new_system_store_id();
             await system_store.make_changes({

--- a/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
+++ b/src/upgrade/upgrade_scripts/5.20.0/remove_mongo_pool.js
@@ -14,7 +14,7 @@ async function run({ dbg, system_store }) {
         dbg.log0(`Internal mongo pool id is : ${internal_mongo_pool}`);
         const mongo_pools = system_store.data.pools.filter(pool => (pool.mongo_info || pool.resource_type === 'INTERNAL'));
         if (mongo_pools.length === 0) {
-             dbg.log0(`Missing mongo pool: ${mongo_pools[0]._id}`);
+             dbg.log0(`Missing mongo pool, Skipping the upgrade script...`);
             return;
         }
 


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. [Backport into 5.20] NooBaa upgrade failure due to remove_mongo_pool.js error


### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-7196

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
