### PR TITLE
Fix default_resource reassignment on noobaa-core pod restart

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1328,6 +1328,15 @@ function get_default_pool(system) {
     return system.pools_by_name[config.DEFAULT_POOL_NAME];
 }
 
+// update only bootstrap/default-pool accounts (legacy install state), not operator
+// skip no-op updates when account already points to the selected optimal pool
+function _is_default_resource_update_candidate(account, optimal_pool_id) {
+    return account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL &&
+        account.default_resource &&
+        account.default_resource.is_default_pool &&
+        String(account.default_resource._id) !== String(optimal_pool_id);
+}
+
 async function get_optimal_non_default_pool_id() {
     for (const pool of system_store.data.pools) {
         // skip backingstore_pool.
@@ -1352,10 +1361,7 @@ async function update_account_default_resource() {
 
                 if (optimal_pool_id) {
                     const updates = system_store.data.accounts
-                        .filter(account =>
-                            account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL &&
-                            account.default_resource
-                        )
+                        .filter(account => _is_default_resource_update_candidate(account, optimal_pool_id))
                         .map(account => ({
                             _id: account._id,
                             $set: {


### PR DESCRIPTION
### Describe the Problem
`update_account_default_resource()` was updating `default_resource` for all non-operator accounts on core restart, which could switch admin to a user backingstore and block backingstore deletion (`DEFAULT_RESOURCE`).

### Explain the Changes
1. Added a small eligibility helper and narrowed updates to candidate accounts only (default-pool accounts, excluding operator, and no-op skips when already on target).

### Issues: Fixed #xxx / Gap #xxx
1. JIRA: https://redhat.atlassian.net/browse/DFBUGS-7130

### Testing Instructions:
1. Install NooBaa.
2. Create new backingstore `aws-backingstore`.
3. Restart the noobaa-core pod `kubectl delete pod noobaa-core-0`
4. Verify after some time (~2mins) that `default_resource` is not being updated from `noobaa-default-backing-store` to `aws-backingstore` (we created above).
`noobaa api account_api read_account '{"email": "admin@noobaa.io"}' | grep default_resource`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of default pool selection and account processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->