### PR TITLE
vectors - pass distance type to lance (df 7337)

### DIFF
--- a/src/test/integration_tests/api/vectors/test_vectors_ops.js
+++ b/src/test/integration_tests/api/vectors/test_vectors_ops.js
@@ -1535,6 +1535,139 @@ mocha.describe('vectors_ops', function() {
             assert.strictEqual(response.vectors[0].key, 'vector_id_1');
         });
 
+        mocha.it('should use distance metric correctly (cosine vs euclidean)', async function() {
+            const vector_bucket_name_cosine = 'test-vec-buc-cosine';
+            const vector_index_name_cosine = 'test-vec-ind-cosine';
+            const vector_bucket_name_euclidean = 'test-vec-buc-euclidean';
+            const vector_index_name_euclidean = 'test-vec-ind-euclidean';
+
+            // Create vector bucket and index with COSINE distance metric
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name_cosine);
+            const params_cosine = {
+                vectorBucketName: vector_bucket_name_cosine,
+                indexName: vector_index_name_cosine,
+                dataType: s3vectors.DataType.FLOAT32,
+                dimension: 3,
+                distanceMetric: s3vectors.DistanceMetric.COSINE
+            };
+            const command_cosine = new s3vectors.CreateIndexCommand(params_cosine);
+            await send(s3_vectors_client, command_cosine);
+            created_vector_indices.push({
+                vector_bucket: vector_bucket_name_cosine,
+                vector_index: vector_index_name_cosine
+            });
+
+            // Create vector bucket and index with EUCLIDEAN distance metric
+            await create_vector_bucket(s3_vectors_client, created_vector_buckets, vector_bucket_name_euclidean);
+            const params_euclidean = {
+                vectorBucketName: vector_bucket_name_euclidean,
+                indexName: vector_index_name_euclidean,
+                dataType: s3vectors.DataType.FLOAT32,
+                dimension: 3,
+                distanceMetric: s3vectors.DistanceMetric.EUCLIDEAN
+            };
+            const command_euclidean = new s3vectors.CreateIndexCommand(params_euclidean);
+            await send(s3_vectors_client, command_euclidean);
+            created_vector_indices.push({
+                vector_bucket: vector_bucket_name_euclidean,
+                vector_index: vector_index_name_euclidean
+            });
+
+            // Create test vectors with different characteristics
+            // Vector 1: [1, 0, 0] - unit vector along x-axis
+            // Vector 2: [0, 1, 0] - unit vector along y-axis
+            // Vector 3: [0.6, 0.8, 0] - normalized vector in x-y plane
+            // Vector 4: [2, 0, 0] - scaled version of vector 1
+            const vectors = [
+                {
+                    key: "vector_id_1",
+                    data: {float32: [1.0, 0.0, 0.0]},
+                    metadata: {name: "x-axis"}
+                },
+                {
+                    key: "vector_id_2",
+                    data: {float32: [0.0, 1.0, 0.0]},
+                    metadata: {name: "y-axis"}
+                },
+                {
+                    key: "vector_id_3",
+                    data: {float32: [0.6, 0.8, 0.0]},
+                    metadata: {name: "diagonal"}
+                },
+                {
+                    key: "vector_id_4",
+                    data: {float32: [2.0, 0.0, 0.0]},
+                    metadata: {name: "scaled-x"}
+                }
+            ];
+
+            // Insert same vectors into both indexes
+            const put_command_cosine = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name_cosine,
+                indexName: vector_index_name_cosine,
+                vectors
+            });
+            await send(s3_vectors_client, put_command_cosine);
+
+            const put_command_euclidean = new s3vectors.PutVectorsCommand({
+                vectorBucketName: vector_bucket_name_euclidean,
+                indexName: vector_index_name_euclidean,
+                vectors
+            });
+            await send(s3_vectors_client, put_command_euclidean);
+
+            // Query vector: [1, 0, 0] - same as vector_id_1
+            const query_vector = {float32: [1.0, 0.0, 0.0]};
+
+            // Query cosine index
+            const query_command_cosine = new s3vectors.QueryVectorsCommand({
+                vectorBucketName: vector_bucket_name_cosine,
+                indexName: vector_index_name_cosine,
+                queryVector: query_vector,
+                topK: 4
+            });
+            const response_cosine = await send(s3_vectors_client, query_command_cosine);
+
+            // Query euclidean index
+            const query_command_euclidean = new s3vectors.QueryVectorsCommand({
+                vectorBucketName: vector_bucket_name_euclidean,
+                indexName: vector_index_name_euclidean,
+                queryVector: query_vector,
+                topK: 4
+            });
+            const response_euclidean = await send(s3_vectors_client, query_command_euclidean);
+
+            // Validate both queries returned results
+            assert.strictEqual(response_cosine.vectors.length, 4);
+            assert.strictEqual(response_euclidean.vectors.length, 4);
+
+            // For COSINE similarity:
+            // - vector_id_1 [1,0,0] should be closest (cosine similarity = 1.0, distance = 0)
+            // - vector_id_4 [2,0,0] should be second (cosine similarity = 1.0, distance = 0, same direction)
+            // - vector_id_3 [0.6,0.8,0] should be third (cosine similarity = 0.6)
+            // - vector_id_2 [0,1,0] should be last (cosine similarity = 0, orthogonal)
+            assert.strictEqual(response_cosine.vectors[0].key, 'vector_id_1');
+            assert.strictEqual(response_cosine.vectors[1].key, 'vector_id_4');
+            assert.strictEqual(response_cosine.vectors[2].key, 'vector_id_3');
+            assert.strictEqual(response_cosine.vectors[3].key, 'vector_id_2');
+
+            // For EUCLIDEAN distance:
+            // - vector_id_1 [1,0,0] should be closest (distance = 0)
+            // - vector_id_3 [0.6,0.8,0] should be second (distance = sqrt(0.16+0.64) = sqrt(0.8) ≈ 0.894)
+            // - vector_id_4 [2,0,0] should be third (distance = 1)
+            // - vector_id_2 [0,1,0] should be last (distance = sqrt(1+1) = sqrt(2) ≈ 1.414)
+            assert.strictEqual(response_euclidean.vectors[0].key, 'vector_id_1');
+            assert.strictEqual(response_euclidean.vectors[1].key, 'vector_id_3');
+            assert.strictEqual(response_euclidean.vectors[2].key, 'vector_id_4');
+            assert.strictEqual(response_euclidean.vectors[3].key, 'vector_id_2');
+
+            // Verify that the ordering is different between the two metrics
+            const cosine_order = response_cosine.vectors.map(v => v.key).join(',');
+            const euclidean_order = response_euclidean.vectors.map(v => v.key).join(',');
+            assert.notStrictEqual(cosine_order, euclidean_order,
+                'Distance metrics should produce different orderings');
+        });
+
         mocha.it('should delete vectors', async function() {
             await create_vector_index(s3_vectors_client, created_vector_buckets,
                 created_vector_indices, vector_bucket_name1, vector_index_name1);

--- a/src/util/vectors_util.js
+++ b/src/util/vectors_util.js
@@ -194,7 +194,12 @@ class LanceConn extends VectorConn {
         }
 
         try {
-            await table.createIndex('vector', {replace: false});
+            await table.createIndex('vector', {
+                replace: false,
+                config: lance.Index.ivfPq({
+                    distanceType: this._aws_distance_metric_to_lance_distance_type(vector_index.distance_metric)
+                })
+            });
         } catch (err) {
             //swallow 'not enougn rows', try again on next put_vectors
             if (!err.message.includes('Not enough rows') && !err.message.include("already exists")) {
@@ -258,7 +263,9 @@ class LanceConn extends VectorConn {
 
         const table = await this.get_table(table_name);
         //TODO - check if(!table)
-        const query = table.vectorSearch(query_vector);
+        const query = table
+            .vectorSearch(query_vector)
+            .distanceType(this._aws_distance_metric_to_lance_distance_type(vector_index.distance_metric));
         if (filter) {
             query.where(filterToSql(filter));
         }
@@ -362,6 +369,10 @@ class LanceConn extends VectorConn {
         }
 
         return table;
+    }
+
+    _aws_distance_metric_to_lance_distance_type(aws_distance_metric) {
+        return (aws_distance_metric === 'cosine' ? 'cosine' : 'l2'); //l2 is Euclidean
     }
 }
 


### PR DESCRIPTION
### Describe the Problem
Vector query ignore distance metric.

### Explain the Changes
Pass distance type parameter to lance index.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-7337

### Testing Instructions:
1. Create two different indices, one for each distance metric.
2. Insert same set of vectors to both indices.
3. Query result for indices should be different.
(See added test in suite)

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating vector distance metric behavior across cosine and euclidean configurations.

* **Improvements**
  * Vector indexing now applies the configured distance metric correctly during index creation.
  * Vector search queries now respect the specified distance metric for accurate similarity ranking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->