### PR TITLE
GCP WIF (STS) | NSS Changes

### DIFF
--- a/src/sdk/namespace_gcp.js
+++ b/src/sdk/namespace_gcp.js
@@ -8,8 +8,7 @@ const P = require('../util/promise');
 const stream_utils = require('../util/stream_utils');
 const dbg = require('../util/debug_module')(__filename);
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
-// we use this wrapper to set a custom user agent
-const GoogleCloudStorage = require('../util/google_storage_wrap');
+const cloud_utils = require('../util/cloud_utils');
 
 /**
  * @implements {nb.Namespace}
@@ -19,34 +18,22 @@ class NamespaceGCP {
     /**
      * @param {{
     *      namespace_resource_id: string,
-    *      project_id: string,
     *      target_bucket: string,
-    *      client_email: string,
-    *      private_key: string,
+    *      credentials_json: string, // Google credentials JSON string (service_account or external_account)
     *      access_mode: string,
     *      stats: import('./endpoint_stats_collector').EndpointStatsCollector,
     * }} params
     */
     constructor({
         namespace_resource_id,
-        project_id,
         target_bucket,
-        client_email,
-        private_key,
+        credentials_json,
         access_mode,
         stats,
     }) {
         this.namespace_resource_id = namespace_resource_id;
-        this.project_id = project_id;
-        this.client_email = client_email;
-        this.private_key = private_key;
-        this.gcs = new GoogleCloudStorage({
-            projectId: this.project_id,
-            credentials: {
-                client_email: this.client_email,
-                private_key: this.private_key,
-            }
-        });
+        this.credentials_json = credentials_json;
+        this.gcs = cloud_utils.create_google_storage_from_connection(credentials_json);
         this.bucket = target_bucket;
         this.access_mode = access_mode;
         this.stats = stats;
@@ -59,8 +46,8 @@ class NamespaceGCP {
     is_server_side_copy(other, other_md, params) {
         //TODO: what is the case here, what determine server side copy? 
         return other instanceof NamespaceGCP &&
-            this.private_key === other.private_key &&
-            this.client_email === other.client_email;
+            (this.credentials_json === other.credentials_json ||
+                cloud_utils.are_same_google_credentials(this.credentials_json, other.credentials_json));
     }
 
     get_bucket() {
@@ -486,7 +473,7 @@ class NamespaceGCP {
 }
 
 function inspect(x) {
-    return util.inspect(_.omit(x, 'source_stream'), true, 5, true);
+    return util.inspect(_.omit(x, 'source_stream', 'credentials_json', 'private_key'), true, 5, true);
 }
 
 module.exports = NamespaceGCP;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -560,14 +560,11 @@ class ObjectSDK {
                 stats: this.stats,
             });
         }
-        if (r.endpoint_type === 'GOOGLE') {
-            const { project_id, private_key, client_email } = JSON.parse(r.secret_key.unwrap());
+        if (r.endpoint_type === 'GOOGLE' || r.endpoint_type === 'GOOGLE_STS') {
             return new NamespaceGCP({
                 namespace_resource_id: r.id,
                 target_bucket: r.target_bucket,
-                project_id,
-                client_email,
-                private_key,
+                credentials_json: r.secret_key.unwrap(),
                 access_mode: r.access_mode,
                 stats: this.stats,
             });

--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -2,8 +2,6 @@
 'use strict';
 
 const system_store = require('../system_services/system_store').get_instance();
-//TODO: why do we what to use the wrap and not directly @google-cloud/storage ? 
-const GoogleCloudStorage = require('../../util/google_storage_wrap');
 const auth_server = require('../common_services/auth_server');
 const dbg = require('../../util/debug_module')(__filename);
 const system_utils = require('../utils/system_utils');
@@ -68,7 +66,6 @@ class NamespaceMonitor {
                 } else if (['AZURE', 'AZURESTS' ].includes(endpoint_type)) {
                     await this.test_blob_resource(nsr);
                 } else if (endpoint_type === 'GOOGLE' || endpoint_type === 'GOOGLE_STS') {
-                    // GOOGLE_STS namespace resources are not supported yet (test_gcs_resource expects service_account JSON).
                     await this.test_gcs_resource(nsr);
                 } else {
                     dbg.error('namespace_monitor: invalid endpoint type', endpoint_type);
@@ -188,14 +185,7 @@ class NamespaceMonitor {
     async test_gcs_resource(nsr) {
         let conn = this.nsr_connections_obj[nsr._id];
         if (!conn) {
-            const { project_id, private_key, client_email } = JSON.parse(nsr.connection.secret_key.unwrap());
-            conn = new GoogleCloudStorage({
-                projectId: project_id,
-                credentials: {
-                    client_email,
-                    private_key,
-                }
-            });
+            conn = cloud_utils.create_google_storage_from_connection(nsr.connection.secret_key.unwrap());
             this.nsr_connections_obj[nsr._id] = conn;
         }
         const { target_bucket } = nsr.connection;

--- a/src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js
@@ -370,3 +370,55 @@ describe('create_google_storage_from_connection', () => {
         expect(GoogleStorage).not.toHaveBeenCalled();
     });
 });
+
+describe('are_same_google_credentials', () => {
+    it('returns true for identical JSON strings', () => {
+        const json = JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE);
+        expect(cloud_utils.are_same_google_credentials(json, json)).toBe(true);
+    });
+
+    it('returns true for equivalent service_account JSON with different key order', () => {
+        const a = JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE);
+        const b = JSON.stringify({
+            private_key: PRIVATE_KEY,
+            client_email: CLIENT_EMAIL,
+            project_id: PROJECT_ID,
+            type: CREDENTIAL_TYPE_SERVICE_ACCOUNT,
+            private_key_id: PRIVATE_KEY_ID,
+        });
+        expect(cloud_utils.are_same_google_credentials(a, b)).toBe(true);
+    });
+
+    it('returns false for different service_account private keys', () => {
+        const a = JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE);
+        const b = JSON.stringify({ ...SERVICE_ACCOUNT_JSON_FIXTURE, private_key: 'other-key' });
+        expect(cloud_utils.are_same_google_credentials(a, b)).toBe(false);
+    });
+
+    it('returns true for equivalent external_account JSON with different formatting', () => {
+        const a = JSON.stringify(EXTERNAL_ACCOUNT_JSON_FIXTURE);
+        const b = JSON.stringify({
+            service_account_impersonation_url: WIF_SERVICE_ACCOUNT_IMPERSONATION_URL,
+            token_url: WIF_TOKEN_URL,
+            audience: WIF_AUDIENCE,
+            type: CREDENTIAL_TYPE_EXTERNAL_ACCOUNT,
+            subject_token_type: WIF_SUBJECT_TOKEN_TYPE,
+            credential_source: {
+                format: WIF_CREDENTIAL_SOURCE_FORMAT,
+                file: WIF_CREDENTIAL_SOURCE_FILE,
+            },
+        });
+        expect(cloud_utils.are_same_google_credentials(a, b)).toBe(true);
+    });
+
+    it('returns false when mixing service_account and external_account', () => {
+        expect(cloud_utils.are_same_google_credentials(
+            JSON.stringify(SERVICE_ACCOUNT_JSON_FIXTURE),
+            JSON.stringify(EXTERNAL_ACCOUNT_JSON_FIXTURE),
+        )).toBe(false);
+    });
+
+    it('returns false for invalid JSON', () => {
+        expect(cloud_utils.are_same_google_credentials(INVALID_JSON, INVALID_JSON)).toBe(false);
+    });
+});

--- a/src/util/cloud_utils.js
+++ b/src/util/cloud_utils.js
@@ -14,6 +14,7 @@ const { NodeHttpHandler } = require('@smithy/node-http-handler');
 const config = require('../../config');
 const noobaa_s3_client = require('../sdk/noobaa_s3_client/noobaa_s3_client');
 const azure_storage = require('./azure_storage_wrap');
+// TODO: why do we want to use the wrap and not directly @google-cloud/storage ?
 const GoogleStorage = require('./google_storage_wrap');
 const { WorkloadIdentityCredential } = require("@azure/identity");
 
@@ -413,6 +414,31 @@ function _is_valid_google_wif_credential_source(credential_source) {
     return typeof credential_source.file === 'string' && credential_source.file.length > 0;
 }
 
+/**
+ * Compare two Google credential JSON for the same GCP identity (ignores JSON formatting).
+ * @param {string|object} credentials_json_a
+ * @param {string|object} credentials_json_b
+ * @returns {boolean}
+ */
+function are_same_google_credentials(credentials_json_a, credentials_json_b) {
+    try {
+        const parsed_credentials_json_a = parse_google_secret_json(credentials_json_a);
+        const parsed_credentials_json_b = parse_google_secret_json(credentials_json_b);
+        if (credentials_json_a === credentials_json_b) return true;
+        const a_is_wif = is_google_wif_credentials(parsed_credentials_json_a);
+        const b_is_wif = is_google_wif_credentials(parsed_credentials_json_b);
+        if (a_is_wif !== b_is_wif) return false;
+        if (a_is_wif) {
+            return parsed_credentials_json_a.subject_token_type === parsed_credentials_json_b.subject_token_type &&
+                parsed_credentials_json_a.audience === parsed_credentials_json_b.audience &&
+                parsed_credentials_json_a.service_account_impersonation_url === parsed_credentials_json_b.service_account_impersonation_url;
+        }
+        return parsed_credentials_json_a.client_email === parsed_credentials_json_b.client_email &&
+            parsed_credentials_json_a.private_key === parsed_credentials_json_b.private_key;
+    } catch (err) {
+        return false;
+    }
+}
 
 exports.find_cloud_connection = find_cloud_connection;
 exports.get_azure_connection_string = get_azure_connection_string;
@@ -430,4 +456,5 @@ exports.create_azure_blob_client = create_azure_blob_client;
 exports.parse_google_secret_json = parse_google_secret_json;
 exports.build_google_cloud_info = build_google_cloud_info;
 exports.is_google_wif_credentials = is_google_wif_credentials;
+exports.are_same_google_credentials = are_same_google_credentials;
 exports.create_google_storage_from_connection = create_google_storage_from_connection;


### PR DESCRIPTION
### Describe the Problem
As part of [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661), this PR sets the new endpoint type `GOOGLE_STS` (we had `GOOGLE`) and implements code changes in parts of the flows related to the GCP WIF (STS) namespace store.

### Explain the Changes
1. Edit `NamespaceGCP` for the 2 `endpoint_type` `'GOOGLE'` and `'GOOGLE_STS'` directly use the `credentials.json` for both types and in `object_sdk` passing the params to `NamespaceGCP`.
2. In `namespace_monitor` edit the `test_gcs_resource` and directly use the `credentials.json` for both types (`'GOOGLE'` and `'GOOGLE_STS'`)
3. Move the TODO comment from `NamespaceGCP` to `src/util/cloud_utils.js`.
4. Added a helper function in `cloud_util` with AI-generated tests that will be used in `is_server_side_copy` function.

### Issues:
List of GAPs:
1. NSS GCP is not GA'd; only authentication changes related to the GCP client.

### Testing Instructions:
#### Unit Test:
Please run: `npx jest src/test/unit_tests/util_functions_tests/test_cloud_utils_google.test.js`.

#### Manual Test:
This PR is tested with the code changes in noobaa/noobaa-operator#1945 (for the full steps, see [comment](https://github.com/noobaa/noobaa-core/pull/9697#issuecomment-4680190094)).
Create 2 namespaces for GCP WIF (STS), and GCP checks that it is in `Ready` phase:
Partial output (I removed the target bucket name):

```bash
nb namespacestore list -n test1
NAME               TYPE                   TARGET-BUCKET    PROVIDER-STORAGE-CLASS   PHASE   AGE
shira-gcs-ns       google-cloud-storage   ***     standard                 Ready   14s
shira-gcs-wif-ns   google-cloud-storage   ***   standard                 Ready   36m53s
```

In the logs of noobaa-core pod you can see:
```bash
Jun-11 6:34:39.432 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcs-wif-ns type GOOGLE_STS, 6a2a4e1bb28c0f002261f66a finished successfully..
Jun-11 6:34:39.528 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcs-ns type GOOGLE, 6a2a56b2b28c0f002261f677 finished successfully..
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded Google Cloud Storage namespace support to use JSON credentials consistently, including the `GOOGLE_STS` credential path.

* **Improvements**
  * Unified handling for Google and Google STS when setting up GCS access.
  * Enhanced server-side copy detection by comparing credential identity rather than raw fields.
  * Reduced credential detail exposure in diagnostic/inspection output.

* **Tests**
  * Added Jest coverage for credential identity comparison, including equivalent JSON with different formatting/key order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->