### PR TITLE
correct unexpected mkdir and error count

### DIFF
--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -273,8 +273,11 @@ class ConfigFS {
      * @returns {Promise<Object>}
      */
     async get_config_data(config_file_path, options = {}) {
+        const fs_context = options.silent_if_missing ?
+            native_fs_utils._fs_context_without_stats(this.fs_context) :
+            this.fs_context;
         try {
-            const { data } = await nb_native().fs.readFile(this.fs_context, config_file_path);
+            const { data } = await nb_native().fs.readFile(fs_context, config_file_path);
             const config_data = JSON.parse(data.toString());
             return config_data;
         } catch (err) {

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -34,23 +34,40 @@ function get_umasked_mode(mode) {
     return mode & ~config.NSFS_UMASK;
 }
 
+/**
+ * Returns an fs_context copy without report_fs_stats.
+ * Used for idempotent fs ops (path creation, existence checks) where expected
+ * errors such as EEXIST/ENOENT should not be counted in nsfs fs worker metrics.
+ * @param {nb.NativeFSContext} fs_context
+ * @returns {nb.NativeFSContext}
+ */
+function _fs_context_without_stats(fs_context) {
+    if (!fs_context?.report_fs_stats) return fs_context;
+    const ctx = { ...fs_context };
+    delete ctx.report_fs_stats;
+    return ctx;
+}
+
 async function _make_path_dirs(file_path, fs_context) {
     const last_dir_pos = file_path.lastIndexOf('/');
     if (last_dir_pos > 0) return _create_path(file_path.slice(0, last_dir_pos), fs_context);
 }
 
 async function _create_path(dir, fs_context, dir_permissions = config.BASE_MODE_DIR) {
+    const fs_context_no_stats = _fs_context_without_stats(fs_context);
     let dir_path = path.isAbsolute(dir) ? path.sep : '';
     for (const item of dir.split(path.sep)) {
         dir_path = path.join(dir_path, item);
         try {
-            await nb_native().fs.mkdir(fs_context, dir_path, get_umasked_mode(dir_permissions));
+            await nb_native().fs.mkdir(fs_context_no_stats, dir_path, get_umasked_mode(dir_permissions));
         } catch (err) {
             const ERR_CODES = ['EISDIR', 'EEXIST'];
             if (!ERR_CODES.includes(err.code)) throw err;
         }
     }
-    if (config.NSFS_TRIGGER_FSYNC) await nb_native().fs.fsync(fs_context, dir_path);
+    if (config.NSFS_TRIGGER_FSYNC) {
+        await nb_native().fs.fsync(fs_context_no_stats, dir_path);
+    }
 }
 
 async function _generate_unique_path(fs_context, tmp_dir_path) {
@@ -408,7 +425,8 @@ async function create_config_file(fs_context, schema_dir, config_path, config_da
     try {
         // validate config file doesn't exist
         try {
-            await nb_native().fs.stat(fs_context, config_path);
+            const fs_context_no_stats = _fs_context_without_stats(fs_context);
+            await nb_native().fs.stat(fs_context_no_stats, config_path);
             throw error_utils.new_error_code('EEXIST', 'configuration file already exists');
         } catch (err) {
             if (err.code !== 'ENOENT') throw err;
@@ -968,6 +986,7 @@ async function warmup_sparse_file(fs_context, file, file_path, stat, pos) {
 exports.get_umasked_mode = get_umasked_mode;
 exports._make_path_dirs = _make_path_dirs;
 exports._create_path = _create_path;
+exports._fs_context_without_stats = _fs_context_without_stats;
 exports._generate_unique_path = _generate_unique_path;
 exports.open_file = open_file;
 exports.use_file = use_file;


### PR DESCRIPTION
### Describe the Problem
https://redhat.atlassian.net/browse/DFBUGS-7013

NSFS exposes FS-level metrics via /metrics/nsfs_stats (e.g. mkdir_error_count, stat_error_count). These come from C++ (fs_napi.cpp): on any syscall failure, OnError() calls report_fs_stats before control returns to JavaScript.

Many config/setup paths in JS are idempotent — they expect and handle errors like:

EEXIST — directory already exists (_create_path)
ENOENT — config file doesn’t exist yet (existence checks, silent_if_missing reads)
JS treats these as normal flow and continues. Metrics still record them as failures.

Example: 2 successful bucket creates could show mkdir_error_count: 44 because each create walks an existing path tree and every mkdir hitting EEXIST is counted as an error. S3 op metrics (create_bucket_error_count: 0) were correct — the FS metrics were misleading.

### Explain the Changes
1. Add _fs_context_without_stats() to strip report_fs_stats for idempotent FS ops
2. Use it in _create_path (mkdir/fsync) and create_config_file stat existence check
3. Use it in ConfigFS.get_config_data() when silent_if_missing: true
Why this approach: A global C++ filter on EEXIST/ENOENT would hide legitimate failures elsewhere. Stripping stats only at known idempotent call sites fixes false positives without affecting real error reporting.

### Issues: Fixed #DFBUGS-7013 / Gap #xxx
1. false-positive FS worker error metrics on NSFS bucket/config setup

### Testing Instructions:
1. Start NSFS with metrics enabled (ALLOW_HTTP_METRICS: true)
`export CONFIG=/private/tmp/noobaa-conf
mkdir -p $CONFIG
echo '{ "ALLOW_HTTP": true, "ALLOW_HTTP_METRICS": true }' > $CONFIG/config.json

node src/cmd/nsfs.js \
  --config_root $CONFIG \
  --http_port 6001 \
  --http_metrics_port 7004 \
  --debug 5`
2. Restart NSFS for a clean window
3. Set Credentials
`export AWS_ACCESS_KEY_ID="..."
export AWS_SECRET_ACCESS_KEY="..."`
5. Create 2 buckets via S3; wait ~12s; scrape /metrics/nsfs_stats
`aws --endpoint-url http://127.0.0.1:6001 s3 mb s3://test-metrics-1
aws --endpoint-url http://127.0.0.1:6001 s3 mb s3://test-metrics-2
sleep 12
curl -s http://127.0.0.1:7004/metrics/nsfs_stats | jq '{
  create_bucket_count: .op_stats_counters.noobaa_nsfs_op_create_bucket_count,
  create_bucket_errors: .op_stats_counters.noobaa_nsfs_op_create_bucket_error_count,
  mkdir_count: .fs_worker_stats_counters.noobaa_nsfs_fs_worker_mkdir_count,
  mkdir_errors: .fs_worker_stats_counters.noobaa_nsfs_fs_worker_mkdir_error_count,
  stat_errors: .fs_worker_stats_counters.noobaa_nsfs_fs_worker_stat_error_count
}'`
6. Expect mkdir_error_count: 0, stat_error_count: 0, create_bucket_error_count: 0
7. Create duplicate bucket name; expect create_bucket_error_count: 1, mkdir_error_count: 0
`aws --endpoint-url http://127.0.0.1:6001 s3 mb s3://test-metrics-1
sleep 12
curl -s http://127.0.0.1:7004/metrics/nsfs_stats | jq '{
  create_bucket_errors: .op_stats_counters.noobaa_nsfs_op_create_bucket_error_count,
  mkdir_errors: .fs_worker_stats_counters.noobaa_nsfs_fs_worker_mkdir_error_count
}'`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced noise in filesystem metrics by excluding routine directory creation and routine config existence checks from tracking.
  * Adjusted config read behavior so silently-missing configs do not impact metrics while preserving existing parsing and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->