### PR TITLE
CI | backport label run from the target branch and not in the fork

### DIFF
--- a/.github/workflows/label-backport-prs.yml
+++ b/.github/workflows/label-backport-prs.yml
@@ -1,7 +1,7 @@
 name: Label backport PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
 jobs:


### PR DESCRIPTION
### Explain the Changes
1. CI | backport label run from the target branch and not in the fork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request workflow configuration for improved CI/CD pipeline management.

**Note:** This change has no direct impact on user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->