### PR TITLE
Add ability to update endpoint on backingstores

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -24,6 +24,7 @@ const ssl_utils = require('../util/ssl_utils');
 const time_utils = require('../util/time_utils');
 const json_utils = require('../util/json_utils');
 const cloud_utils = require('../util/cloud_utils');
+const COMMON_CONSTANTS = require('../common/constants');
 const BlockStoreFs = require('./block_store_services/block_store_fs').BlockStoreFs;
 const BlockStoreS3 = require('./block_store_services/block_store_s3').BlockStoreS3;
 const BlockStoreGoogle = require('./block_store_services/block_store_google').BlockStoreGoogle;
@@ -110,7 +111,7 @@ class Agent {
                     params.cloud_info.endpoint_type === 'S3_COMPATIBLE' ||
                     params.cloud_info.endpoint_type === 'FLASHBLADE' ||
                     params.cloud_info.endpoint_type === 'IBM_COS') {
-                    this.node_type = 'BLOCK_STORE_S3';
+                    this.node_type = COMMON_CONSTANTS.STORE_TYPE.S3;
                     this.block_store = new BlockStoreS3(block_store_options);
                 } else if (params.cloud_info.endpoint_type === 'AZURE' ||
                     params.cloud_info.endpoint_type === 'AZURESTS') {
@@ -243,9 +244,18 @@ class Agent {
         this.block_store.cleanup_target_path();
     }
 
-    async update_credentials(access_keys) {
+    async update_hosted_agents(agent_params) {
         if (!this.cloud_info) return;
-        this.cloud_info.access_keys = access_keys;
+
+        if (agent_params.access_keys) {
+            this.cloud_info.access_keys = agent_params.access_keys;
+        }
+
+        if (this.node_type === COMMON_CONSTANTS.STORE_TYPE.S3 && agent_params.endpoint) {
+            this.cloud_info.endpoint = agent_params.endpoint;
+            this.cloud_info.endpoint_type = agent_params.endpoint_type;
+        }
+
         const block_store_options = {
             node_name: this.node_name,
             rpc_client: this.client,
@@ -255,7 +265,7 @@ class Agent {
             cloud_path: this.cloud_path,
         };
 
-        if (this.node_type === 'BLOCK_STORE_S3') {
+        if (this.node_type === COMMON_CONSTANTS.STORE_TYPE.S3) {
             this.block_store = new BlockStoreS3(block_store_options);
         } else if (this.node_type === 'BLOCK_STORE_AZURE') {
             const connection_string = cloud_utils.get_azure_new_connection_string({

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -491,7 +491,7 @@ module.exports = {
             method: 'PUT',
             params: {
                 type: 'object',
-                required: ['name', 'secret'],
+                required: ['name'],
                 properties: {
                     name: {
                         type: 'string'
@@ -501,6 +501,17 @@ module.exports = {
                     azure_log_access_keys: { $ref: 'common_api#/definitions/azure_log_access_keys' },
                     region: {
                         type: 'string'
+                    },
+                    endpoint_info: {
+                        type: 'object',
+                        properties: {
+                            endpoint: {
+                                type: 'string'
+                            },
+                            endpoint_type: {
+                                type: 'string'
+                            },
+                        }
                     }
                 }
             },
@@ -542,6 +553,9 @@ module.exports = {
                     },
                     ignore_name_already_exist: {
                         type: 'boolean'
+                    },
+                    bucket: {
+                        type: 'string'
                     }
                 }
             },

--- a/src/api/hosted_agents_api.js
+++ b/src/api/hosted_agents_api.js
@@ -110,6 +110,34 @@ module.exports = {
             }
         },
 
+        update_hosted_agents: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['pool_ids'],
+                properties: {
+                    pool_ids: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        }
+                    },
+                    credentials: {
+                        $ref: 'common_api#/definitions/access_keys',
+                    },
+                    endpoint: {
+                        type: 'string'
+                    },
+                    endpoint_type: {
+                        type: 'string'
+                    }
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+
         update_storage_limit: {
             method: 'POST',
             params: {

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -20,6 +20,9 @@ const COMMON_CONSTANTS = {
       DONE: 'DONE',
     },
   },
+  STORE_TYPE: {
+    S3: 'BLOCK_STORE_S3',
+  },
 };
 
 module.exports = COMMON_CONSTANTS;

--- a/src/hosted_agents/hosted_agents.js
+++ b/src/hosted_agents/hosted_agents.js
@@ -277,7 +277,24 @@ class HostedAgents {
                 continue;
             }
             const agent = this._started_agents[node_name].agent;
-            agent.update_credentials(access_keys);
+            agent.update_hosted_agents({access_keys});
+        }
+    }
+
+    update_hosted_agents(params) {
+        const pool_ids = params.pool_ids;
+        for (const pid of pool_ids) {
+            const node_name = 'noobaa-internal-agent-' + pid;
+            if (!this._started_agents[node_name]) {
+                dbg.error(`update_hosted_agents agent ${node_name} does not exist`);
+                continue;
+            }
+            const agent = this._started_agents[node_name].agent;
+            agent.update_hosted_agents({
+                access_keys: params.credentials,
+                endpoint: params.endpoint,
+                endpoint_type: params.endpoint_type,
+            });
         }
     }
 
@@ -308,6 +325,14 @@ async function update_credentials(req) {
         await HostedAgents.instance().update_agents_credentials({ pool_ids, access_keys: credentials });
     } catch (error) {
         dbg.error('update_credentials had failed', error);
+    }
+}
+
+async function update_hosted_agents(req) {
+    try {
+        await HostedAgents.instance().update_hosted_agents(req.rpc_params);
+    } catch (error) {
+        dbg.error('update_hosted_agents had failed', error);
     }
 }
 
@@ -390,6 +415,7 @@ HostedAgents._instance = null;
 // EXPORTS
 exports.create_pool_agent = create_pool_agent;
 exports.update_credentials = update_credentials;
+exports.update_hosted_agents = update_hosted_agents;
 exports.update_storage_limit = update_storage_limit;
 exports.remove_pool_agent = remove_pool_agent;
 exports.start = req => HostedAgents.instance().start();

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
+/*eslint max-lines: ["error", 2100]*/
 'use strict';
 
 const P = require('../../util/promise');
@@ -591,42 +592,61 @@ async function update_external_connection(req) {
     const secret = req.rpc_params.secret;
     const azure_log_access_keys = req.rpc_params.azure_log_access_keys;
     const region = req.rpc_params.region || connection.region;
+    const new_endpoint = req.rpc_params.endpoint_info?.endpoint || connection.endpoint;
+    const encrypted_secret = secret ?
+        system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
+            secret, req.account.master_key_id._id) : undefined;
 
-    const encrypted_secret = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
-        secret, req.account.master_key_id._id);
-
-    let check_failed = false;
-    try {
-        const { status } = await _check_external_connection_internal({
-            name,
-            identity,
-            secret,
-            endpoint_type: connection.endpoint_type,
-            endpoint: connection.endpoint,
-            region: region,
-            cp_code: connection.cp_code,
-            auth_method: connection.auth_method,
-            azure_log_access_keys: azure_log_access_keys,
-        });
-        check_failed = status !== 'SUCCESS';
-
-    } catch (error) {
-        dbg.error('update_external_connection: _check_external_connection_internal had error', error);
-        check_failed = true;
+    if (req.rpc_params.endpoint_info?.endpoint_type &&
+        req.rpc_params.endpoint_info.endpoint_type !== connection.endpoint_type) {
+        throw new RpcError('FORBIDDEN', 'Changing endpoint_type is not allowed');
     }
 
-    if (check_failed) {
-        throw new RpcError('INVALID_CREDENTIALS', `Credentials are not valid ${name}`);
+    let endpoint_update = false;
+    if (new_endpoint && new_endpoint !== connection.endpoint) {
+        if (connection.endpoint_type !== 'S3_COMPATIBLE' &&
+            connection.endpoint_type !== 'IBM_COS') {
+            throw new RpcError('FORBIDDEN',
+                'Endpoint updates are only supported for S3-compatible and IBM COS connections');
+        }
+        endpoint_update = true;
     }
 
-    const acc_update_set_obj = {
-        "sync_credentials_cache.$.access_key": identity,
-        "sync_credentials_cache.$.secret_key": encrypted_secret,
-    };
-    const ns_resource_update_map_obj = {
-        'connection.access_key': identity,
-        'connection.secret_key': encrypted_secret
-    };
+    if (secret) {
+        let check_result;
+        try {
+            check_result = await _check_external_connection_internal({
+                name,
+                identity,
+                secret,
+                endpoint: new_endpoint || connection.endpoint,
+                endpoint_type: connection.endpoint_type,
+                region: region,
+                cp_code: connection.cp_code,
+                auth_method: connection.auth_method,
+                azure_log_access_keys: azure_log_access_keys,
+            });
+
+        } catch (error) {
+            dbg.error('update_external_connection: _check_external_connection_internal had error', error);
+            throw new RpcError(error.rpc_code || error.code || 'INTERNAL_ERROR',
+                error.message || `Connection check failed for ${name}`);
+        }
+
+        if (check_result.status !== 'SUCCESS') {
+            throw new RpcError(check_result.status || check_result.error?.code || 'INTERNAL_ERROR',
+                check_result.error?.message || `Connection check failed for ${name}`);
+        }
+    }
+
+    const acc_update_set_obj = {};
+    const ns_resource_update_map_obj = {};
+    if (identity && secret) {
+        acc_update_set_obj["sync_credentials_cache.$.access_key"] = identity;
+        acc_update_set_obj["sync_credentials_cache.$.secret_key"] = encrypted_secret;
+        ns_resource_update_map_obj["connection.access_key"] = identity;
+        ns_resource_update_map_obj["connection.secret_key"] = encrypted_secret;
+    }
 
     if (azure_log_access_keys) {
         const encrypted_azure_client_secret = system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id(
@@ -640,6 +660,11 @@ async function update_external_connection(req) {
         };
         acc_update_set_obj["sync_credentials_cache.$.azure_log_access_keys"] = azure_creds_obj;
         ns_resource_update_map_obj["connection.azure_log_access_keys"] = azure_creds_obj;
+    }
+
+    if (endpoint_update) {
+        acc_update_set_obj["sync_credentials_cache.$.endpoint"] = new_endpoint;
+        ns_resource_update_map_obj["connection.endpoint"] = new_endpoint;
     }
 
     const accounts_updates = [{
@@ -660,8 +685,13 @@ async function update_external_connection(req) {
         )
         .map(pool => ({
             _id: pool._id,
-            'cloud_pool_info.access_keys.access_key': identity,
-            'cloud_pool_info.access_keys.secret_key': encrypted_secret,
+            ...(identity && secret ? {
+                'cloud_pool_info.access_keys.access_key': identity,
+                'cloud_pool_info.access_keys.secret_key': encrypted_secret,
+            } : {}),
+            ...(endpoint_update ? {
+                'cloud_pool_info.endpoint': new_endpoint,
+            } : {}),
         }));
 
     const ns_resources_updates = system_store.data.namespace_resources
@@ -686,12 +716,18 @@ async function update_external_connection(req) {
     });
 
     if (pools_updates.length > 0) {
-        await server_rpc.client.hosted_agents.update_credentials({
+        await server_rpc.client.hosted_agents.update_hosted_agents({
             pool_ids: pools_updates.map(update => String(update._id)),
-            credentials: {
+            ...(identity && secret ? {
+                credentials: {
                 access_key: identity.unwrap(),
                 secret_key: secret.unwrap(),
-            }
+            },
+            } : {}),
+            ...(endpoint_update ? {
+                endpoint: new_endpoint,
+                endpoint_type: connection.endpoint_type,
+            } : {}),
         }, {
             auth_token: req.auth_token
         });
@@ -931,10 +967,23 @@ async function check_aws_connection(params) {
 
     try {
         await P.timeout(check_connection_timeout, s3.listBuckets({}), () => timeoutError);
+
+        if (params.bucket) {
+            const resp = await s3.listObjectsV2({
+                Bucket: params.bucket,
+                Prefix: 'noobaa_blocks/',
+                MaxKeys: 1
+            });
+
+            if (!resp?.KeyCount) {
+                throw Object.assign(new Error(`new endpoint should be a valid location used by noobaa`),
+                    { code: 'UnknownEndpoint' });
+            }
+        }
         return { status: 'SUCCESS' };
     } catch (err) {
         const error_code = err.Code || err.code;
-        dbg.warn(`got error on listBuckets with params`, _.omit(params, 'secret'),
+        dbg.warn(`got error on check_aws_connection with params`, _.omit(params, 'secret'),
             ` error: ${err}, code: ${error_code}, message: ${err.message}`
         );
         const status = aws_error_mapping[error_code] || 'UNKNOWN_FAILURE';

--- a/src/test/unit_tests/internal/test_account_server.test.js
+++ b/src/test/unit_tests/internal/test_account_server.test.js
@@ -1,0 +1,754 @@
+/* Copyright (C) 2026 NooBaa */
+/* eslint max-lines-per-function: ['error', 1200] */
+
+'use strict';
+
+const SensitiveString = require('../../../util/sensitive_string');
+
+const MOCK_ACCOUNT_ID = 'account_id_123';
+const MOCK_POOL_ID = 'pool_id_456';
+const MOCK_NS_RESOURCE_ID = 'ns_resource_id_789';
+const MOCK_AUTH_TOKEN = 'mock_auth_token';
+const MOCK_MASTER_KEY_ID = 'master_key_id_abc';
+
+function make_sensitive(str) {
+    return new SensitiveString(str);
+}
+
+const mock_connection = {
+    name: 'my-connection',
+    endpoint: 'http://endpoint-a.example.com',
+    endpoint_type: 'S3_COMPATIBLE',
+    access_key: make_sensitive('old_access_key'),
+    secret_key: make_sensitive('old_secret_key'),
+    region: 'us-east-1',
+};
+
+function make_mock_pool(overrides = {}) {
+    return {
+        _id: MOCK_POOL_ID,
+        cloud_pool_info: {
+            endpoint_type: mock_connection.endpoint_type,
+            endpoint: mock_connection.endpoint,
+            access_keys: {
+                account_id: { _id: MOCK_ACCOUNT_ID },
+                access_key: mock_connection.access_key,
+                secret_key: mock_connection.secret_key,
+            },
+        },
+        ...overrides,
+    };
+}
+
+function make_mock_ns_resource(overrides = {}) {
+    return {
+        _id: MOCK_NS_RESOURCE_ID,
+        account: { _id: MOCK_ACCOUNT_ID },
+        connection: {
+            endpoint_type: mock_connection.endpoint_type,
+            endpoint: mock_connection.endpoint,
+            access_key: mock_connection.access_key,
+            secret_key: mock_connection.secret_key,
+        },
+        ...overrides,
+    };
+}
+
+// --- Mocks ---
+
+const mock_system_store = {
+    master_key_manager: {
+        encrypt_sensitive_string_with_master_key_id: jest.fn(secret => make_sensitive('encrypted_' + secret)),
+    },
+    data: {
+        pools: [],
+        namespace_resources: [],
+    },
+    make_changes: jest.fn().mockResolvedValue(undefined),
+};
+
+const mock_server_rpc = {
+    client: {
+        hosted_agents: {
+            update_hosted_agents: jest.fn().mockResolvedValue(undefined),
+        },
+    },
+};
+
+const mock_cloud_utils = {
+    find_cloud_connection: jest.fn().mockReturnValue(mock_connection),
+    get_s3_endpoint_signature_ver: jest.fn().mockReturnValue('v4'),
+};
+
+const mock_noobaa_s3_client = {
+    get_s3_client_v3_params: jest.fn(),
+    get_requestHandler_with_suitable_agent: jest.fn().mockReturnValue({}),
+};
+
+jest.mock('../../../../config', () => {
+    const { EventEmitter } = require('events');
+    return {
+        DEFAULT_REGION: 'us-east-1',
+        event_emitter: new EventEmitter(),
+        LOG_TO_STDERR_ENABLED: false,
+        LOG_TO_SYSLOG_ENABLED: false,
+        DEBUG_FACILITY: 'LOG_LOCAL0',
+    };
+});
+jest.mock('../../../util/debug_module', () => {
+    const mock_dbg = {
+        log0: jest.fn(),
+        log1: jest.fn(),
+        log2: jest.fn(),
+        log3: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        set_module_level: jest.fn(),
+    };
+    return () => mock_dbg;
+});
+jest.mock('../../../util/cloud_utils', () => mock_cloud_utils);
+jest.mock('../../../server/system_services/system_store', () => ({
+    get_instance: () => mock_system_store,
+}));
+jest.mock('../../../server/server_rpc', () => mock_server_rpc);
+jest.mock('../../../sdk/noobaa_s3_client/noobaa_s3_client', () => mock_noobaa_s3_client);
+jest.mock('../../../util/promise', () => ({
+    timeout: jest.fn((timeout, promise) => promise),
+}));
+jest.mock('../../../rpc', () => ({
+    RpcError: class RpcError extends Error {
+        constructor(rpc_code, message) {
+            super(message || rpc_code);
+            this.rpc_code = rpc_code;
+        }
+    },
+}));
+jest.mock('../../../server/notifications/dispatcher', () => ({ instance: () => ({}) }));
+jest.mock('../../../server/bg_services/usage_aggregator', () => ({}));
+jest.mock('../../../endpoint/sts/sts_rest', () => ({ OP_NAME_TO_ACTION: {} }));
+jest.mock('@azure/monitor-query-logs', () => ({ Durations: {}, LogsQueryClient: jest.fn() }));
+jest.mock('@azure/identity', () => ({ ClientSecretCredential: jest.fn() }));
+jest.mock('../../../util/NetStorageKit-Node-master/lib/netstorage', () => jest.fn());
+jest.mock('../../../util/account_util', () => ({}));
+jest.mock('../../../endpoint/iam/iam_utils', () => ({}));
+jest.mock('../../../endpoint/iam/iam_constants', () => ({
+    IAM_ACTIONS: {},
+    IAM_DEFAULT_PATH: '/',
+    ACCESS_KEY_STATUS_ENUM: {},
+    MAX_TAGS: 50,
+    MAX_NUMBER_OF_IAM_ROLES: 100,
+    DEFAULT_MAX_SESSION_DURATION_SECS: 3600,
+}));
+
+const account_server = require('../../../server/system_services/account_server');
+
+describe('account_server - update_external_connection', () => {
+
+    let mock_req;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mock_cloud_utils.find_cloud_connection.mockReturnValue({ ...mock_connection });
+        mock_cloud_utils.get_s3_endpoint_signature_ver.mockReturnValue('v4');
+        mock_noobaa_s3_client.get_requestHandler_with_suitable_agent.mockReturnValue({});
+        mock_system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id
+            .mockImplementation(secret => make_sensitive('encrypted_' + secret));
+        mock_system_store.make_changes.mockResolvedValue(undefined);
+        mock_server_rpc.client.hosted_agents.update_hosted_agents.mockResolvedValue(undefined);
+        mock_system_store.data.pools = [];
+        mock_system_store.data.namespace_resources = [];
+
+        mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                master_key_id: { _id: MOCK_MASTER_KEY_ID },
+                sync_credentials_cache: [mock_connection],
+            },
+            rpc_params: {
+                name: 'my-connection',
+                identity: make_sensitive('new_access_key'),
+                secret: make_sensitive('new_secret_key'),
+            },
+            auth_token: MOCK_AUTH_TOKEN,
+        };
+    });
+
+    describe('endpoint update validation', () => {
+
+        test('should throw FORBIDDEN when endpoint_type is not S3_COMPATIBLE or IBM_COS', async () => {
+            mock_cloud_utils.find_cloud_connection.mockReturnValue({
+                ...mock_connection,
+                endpoint_type: 'AWS',
+            });
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'AWS',
+            };
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toMatchObject({ rpc_code: 'FORBIDDEN' });
+        });
+
+        test('should allow endpoint update for S3_COMPATIBLE connections', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+            };
+
+            await account_server.update_external_connection(mock_req);
+            expect(mock_system_store.make_changes).toHaveBeenCalled();
+        });
+
+        test('should allow endpoint update for IBM_COS connections', async () => {
+            mock_cloud_utils.find_cloud_connection.mockReturnValue({
+                ...mock_connection,
+                endpoint_type: 'IBM_COS',
+            });
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'IBM_COS',
+            };
+
+            await account_server.update_external_connection(mock_req);
+            expect(mock_system_store.make_changes).toHaveBeenCalled();
+        });
+
+        test('should not set endpoint_update when endpoint has not changed', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: mock_connection.endpoint,
+            };
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const acc_set = make_changes_arg.update.accounts[0].$set;
+            expect(acc_set).not.toHaveProperty('sync_credentials_cache.$.endpoint');
+        });
+    });
+
+    describe('credential updates', () => {
+
+        test('should update account credentials when identity and secret are provided', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const acc_set = make_changes_arg.update.accounts[0].$set;
+            expect(acc_set['sync_credentials_cache.$.access_key']).toEqual(make_sensitive('new_access_key'));
+            expect(acc_set['sync_credentials_cache.$.secret_key']).toBeDefined();
+        });
+
+        test('should use connection access_key as identity when rpc_params.identity is not provided', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            delete mock_req.rpc_params.identity;
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const acc_set = make_changes_arg.update.accounts[0].$set;
+            expect(acc_set['sync_credentials_cache.$.access_key'].unwrap()).toBe('old_access_key');
+        });
+    });
+
+    describe('pool and namespace resource updates with endpoint change', () => {
+
+        test('should include endpoint in pool updates when endpoint is changed', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.pools = [make_mock_pool()];
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+            };
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const pool_update = make_changes_arg.update.pools[0];
+            expect(pool_update['cloud_pool_info.endpoint']).toBe('http://new-endpoint.example.com');
+        });
+
+        test('should include endpoint in namespace resource updates when endpoint is changed', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.namespace_resources = [make_mock_ns_resource()];
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+            };
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const ns_update = make_changes_arg.update.namespace_resources[0];
+            expect(ns_update['connection.endpoint']).toBe('http://new-endpoint.example.com');
+        });
+
+        test('should not include endpoint fields in pool update when endpoint unchanged', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.pools = [make_mock_pool()];
+
+            await account_server.update_external_connection(mock_req);
+
+            const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+            const pool_update = make_changes_arg.update.pools[0];
+            expect(pool_update).not.toHaveProperty('cloud_pool_info.endpoint');
+            expect(pool_update).not.toHaveProperty('cloud_pool_info.endpoint_type');
+        });
+    });
+
+    describe('hosted agents update', () => {
+
+        test('should call update_hosted_agents with endpoint when pools are updated and endpoint changed', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.pools = [make_mock_pool()];
+            mock_req.rpc_params.endpoint_info = {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+            };
+
+            await account_server.update_external_connection(mock_req);
+
+            expect(mock_server_rpc.client.hosted_agents.update_hosted_agents).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pool_ids: [String(MOCK_POOL_ID)],
+                    endpoint: 'http://new-endpoint.example.com',
+                    endpoint_type: 'S3_COMPATIBLE',
+                }),
+                { auth_token: MOCK_AUTH_TOKEN }
+            );
+        });
+
+        test('should call update_hosted_agents with credentials when pools are updated', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.pools = [make_mock_pool()];
+
+            await account_server.update_external_connection(mock_req);
+
+            expect(mock_server_rpc.client.hosted_agents.update_hosted_agents).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pool_ids: [String(MOCK_POOL_ID)],
+                    credentials: {
+                        access_key: 'new_access_key',
+                        secret_key: 'new_secret_key',
+                    },
+                }),
+                { auth_token: MOCK_AUTH_TOKEN }
+            );
+        });
+
+        test('should not call update_hosted_agents when no pools match', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockResolvedValue({}),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            mock_system_store.data.pools = [];
+
+            await account_server.update_external_connection(mock_req);
+
+            expect(mock_server_rpc.client.hosted_agents.update_hosted_agents).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('connection check failure propagation', () => {
+
+        test('should throw INVALID_CREDENTIALS when check_aws_connection returns that status', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockRejectedValue(
+                    Object.assign(new Error('invalid creds'), { code: 'InvalidAccessKeyId' })
+                ),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toMatchObject({ rpc_code: 'INVALID_CREDENTIALS' });
+        });
+
+        test('should throw TIMEOUT when connection times out', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockRejectedValue(
+                    Object.assign(new Error('Operation timeout'), { code: 'OperationTimeout' })
+                ),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toMatchObject({ rpc_code: 'TIMEOUT' });
+        });
+
+        test('should propagate error.code when _check_external_connection_internal throws unexpectedly', async () => {
+            mock_cloud_utils.get_s3_endpoint_signature_ver.mockImplementation(() => {
+                throw Object.assign(new Error('something broke'), { code: 'UNEXPECTED_FAILURE' });
+            });
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toMatchObject({ rpc_code: 'UNEXPECTED_FAILURE' });
+        });
+
+        test('should fall back to INTERNAL_ERROR when thrown error has no code', async () => {
+            mock_cloud_utils.get_s3_endpoint_signature_ver.mockImplementation(() => {
+                throw new Error('unknown error');
+            });
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toMatchObject({ rpc_code: 'INTERNAL_ERROR' });
+        });
+
+        test('should not call make_changes when connection check fails', async () => {
+            const mock_s3 = {
+                listBuckets: jest.fn().mockRejectedValue(
+                    Object.assign(new Error('invalid creds'), { code: 'InvalidAccessKeyId' })
+                ),
+            };
+            mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+            await expect(account_server.update_external_connection(mock_req))
+                .rejects.toThrow();
+            expect(mock_system_store.make_changes).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('account_server - check_aws_connection (bucket validation via check_external_connection)', () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mock_cloud_utils.find_cloud_connection.mockReturnValue({ ...mock_connection });
+        mock_cloud_utils.get_s3_endpoint_signature_ver.mockReturnValue('v4');
+        mock_noobaa_s3_client.get_requestHandler_with_suitable_agent.mockReturnValue({});
+        mock_system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id
+            .mockImplementation(secret => make_sensitive('encrypted_' + secret));
+        mock_system_store.make_changes.mockResolvedValue(undefined);
+        mock_server_rpc.client.hosted_agents.update_hosted_agents.mockResolvedValue(undefined);
+        mock_system_store.data.pools = [];
+        mock_system_store.data.namespace_resources = [];
+    });
+
+    test('should return SUCCESS when listBuckets succeeds and no bucket param', async () => {
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                master_key_id: { _id: MOCK_MASTER_KEY_ID },
+                sync_credentials_cache: [mock_connection],
+            },
+            rpc_params: {
+                name: 'my-connection',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+            },
+            auth_token: MOCK_AUTH_TOKEN,
+        };
+
+        await account_server.update_external_connection(mock_req);
+        expect(mock_s3.listBuckets).toHaveBeenCalled();
+        expect(mock_system_store.make_changes).toHaveBeenCalled();
+    });
+
+    test('should not call listObjectsV2 when no bucket param is provided', async () => {
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+            listObjectsV2: jest.fn(),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                master_key_id: { _id: MOCK_MASTER_KEY_ID },
+                sync_credentials_cache: [mock_connection],
+            },
+            rpc_params: {
+                name: 'my-connection',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+                endpoint_info: {
+                    endpoint: 'http://different-endpoint.example.com',
+                    endpoint_type: 'S3_COMPATIBLE',
+                },
+            },
+            auth_token: MOCK_AUTH_TOKEN,
+        };
+
+        await account_server.update_external_connection(mock_req);
+        expect(mock_s3.listObjectsV2).not.toHaveBeenCalled();
+    });
+
+    test('should check noobaa_blocks when bucket param is provided via check_external_connection', async () => {
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+            listObjectsV2: jest.fn().mockResolvedValue({ KeyCount: 2 }),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                sync_credentials_cache: [],
+            },
+            rpc_params: {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+                bucket: 'target-bucket',
+            },
+        };
+
+        const result = await account_server.check_external_connection(mock_req);
+        expect(result.status).toBe('SUCCESS');
+        expect(mock_s3.listObjectsV2).toHaveBeenCalledWith({
+            Bucket: 'target-bucket',
+            Prefix: 'noobaa_blocks/',
+            MaxKeys: 1,
+        });
+    });
+
+    test('should return INVALID_ENDPOINT when noobaa_blocks not found via check_external_connection', async () => {
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+            listObjectsV2: jest.fn().mockResolvedValue({ KeyCount: 0 }),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                sync_credentials_cache: [],
+            },
+            rpc_params: {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+                bucket: 'target-bucket',
+            },
+        };
+
+        const result = await account_server.check_external_connection(mock_req);
+        expect(result.status).toBe('INVALID_ENDPOINT');
+    });
+
+    test('should not call listObjectsV2 when bucket is omitted from check_external_connection', async () => {
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+            listObjectsV2: jest.fn(),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                sync_credentials_cache: [],
+            },
+            rpc_params: {
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+            },
+        };
+
+        const result = await account_server.check_external_connection(mock_req);
+        expect(result.status).toBe('SUCCESS');
+        expect(mock_s3.listObjectsV2).not.toHaveBeenCalled();
+    });
+
+    test('should prepend http:// to endpoint if no protocol specified', async () => {
+        mock_cloud_utils.find_cloud_connection.mockReturnValue({
+            ...mock_connection,
+            endpoint: 'bare-endpoint.example.com',
+        });
+        const mock_s3 = {
+            listBuckets: jest.fn().mockResolvedValue({}),
+        };
+        mock_noobaa_s3_client.get_s3_client_v3_params.mockReturnValue(mock_s3);
+
+        const mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                master_key_id: { _id: MOCK_MASTER_KEY_ID },
+                sync_credentials_cache: [{ ...mock_connection, endpoint: 'bare-endpoint.example.com' }],
+            },
+            rpc_params: {
+                name: 'my-connection',
+                identity: make_sensitive('access_key'),
+                secret: make_sensitive('secret_key'),
+            },
+            auth_token: MOCK_AUTH_TOKEN,
+        };
+
+        await account_server.update_external_connection(mock_req);
+        const s3_params = mock_noobaa_s3_client.get_s3_client_v3_params.mock.calls[0][0];
+        expect(s3_params.endpoint).toBe('http://bare-endpoint.example.com');
+    });
+});
+
+describe('account_server - endpoint-only update (CLI path, no secret)', () => {
+
+    let mock_req;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mock_cloud_utils.find_cloud_connection.mockReturnValue({ ...mock_connection });
+        mock_cloud_utils.get_s3_endpoint_signature_ver.mockReturnValue('v4');
+        mock_noobaa_s3_client.get_requestHandler_with_suitable_agent.mockReturnValue({});
+        mock_system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id
+            .mockImplementation(secret => make_sensitive('encrypted_' + secret));
+        mock_system_store.make_changes.mockResolvedValue(undefined);
+        mock_server_rpc.client.hosted_agents.update_hosted_agents.mockResolvedValue(undefined);
+        mock_system_store.data.pools = [make_mock_pool()];
+        mock_system_store.data.namespace_resources = [make_mock_ns_resource()];
+
+        mock_req = {
+            account: {
+                _id: MOCK_ACCOUNT_ID,
+                master_key_id: { _id: MOCK_MASTER_KEY_ID },
+                sync_credentials_cache: [mock_connection],
+            },
+            rpc_params: {
+                name: 'my-connection',
+                endpoint_info: {
+                    endpoint: 'http://new-endpoint.example.com',
+                    endpoint_type: 'S3_COMPATIBLE',
+                },
+            },
+            auth_token: MOCK_AUTH_TOKEN,
+        };
+    });
+
+    test('should skip connection check when secret is not provided', async () => {
+        await account_server.update_external_connection(mock_req);
+        expect(mock_noobaa_s3_client.get_s3_client_v3_params).not.toHaveBeenCalled();
+    });
+
+    test('should not encrypt anything when secret is not provided', async () => {
+        await account_server.update_external_connection(mock_req);
+        expect(mock_system_store.master_key_manager.encrypt_sensitive_string_with_master_key_id)
+            .not.toHaveBeenCalled();
+    });
+
+    test('should update endpoint in account sync_credentials_cache', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const acc_set = make_changes_arg.update.accounts[0].$set;
+        expect(acc_set['sync_credentials_cache.$.endpoint']).toBe('http://new-endpoint.example.com');
+    });
+
+    test('should not update credentials in account when secret is not provided', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const acc_set = make_changes_arg.update.accounts[0].$set;
+        expect(acc_set).not.toHaveProperty('sync_credentials_cache.$.access_key');
+        expect(acc_set).not.toHaveProperty('sync_credentials_cache.$.secret_key');
+    });
+
+    test('should update endpoint in matching pools', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const pool_update = make_changes_arg.update.pools[0];
+        expect(pool_update['cloud_pool_info.endpoint']).toBe('http://new-endpoint.example.com');
+    });
+
+    test('should not update credentials in pools when secret is not provided', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const pool_update = make_changes_arg.update.pools[0];
+        expect(pool_update).not.toHaveProperty('cloud_pool_info.access_keys.access_key');
+        expect(pool_update).not.toHaveProperty('cloud_pool_info.access_keys.secret_key');
+    });
+
+    test('should update endpoint in matching namespace resources', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const ns_update = make_changes_arg.update.namespace_resources[0];
+        expect(ns_update['connection.endpoint']).toBe('http://new-endpoint.example.com');
+    });
+
+    test('should not update credentials in namespace resources when secret is not provided', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        const make_changes_arg = mock_system_store.make_changes.mock.calls[0][0];
+        const ns_update = make_changes_arg.update.namespace_resources[0];
+        expect(ns_update).not.toHaveProperty('connection.access_key');
+        expect(ns_update).not.toHaveProperty('connection.secret_key');
+    });
+
+    test('should call update_hosted_agents with endpoint but no credentials', async () => {
+        await account_server.update_external_connection(mock_req);
+
+        expect(mock_server_rpc.client.hosted_agents.update_hosted_agents).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pool_ids: [String(MOCK_POOL_ID)],
+                endpoint: 'http://new-endpoint.example.com',
+                endpoint_type: 'S3_COMPATIBLE',
+            }),
+            { auth_token: MOCK_AUTH_TOKEN }
+        );
+        const call_args = mock_server_rpc.client.hosted_agents.update_hosted_agents.mock.calls[0][0];
+        expect(call_args).not.toHaveProperty('credentials');
+    });
+
+    test('should still throw FORBIDDEN for unsupported endpoint types without secret', async () => {
+        mock_cloud_utils.find_cloud_connection.mockReturnValue({
+            ...mock_connection,
+            endpoint_type: 'AWS',
+        });
+        mock_req.rpc_params.endpoint_info.endpoint_type = 'AWS';
+
+        await expect(account_server.update_external_connection(mock_req))
+            .rejects.toMatchObject({ rpc_code: 'FORBIDDEN' });
+    });
+});


### PR DESCRIPTION
### Describe the Problem
The endpoint field in the backingstore cannot be changed after its creation. This causes a problem if the user needs to change the endpoint while data is present in the backingstore.

### Explain the Changes
1. Add `endpoint` and `endpoint_type` to `update_external_connection` API definition and make `secret` as not mandatory.
2. In `update_external_connection` implementation, reject the request if backingstore is not of types `S3 compatible` or `IBM COS`.
3. Update the accounts and pools table with the new endpoint details.
4. Update the hosted agents by calling RPC `update_hosted_agents` with the new endpoint.
5. Add a new API `update_hosted_agents` which accepts credentials and endpoint details.
6. In agents class implementation rename `update_credentials ` to `update_hosted_agents` so that we have a common method to support both secret and endpoint changes.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Create a backingstore of type S3 compatible with any target endpoint.
2. Once it goes to ready phase, create a bucketclass for the backingstore.
3. Create an OBC with the newly created bucketclass.
4. Edit the backingstore using `kubectl edit` and update the endpoint. 
5. Test that the new endpoint is now accessible from the OBC.


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin API to update hosted agent settings, including credentials plus optional endpoint and endpoint type.
  * Hosted agent updates now support applying S3-backed endpoint configuration.
* **Changes**
  * External connection updates now only require a name; endpoint, endpoint type, and bucket are captured as strings.
  * Endpoint changes are gated to specific connection types and validated during update.
  * Hosted-agent propagation now uses the new hosted-agent update path and conditionally includes credentials and endpoint details.
* **Bug Fixes**
  * Improved AWS/S3 endpoint validation by verifying objects exist under the expected prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->