### PR TITLE
Object Lock: support PutObjectLockConfiguration on existing buckets

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1707,7 +1707,9 @@ module.exports = {
             properties: {
                 object_lock_enabled: {
                     type: 'string',
-                    enum: ['Enabled']
+                    // 'Disabled' is an internal bucket metadata state for non-locked buckets.
+                    // S3 PutObjectLockConfiguration still validates request payload as 'Enabled'.
+                    enum: ['Enabled', 'Disabled']
                 },
                 rule: {
                     type: 'object',

--- a/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
@@ -11,10 +11,10 @@ async function put_bucket_object_lock(req, res) {
     if (!config.WORM_ENABLED) {
         throw new S3Error(S3Error.NotImplemented);
     }
-    // TODO: may require at the future Content-MD5 & bucket-object-lock-token support
     if (req.body.ObjectLockConfiguration.ObjectLockEnabled[0] !== 'Enabled') {
         throw new S3Error(S3Error.MalformedXML);
     }
+
     const lock_configuration = s3_utils.parse_body_object_lock_conf_xml(req);
 
     try {
@@ -23,12 +23,17 @@ async function put_bucket_object_lock(req, res) {
             object_lock_configuration: lock_configuration,
         });
     } catch (err) {
-        let error = err;
         if (err.rpc_code === 'INVALID_SCHEMA' || err.rpc_code === 'INVALID_SCHEMA_PARAMS') {
             console.error('put_bucket_object_lock: Invalid schema provided', err);
-            error = new S3Error(S3Error.MalformedXML);
+            throw new S3Error(S3Error.MalformedXML);
         }
-        throw error;
+        if (err.rpc_code === 'INVALID_BUCKET_STATE') {
+            throw new S3Error(
+                S3Error.InvalidBucketState,
+                err.message
+            );
+        }
+        throw err;
     }
 }
 

--- a/src/endpoint/s3/ops/s3_put_object_legal_hold.js
+++ b/src/endpoint/s3/ops/s3_put_object_legal_hold.js
@@ -12,7 +12,6 @@ async function put_object_legal_hold(req) {
     if (!config.WORM_ENABLED) {
         throw new S3Error(S3Error.NotImplemented);
     }
-    // TODO: may require at the future Content-MD5 support
     const legal_hold_status = req.body.LegalHold.Status[0];
     if (legal_hold_status !== 'ON' && legal_hold_status !== 'OFF') {
         throw new S3Error(S3Error.MalformedXML);

--- a/src/endpoint/s3/ops/s3_put_object_retention.js
+++ b/src/endpoint/s3/ops/s3_put_object_retention.js
@@ -12,7 +12,6 @@ async function put_object_retention(req) {
     if (!config.WORM_ENABLED) {
         throw new S3Error(S3Error.NotImplemented);
     }
-    // TODO: may require at the future Content-MD5 support
     if (!req.body.Retention) throw new S3Error(S3Error.MalformedXML);
     const mode = req.body.Retention.Mode[0];
     let retain_until_date = req.body.Retention.RetainUntilDate[0];

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -856,7 +856,8 @@ async function read_bucket_sdk_info(req) {
 async function update_bucket(req) {
     const bucket = find_bucket(req, req.name);
     const conf = bucket.object_lock_configuration;
-    if (config.WORM_ENABLED && conf && conf.object_lock_enabled === 'Enabled' && req.rpc_params.versioning === 'SUSPENDED') {
+    if (config.WORM_ENABLED && conf && conf.object_lock_enabled === 'Enabled' &&
+        req.rpc_params.versioning && req.rpc_params.versioning !== 'ENABLED') {
         throw new RpcError('INVALID_BUCKET_STATE', 'An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.');
     }
 
@@ -2001,9 +2002,21 @@ async function put_object_lock_configuration(req) {
     dbg.log0('add object lock configuration to bucket', req.rpc_params);
     const bucket = find_bucket(req);
 
-    if (bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
-        throw new RpcError('INVALID_BUCKET_STATE');
+    const enabling_lock_request = req.rpc_params.object_lock_configuration.object_lock_enabled === 'Enabled';
+
+    if (!enabling_lock_request) {
+        dbg.error('put_object_lock_configuration: ObjectLockEnabled must be Enabled');
+        throw new RpcError('INVALID_SCHEMA_PARAMS');
     }
+
+    if (bucket.versioning !== 'ENABLED') {
+        dbg.error('put_object_lock_configuration: versioning must be ENABLED before enabling Object Lock');
+        throw new RpcError(
+            'INVALID_BUCKET_STATE',
+            "Versioning must be 'Enabled' on the bucket to apply a Object Lock configuration"
+        );
+    }
+
     await system_store.make_changes({
         update: {
             buckets: [{

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -12,12 +12,14 @@ const mocha = require('mocha');
 const assert = require('assert');
 const path = require('path');
 const fs_utils = require('../../../../util/fs_utils');
+const config = require('../../../../../config');
 const today = new Date();
 const tomorrow = new Date(today);
 tomorrow.setDate(tomorrow.getDate() + 1);
 const todayPlus15 = new Date(today);
 todayPlus15.setDate(todayPlus15.getDate() + 15);
 const malformedXML_message = "The XML you provided was not well-formed or did not validate against our published schema.";
+const original_worm_enabled = config.WORM_ENABLED;
 async function assert_throws_async(promise, expected_code = 'AccessDenied', expected_message = 'Access Denied') {
     try {
         await promise;
@@ -48,6 +50,7 @@ mocha.describe('s3 worm', function() {
     let s3_owner;
     //let s3_a;
     mocha.before(async function() {
+        config.WORM_ENABLED = true;
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
         const s3_creds = {
@@ -88,6 +91,9 @@ mocha.describe('s3 worm', function() {
             s3_creds.credentials.secretAccessKey = admin_keys[0].secret_key.unwrap();
             s3_owner = new S3(s3_creds);
         }
+    });
+    mocha.after(function() {
+        config.WORM_ENABLED = original_worm_enabled;
     });
     mocha.describe('buckets creation', function() {
         mocha.it('create bucket BKT & enable lock', async function() {
@@ -980,6 +986,77 @@ mocha.describe('s3 worm', function() {
                 Bucket: BKT,
                 Key: OBJ1,
             }), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
+        });
+    });
+
+    mocha.describe('enable Object Lock on existing bucket', function() {
+        const EXISTING_BKT = 'existing-bucket-lock-test';
+        const EXISTING_OBJ = 'existing-obj';
+
+        mocha.it('should create bucket without Object Lock', async function() {
+            await s3_owner.createBucket({ Bucket: EXISTING_BKT });
+        });
+
+        mocha.it('should put object before enabling lock', async function() {
+            await s3_owner.putObject({
+                Bucket: EXISTING_BKT,
+                Key: EXISTING_OBJ,
+                Body: file_body,
+                ContentType: 'text/plain'
+            });
+        });
+
+        mocha.it('should fail to enable lock without versioning', async function() {
+            await assert_throws_async(s3_owner.putObjectLockConfiguration({
+                Bucket: EXISTING_BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: {
+                        DefaultRetention: { Mode: 'GOVERNANCE', Days: 1 }
+                    }
+                }
+            }), 'InvalidBucketState',
+                "Versioning must be 'Enabled' on the bucket to apply a Object Lock configuration");
+        });
+
+        mocha.it('should enable versioning on bucket', async function() {
+            await s3_owner.putBucketVersioning({
+                Bucket: EXISTING_BKT,
+                VersioningConfiguration: { Status: 'Enabled' }
+            });
+        });
+
+        mocha.it('should enable lock on existing bucket', async function() {
+            await s3_owner.putObjectLockConfiguration({
+                Bucket: EXISTING_BKT,
+                ObjectLockConfiguration: {
+                    ObjectLockEnabled: 'Enabled',
+                    Rule: {
+                        DefaultRetention: { Mode: 'GOVERNANCE', Days: 1 }
+                    }
+                }
+            });
+        });
+
+        mocha.it('should verify lock configuration is set', async function() {
+            const conf = await s3_owner.getObjectLockConfiguration({
+                Bucket: EXISTING_BKT
+            });
+            assert.equal(
+                conf.ObjectLockConfiguration.ObjectLockEnabled, 'Enabled');
+            assert.equal(
+                conf.ObjectLockConfiguration.Rule.DefaultRetention.Mode,
+                'GOVERNANCE');
+            assert.equal(
+                conf.ObjectLockConfiguration.Rule.DefaultRetention.Days, 1);
+        });
+
+        mocha.it('existing object should not have retention', async function() {
+            await assert_throws_async(s3_owner.getObjectRetention({
+                Bucket: EXISTING_BKT,
+                Key: EXISTING_OBJ,
+            }), 'NoSuchObjectLockConfiguration',
+            'The specified object does not have a ObjectLock configuration');
         });
     });
 

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -101,7 +101,7 @@ require('../../unit_tests/util_functions_tests/test_cloud_utils');
 require('../../integration_tests/internal/test_upgrade_scripts.js');
 require('../../integration_tests/internal/test_tiering_ttl_worker');
 // require('./test_tiering_upload');
-//require('../../integration_tests/api/s3/test_s3_worm.js');
+require('../../integration_tests/api/s3/test_s3_worm.js');
 require('../../integration_tests/api/s3/test_bucket_logging');
 require('../../integration_tests/api/s3/test_notifications');
 require('../../integration_tests/api/s3/test_chunked_upload');

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -681,6 +681,12 @@ function validate_bucket_creation(params) {
         !VALID_BUCKET_NAME_REGEXP.test(params.name)) {
         throw new RpcError('INVALID_BUCKET_NAME');
     }
+    if (params.lock_enabled && !config.NSFS_VERSIONING_ENABLED) {
+        throw new RpcError(
+            'INVALID_BUCKET_STATE',
+            'Object Lock cannot be enabled when NSFS versioning is disabled'
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
### Describe the Problem

`PutObjectLockConfiguration` on this branch initially rejected enabling Object Lock on existing buckets, and behavior/validation around Object Lock had some gaps between intended behavior and what CI actually enforced.

### Explain the Changes

1. Enabled Object Lock configuration on existing buckets (AWS-aligned flow), with explicit requirement that bucket versioning is `ENABLED` before lock configuration is applied.
2. Enforced that Object Lock cannot be disabled once enabled, and blocked versioning changes to non-`ENABLED` states on lock-enabled buckets.
3. Improved error mapping/propagation for bucket state and validation failures in the Object Lock S3 path.
4. Updated schema handling for internal object lock metadata states used by bucket metadata.
5. Added and enabled Object Lock integration coverage in CI (`test_s3_worm`), including existing-bucket lock-enable scenarios.
6. Added NSFS validation to reject bucket creation when Object Lock is requested while NSFS versioning is disabled.
7. Included NC stability follow-up adjustments required for this test scope.

### Issues: Fixed #xxx / Gap #xxx

- Fixed #RHSTOR-841
- Gap #N/A (no separate gap tracker added in this PR)

### Testing Instructions:

1. Run `node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/integration_tests/api/s3/test_s3_worm.js --timeout 120000`
2. Verify existing-bucket lock-enable flow:
   - fails when versioning is not enabled
   - succeeds after enabling versioning
3. Verify versioning-state protections on lock-enabled buckets.
4. Verify NSFS rejects Object Lock bucket creation when `NSFS_VERSIONING_ENABLED=false`.

- [ ] Doc added/updated
- [x] Tests added