### PR TITLE
CI | Adding permissions to the backport label action

### DIFF
--- a/.github/workflows/label-backport-prs.yml
+++ b/.github/workflows/label-backport-prs.yml
@@ -8,6 +8,7 @@ jobs:
   label_pr:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
### Explain the Changes
1. CI | Adding permissions to the backport label action



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow for more reliable management of backport pull request labels, including automatic application to currently open pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->