### PR TITLE
LDAP NC guide

### DIFF
--- a/docs/NooBaaNonContainerized/ldap_non_containerised.md
+++ b/docs/NooBaaNonContainerized/ldap_non_containerised.md
@@ -1,0 +1,478 @@
+# LDAP on NooBaa Non-Containerized (NC) — Step-by-Step Guide
+
+> For the IAM Roles design (Phase 1 & Phase 2), schemas, code changes, and diagrams, see [IAM NC Design](../design/iam_nc.md#iam-roles).
+
+## Table of Contents
+
+1. [What is LDAP?](#what-is-ldap)
+  - [Request sequence](#request-sequence-assumerolewithwebidentity--s3)
+2. [Prerequisites](#1-prerequisites)
+3. [Start the LDAP test server](#2-start-the-ldap-test-server)
+4. [Verify LDAP connectivity](#3-verify-ldap-connectivity)
+5. [Configure LDAP in NooBaa](#4-configure-ldap-in-noobaa)
+6. [Start the NC endpoint](#5-start-the-nc-endpoint)
+7. [Create a role account](#6-create-a-role-account)
+8. [Generate the web-identity JWT](#7-generate-the-web-identity-jwt)
+9. [Call AssumeRoleWithWebIdentity](#8-call-assumerolewithwebidentity)
+10. [Use temporary credentials for S3](#9-use-temporary-credentials-for-s3)
+11. [Troubleshooting](#10-troubleshooting)
+
+---
+
+## What is LDAP?
+
+**LDAP** (Lightweight Directory Access Protocol) is a standard protocol for accessing and maintaining directory information — typically usernames, passwords, group memberships, and organizational data.
+
+In NooBaa, LDAP acts as an **external identity provider**: NooBaa delegates username/password validation to your existing directory at STS request time, so users can authenticate with credentials they already know.
+
+## Why is LDAP integration required?
+
+Without LDAP, every person who needs S3 access must have a **dedicated NooBaa account** with permanent access keys.
+
+LDAP integration addresses this by letting organizations **reuse their existing directory credentials** to obtain **short-lived STS tokens** for S3. Users never receive permanent NooBaa access keys; they authenticate once against LDAP and receive temporary credentials.
+
+## How NooBaa uses LDAP
+
+NooBaa integrates LDAP through the AWS-compatible STS operation `**AssumeRoleWithWebIdentity`**:
+
+1. A client application builds a **JWT web-identity token** containing the LDAP username and password.
+2. The client calls the NooBaa STS endpoint with that token and a **Role ARN** pointing to a pre-configured role account in NooBaa.
+3. NooBaa parses and verifies the JWT
+4. NooBaa validates the credentials against the external LDAP server.
+5. On success, NooBaa issues **temporary access keys + session token** for the target role account.
+6. Client uses those credentials (plus SessionToken) for S3 operations.
+
+### Request sequence (AssumeRoleWithWebIdentity → S3)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant App as Client App
+    participant STS as NooBaa STS
+    participant LDAP as LDAP Server
+    participant S3 as NooBaa S3
+    participant FS as Filesystem
+
+    Note over App: Build JWT with user, password, type=ldap<br/>Sign with jwt_secret
+
+    User->>App: Login (LDAP creds)
+    App->>STS: AssumeRoleWithWebIdentity<br/>RoleArn + WebIdentityToken
+
+    STS->>STS: Verify JWT signature / decode claims
+    STS->>LDAP: Verify username and password
+    LDAP-->>STS: Authentication OK
+
+    STS->>STS: Resolve role account from RoleArn<br/>Check role_config policy
+    STS-->>App: Credentials<br/>(AccessKeyId, SecretAccessKey, SessionToken)
+
+    App->>S3: PUT / GET / LIST<br/>X-Amz-Security-Token header
+    S3->>S3: Verify session JWT<br/>Act as role account
+    S3->>FS: Read / write objects
+    FS-->>S3: Result
+    S3-->>App: S3 response
+```
+
+
+
+## What you need to set up
+
+
+| Component                                         | Purpose                                                                      |
+| ------------------------------------------------- | ---------------------------------------------------------------------------- |
+| External LDAP server                              | Source of truth for user credentials                                         |
+| LDAP config file `/etc/noobaa-server/ldap_config` | LDAP server details so NooBaa can connect                                    |
+| NC account with `role_config`                     | Defines the STS role that LDAP users assume (buckets, FS identity, policies) |
+| JWT signing secret (`jwt_secret`)                 | To encode/decode JWT tokens                                                  |
+| STS HTTPS port                                    | `7443` (configurable via `ENDPOINT_SSL_STS_PORT`)                            |
+| S3 HTTPS port                                     | `6443`                                                                       |
+| Role ARN format                                   | `arn:aws:sts::<role-account-access-key>:role/<role_name>`                    |
+
+
+---
+
+## 1. Prerequisites
+
+- NooBaa NC source tree (or RPM installed).
+- Node.js (to run `nsfs.js` / `manage_nsfs.js`).
+- Docker (for the LDAP test server).
+- `openldap` CLI tools (`ldapsearch`) — `brew install openldap` on macOS.
+- AWS CLI v2.
+- `jsonwebtoken` npm package (for generating test tokens).
+
+---
+
+## 2. Start the LDAP test server
+
+Ensure you have the following in .env
+LOCAL_MD_SERVER=true
+JWT_SECRET=
+
+```bash
+docker run --rm -it \
+  -p 1389:389 \
+  -p 1636:636 \
+  ghcr.io/ldapjs/docker-test-openldap/openldap:latest
+```
+
+Keep this container running in a dedicated terminal.
+
+---
+
+## 3. Verify LDAP connectivity
+
+Search for a user (no TLS):
+
+```bash
+ldapsearch -H ldap://127.0.0.1:1389 -x \
+  -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone \
+  -b "ou=people,dc=planetexpress,dc=com" "(uid=fry)" ou
+```
+
+Note: Above details can be found on [LDAP testing details](https://github.com/ldapjs/docker-test-openldap/pkgs/container/docker-test-openldap%2Fopenldap)
+
+If these succeed, the LDAP server is ready.
+
+---
+
+## 4. Configure LDAP in NooBaa
+
+Create `/etc/noobaa-server/ldap_config` on the host where the NC endpoint runs:
+
+```bash
+sudo mkdir -p /etc/noobaa-server
+
+sudo tee /etc/noobaa-server/ldap_config <<'EOF'
+{
+  "uri": "ldaps://127.0.0.1:1636",
+  "admin": "cn=admin,dc=planetexpress,dc=com",
+  "secret": "GoodNewsEveryone",
+  "search_dn": "ou=people,dc=planetexpress,dc=com",
+  "dn_attribute": "uid",
+  "search_scope": "sub",
+  "jwt_secret": "<same as env>",
+  "tls_options": {
+    "rejectUnauthorized": false
+  }
+}
+EOF
+```
+
+---
+
+## 5. Start the NC endpoint
+
+In a separate terminal, from the noobaa-core repo root:
+
+```bash
+sudo node src/cmd/nsfs.js --debug=5
+```
+
+The endpoint starts S3 (port `6443`) and STS (port `7443`) HTTPS servers.
+
+Confirm LDAP connected — look for this in the debug output:
+
+```text
+_connect: initial connect succeeded
+```
+
+If bind fails you will see retry messages every 3 seconds until LDAP is reachable.
+
+---
+
+## 6. Create a role account
+
+LDAP users do not call STS with permanent access keys. Instead they call `AssumeRoleWithWebIdentity` against an account that has a `**role_config**`. The role account's access key is used in the Role ARN.
+
+Create a new account with a role in one step using `noobaa-cli` / `manage_nsfs.js`:
+
+```bash
+mkdir -p /private/tmp/noobaa-buckets
+
+sudo node src/cmd/manage_nsfs.js account add \
+  --name ldap_role \
+  --uid 501 \
+  --gid 20 \
+  --new_buckets_path /private/tmp/noobaa-buckets \
+  --role_config '{"role_name":"ldap_user","assume_role_policy":{"statement":[{"effect":"allow","action":["sts:*"],"principal":["*"]}]}}'
+```
+
+Sample response:
+
+```
+{
+  "response": {
+    "code": "AccountCreated",
+    "message": "Account has been created successfully: ldap_role",
+    "reply": {
+      "_id": "6a2bdeabf5c8e167f92cb079",
+      "name": "ldap_role",
+      "email": "ldap_role",
+      "creation_date": "2026-06-12T10:25:47.422Z",
+      "access_keys": [
+        {
+          "access_key": "uLKzwrCVTMjBgeKW8PJ7",
+          "secret_key": "EAXGSIHbsUnq/2ybL66uSo5axOz6mv6pPjyaf5MA"
+        }
+      ],
+      "nsfs_account_config": {
+        "uid": 501,
+        "gid": 20,
+        "new_buckets_path": "/private/tmp/noobaa-buckets"
+      },
+      "role_config": {
+        "role_name": "ldap_user",
+        "assume_role_policy": {
+          "statement": [
+            {
+              "effect": "allow",
+              "action": [
+                "sts:*"
+              ],
+              "principal": [
+                "*"
+              ]
+            }
+          ]
+        }
+      },
+      "allow_bucket_creation": true
+    }
+  }
+}
+```
+
+If you already have an account, to add `role_config` to an existing account:
+
+```bash
+sudo node src/cmd/manage_nsfs.js account update \
+  --name ldap_role \
+  --role_config '{"role_name":"ldap_user","assume_role_policy":{"statement":[{"effect":"allow","action":["sts:*"],"principal":["*"]}]}}'
+```
+
+Remove `role_config`:
+
+```bash
+sudo node src/cmd/manage_nsfs.js account update \
+  --name ldap_role \
+  --role_config ''
+```
+
+Retrieve the access key (needed for the Role ARN):
+
+```bash
+sudo node src/cmd/manage_nsfs.js account status \
+  --name ldap_role \
+  --show_secrets
+```
+
+#### `role_config` JSON structure
+
+```json
+{
+  "role_name": "ldap_user",
+  "assume_role_policy": {
+    "statement": [{
+      "effect": "allow",
+      "action": ["sts:*"],
+      "principal": ["*"]
+    }]
+  }
+}
+```
+
+
+| Field                                      | Description                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------ |
+| `role_name`                                | Name used in the STS Role ARN                                                  |
+| `assume_role_policy.statement[].effect`    | `allow` or `deny`                                                              |
+| `assume_role_policy.statement[].action`    | e.g. `["sts:*"]` or `["sts:AssumeRoleWithWebIdentity"]`                        |
+| `assume_role_policy.statement[].principal` | Who may assume the role. `["*"]` allows any anonymous LDAP web-identity caller |
+
+
+---
+
+## 7. Generate the web-identity JWT
+
+The JWT payload must contain `user` and `password`.
+
+**Important:** the signing secret must match `jwt_secret` in `/etc/noobaa-server/ldap_config`.
+
+```bash
+export JWT_SECRET=<secret_string>
+
+# Token for fry
+TOKEN=$(node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign({
+  user: 'fry',
+  password: 'fry'
+}, process.env.JWT_SECRET));
+")
+
+# Token for leela
+TOKEN_LEELA=$(node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign({
+  user: 'leela',
+  password: 'leela'
+}, process.env.JWT_SECRET));
+")
+
+echo "Fry token:  $TOKEN"
+echo "Leela token: $TOKEN_LEELA"
+```
+
+### Unsigned token (only when `jwt_secret` is NOT set in ldap_config)
+
+```bash
+node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign(
+  { user: 'fry', password: 'fry', type: 'ldap' },
+  undefined,
+  { algorithm: 'none' }
+));
+"
+```
+
+---
+
+## 8. Call AssumeRoleWithWebIdentity
+
+Set the role account access key from [step 6](#6-create-a-role-account):
+
+```bash
+export ROLE_ACCESS_KEY=<access-key-from-step-6>   # from `account status --show_secrets`
+```
+
+Call STS — **no caller AWS credentials required**:
+
+```bash
+aws sts assume-role-with-web-identity \
+  --endpoint https://127.0.0.1:7443 \
+  --role-arn "arn:aws:sts::${ROLE_ACCESS_KEY}:role/ldap_user" \
+  --role-session-name fry1 \
+  --web-identity-token "$TOKEN" \
+  --no-verify-ssl
+```
+
+Example successful response:
+
+```json
+{
+  "Credentials": {
+    "AccessKeyId": "67H8BDvKqR6otsEdHYlb",
+    "SecretAccessKey": "IS3F1/G0iRXdK9xpxAUcw+05+nVolYuU53nacGu1",
+    "SessionToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "Expiration": "2026-04-24T08:08:40+00:00"
+  },
+  "AssumedRoleUser": {
+    "AssumedRoleId": "eFqt2bpoL9TwrOlGxTFF:fry1",
+    "Arn": "arn:aws:sts::eFqt2bpoL9TwrOlGxTFF:assumed-role/ldap_user/fry1"
+  },
+  "SourceIdentity": "cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com"
+}
+```
+
+Test with a different LDAP user (leela):
+
+```bash
+aws sts assume-role-with-web-identity \
+  --endpoint https://127.0.0.1:7443 \
+  --role-arn "arn:aws:sts::${ROLE_ACCESS_KEY}:role/ldap_user" \
+  --role-session-name leela-session \
+  --web-identity-token "$TOKEN_LEELA" \
+  --no-verify-ssl
+```
+
+### Role ARN reference
+
+```text
+arn:aws:sts::<role-account-access-key>:role/<role_name>
+```
+
+- `<role-account-access-key>` — permanent access key of the account that owns `role_config`
+- `<role_name>` — must match `role_config.role_name` exactly
+
+---
+
+## 9. Use temporary credentials for S3
+
+Export the credentials from the STS response:
+
+```bash
+export TEMP_ACCESS_KEY=67H8BDvKqR6otsEdHYlb
+export TEMP_SECRET_KEY='IS3F1/G0iRXdK9xpxAUcw+05+nVolYuU53nacGu1'
+export TEMP_SESSION_TOKEN='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+```
+
+List buckets:
+
+```bash
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --endpoint-url https://127.0.0.1:6443 --no-verify-ssl s3 ls
+```
+
+(
+if 6443 port not working, try:
+
+```
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --endpoint-url http://127.0.0.1:6001 --no-verify-ssl s3 ls 
+```
+
+)
+
+Create buckets:
+
+```
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --region us-east-1 \
+  --endpoint-url http://127.0.0.1:6001 \
+  s3 mb s3://test-bucket-fry
+```
+
+---
+
+## 10. Troubleshooting
+
+### LDAP connection
+
+
+| Symptom                                   | Check                                                                                  |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `_connect: initial connect failed`        | LDAP docker running? Ports `1389`/`1636` mapped?                                       |
+| `LDAP is not configured or not connected` | File exists at `/etc/noobaa-server/ldap_config`? Endpoint restarted after creating it? |
+
+
+### JWT / web identity
+
+
+| Symptom                          | Check                                                    |
+| -------------------------------- | -------------------------------------------------------- |
+| `INVALID_WEB_IDENTITY_TOKEN`     | `jwt_secret` in ldap_config matches token signing secret |
+| `Missing a required claim: user` | JWT must include `user` and `password` fields            |
+| `invalid signature`              | Regenerate token with correct `JWT_SECRET`               |
+
+
+### Role / STS
+
+
+| Symptom                          | Check                                                         |
+| -------------------------------- | ------------------------------------------------------------- |
+| `NO_SUCH_ROLE`                   | Account has `role_config`; `role_name` in ARN matches         |
+| `issue with LDAP authentication` | Wrong username/password; check `search_dn` and `dn_attribute` |
+
+
+```bash
+# Verify role_config on NC account
+sudo node src/cmd/manage_nsfs.js account status \
+  --name ldap_role \
+  --show_secrets
+```

--- a/docs/NooBaaNonContainerized/ldap_non_containerised.md
+++ b/docs/NooBaaNonContainerized/ldap_non_containerised.md
@@ -1,0 +1,456 @@
+# LDAP on NooBaa Non-Containerized (NC) — Step-by-Step Guide
+
+> IAM Roles design (trust vs permission policy, schemas, CRUD, diagrams) lives in [IAM NC Design](../design/iam_nc.md#iam-roles). This guide covers LDAP-specific setup and the STS `AssumeRoleWithWebIdentity` flow for **S3** access.
+
+## Table of Contents
+
+1. [What is LDAP?](#what-is-ldap)
+   - [Request sequence](#request-sequence-assumerolewithwebidentity--s3)
+2. [Prerequisites](#1-prerequisites)
+3. [Start the LDAP test server (optional)](#2-start-the-ldap-test-server-optional)
+4. [Verify LDAP connectivity](#3-verify-ldap-connectivity)
+5. [Configure LDAP in NooBaa](#4-configure-ldap-in-noobaa)
+6. [Start the NC endpoint](#5-start-the-nc-endpoint)
+7. [Create a role for LDAP users](#6-create-a-role-for-ldap-users)
+8. [Generate the web-identity JWT](#7-generate-the-web-identity-jwt)
+9. [Call AssumeRoleWithWebIdentity](#8-call-assumerolewithwebidentity)
+10. [Use temporary credentials for S3](#9-use-temporary-credentials-for-s3)
+11. [Troubleshooting](#10-troubleshooting)
+
+---
+
+## What is LDAP?
+
+**LDAP** (Lightweight Directory Access Protocol) is a standard protocol for accessing and maintaining directory information — typically usernames, passwords, group memberships, and organizational data.
+
+In NooBaa, LDAP acts as an **external identity provider**: NooBaa delegates username/password validation to your existing directory at STS request time, so users can authenticate with credentials they already know.
+
+## Why is LDAP integration required?
+
+Without LDAP, every person who needs S3 access must have a **dedicated NooBaa account** with permanent access keys.
+
+LDAP integration addresses this by letting organizations **reuse their existing directory credentials** to obtain **short-lived STS tokens** for S3. Users never receive permanent NooBaa access keys; they authenticate once against LDAP and receive temporary credentials.
+
+Roles themselves are not LDAP-specific — the same IAM role model is used for STS `AssumeRole` and for other web-identity providers. LDAP is one federated identity source that can assume those roles. See [IAM NC Design](../design/iam_nc.md#iam-roles).
+
+## How NooBaa uses LDAP
+
+NooBaa integrates LDAP through the AWS-compatible STS operation **`AssumeRoleWithWebIdentity`**:
+
+1. A client application builds a **JWT web-identity token** containing the LDAP username and password.
+2. The client calls the NooBaa STS endpoint with that token and a **Role ARN** for a pre-configured IAM role.
+3. NooBaa parses and verifies the JWT.
+4. NooBaa validates the credentials against the external LDAP server and fetches bind attributes (for example `ou`, `memberOf`).
+5. NooBaa evaluates the role trust policy (`Principal.Federated`, `Action`, optional `ldap:*` `Condition`s).
+6. On success, NooBaa issues **temporary access keys + session token** for the target role.
+7. The client uses those credentials (plus `SessionToken`) for **S3** operations.
+
+### Request sequence (AssumeRoleWithWebIdentity → S3)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant App as Client App
+    participant STS as NooBaa STS
+    participant LDAP as LDAP Server
+    participant S3 as NooBaa S3
+    participant FS as Filesystem
+
+    Note over App: Build JWT with user, password, type=ldap<br/>Sign with jwt_secret
+
+    User->>App: Login (LDAP creds)
+    App->>STS: AssumeRoleWithWebIdentity<br/>RoleArn + WebIdentityToken
+
+    STS->>STS: Verify JWT signature / decode claims
+    STS->>LDAP: Bind + fetch attributes (ou, memberOf, ...)
+    LDAP-->>STS: Authentication OK + attributes
+
+    STS->>STS: Resolve IAM role from RoleArn<br/>Evaluate trust policy (Federated + Conditions)
+    STS-->>App: Credentials<br/>(AccessKeyId, SecretAccessKey, SessionToken)
+
+    App->>S3: PUT / GET / LIST<br/>X-Amz-Security-Token header
+    S3->>S3: Verify session JWT<br/>Act as role uid/gid
+    S3->>FS: Read / write objects
+    FS-->>S3: Result
+    S3-->>App: S3 response
+```
+
+## What you need to set up
+
+| Component | Purpose |
+| --- | --- |
+| External LDAP server | Source of truth for user credentials (production or lab). A Docker test image is optional for local trials. |
+| LDAP config file `/etc/noobaa-server/ldap_config` | LDAP server details so NooBaa can connect |
+| IAM role with trust policy (preferred) | Standalone role with `Principal.Federated` + optional `ldap:*` conditions. See [IAM NC Design](../design/iam_nc.md#iam-roles). |
+| JWT signing secret (`jwt_secret` in ldap_config) | Used to encode/decode LDAP web-identity JWTs |
+| STS HTTPS port | `7443` (configurable via `ENDPOINT_SSL_STS_PORT`) |
+| S3 HTTPS port | `6443` |
+| IAM HTTPS port (for CreateRole) | Enable via `ENDPOINT_SSL_IAM_PORT` (for example `7005`) |
+| Role ARN formats | IAM roles: `arn:aws:iam::<owner_account_id>:role/<role_name>` · Legacy `role_config`: `arn:aws:sts::<access_key>:role/<role_name>` |
+
+---
+
+## 1. Prerequisites
+
+- NooBaa NC source tree (or RPM installed).
+- Node.js (to run `nsfs.js` / `manage_nsfs.js`).
+- An LDAP directory you can bind against. For a **local lab only**, Docker can run the optional test OpenLDAP image in [step 2](#2-start-the-ldap-test-server-optional). Production use should point `ldap_config` at your real LDAP/AD server.
+- `openldap` CLI tools (`ldapsearch`) — helpful for verifying connectivity to either the test container or a real server (`brew install openldap` on macOS).
+- AWS CLI v2.
+- `jsonwebtoken` npm package (for generating test tokens).
+
+---
+
+## 2. Start the LDAP test server (optional)
+
+Skip this section if you already have a real LDAP server. The Docker image below is only a **convenience for local testing**; it is not a replacement for a production directory.
+
+```bash
+docker run --rm -it \
+  -p 1389:389 \
+  -p 1636:636 \
+  ghcr.io/ldapjs/docker-test-openldap/openldap:latest
+```
+
+Keep this container running in a dedicated terminal when using it.
+
+---
+
+## 3. Verify LDAP connectivity
+
+Use `ldapsearch` against your directory (test container or real server). Example against the optional test image (no TLS on port `1389`):
+
+```bash
+ldapsearch -H ldap://127.0.0.1:1389 -x \
+  -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone \
+  -b "ou=people,dc=planetexpress,dc=com" "(uid=fry)" ou memberOf
+```
+
+For a real LDAP server, substitute your host, bind DN, password, and search base. Confirm you can search the user and see attributes you plan to use in trust-policy conditions (`ou`, `memberOf`, and so on).
+
+Test-image directory details: [ldapjs docker-test-openldap](https://github.com/ldapjs/docker-test-openldap/pkgs/container/docker-test-openldap%2Fopenldap).
+
+If the search succeeds, the LDAP server is ready.
+
+---
+
+## 4. Configure LDAP in NooBaa
+
+Create `/etc/noobaa-server/ldap_config` on the host where the NC endpoint runs.
+
+Field names must be `admin_user` and `admin_password` (mapped internally to the LDAP bind credentials):
+
+```bash
+sudo mkdir -p /etc/noobaa-server
+
+sudo tee /etc/noobaa-server/ldap_config <<'EOF'
+{
+  "uri": "ldaps://127.0.0.1:1636",
+  "admin_user": "cn=admin,dc=planetexpress,dc=com",
+  "admin_password": "GoodNewsEveryone",
+  "search_dn": "ou=people,dc=planetexpress,dc=com",
+  "dn_attribute": "uid",
+  "search_scope": "sub",
+  "jwt_secret": "<jwt-signing-secret>",
+  "tls_options": {
+    "rejectUnauthorized": false
+  }
+}
+EOF
+```
+
+Point `uri`, `admin_user`, `admin_password`, and `search_dn` at your real LDAP server when not using the test image. Set `jwt_secret` to the secret you will use to sign web-identity JWTs.
+
+---
+
+## 5. Start the NC endpoint
+
+In a separate terminal, from the noobaa-core repo root:
+
+```bash
+sudo node src/cmd/nsfs.js --debug=5
+```
+
+`ENDPOINT_SSL_IAM_PORT` enables the IAM HTTPS endpoint so you can call `CreateRole` (see [step 6](#6-create-a-role-for-ldap-users)). S3 defaults to `6443` and STS to `7443`.
+
+Confirm LDAP connected — look for this in the debug output:
+
+```text
+_connect: initial connect succeeded
+```
+
+If bind fails you will see retry messages every 3 seconds until LDAP is reachable.
+
+---
+
+## 6. Create a role for LDAP users
+
+LDAP callers do not present permanent access keys. They call `AssumeRoleWithWebIdentity` against a role whose trust policy allows federated LDAP principals.
+
+### Preferred: standalone IAM role (`CreateRole`)
+
+Roles are first-class identities under the owner account (see [IAM NC Design](../design/iam_nc.md#iam-roles)). Uniqueness is **`(owner account id, role name)`**, not global role name alone.
+
+1. Create (or reuse) an owner account that has access keys and an `nsfs_account_config` (uid/gid) — the role inherits filesystem identity from that account unless overridden by the role entity.
+
+```bash
+mkdir -p /private/tmp/noobaa-buckets
+
+sudo node src/cmd/manage_nsfs.js account add \
+  --name ldap_role_owner \
+  --uid 501 \
+  --gid 20 \
+  --new_buckets_path /private/tmp/noobaa-buckets
+```
+
+2. Create a role with a Federated trust policy. `Principal.Federated` must match the LDAP URI in `ldap_config` (scheme is stripped when matching). Optional `Condition` blocks restrict by LDAP attributes such as `ou` or `memberOf`:
+
+```bash
+export OWNER_ACCESS_KEY=<owner-access-key>
+export OWNER_SECRET_KEY=<owner-secret-key>
+
+# Trust: any authenticated user from this LDAP server
+cat > /tmp/ldap-trust-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldaps://127.0.0.1:1636" },
+    "Action": "sts:AssumeRoleWithWebIdentity"
+  }]
+}
+EOF
+
+AWS_ACCESS_KEY_ID="$OWNER_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$OWNER_SECRET_KEY" \
+aws iam create-role \
+  --role-name ldap_user \
+  --assume-role-policy-document file:///tmp/ldap-trust-policy.json \
+  --endpoint-url https://127.0.0.1:7005 \
+  --no-verify-ssl
+```
+
+Restrict by department (`ldap:ou`) and/or group (`ldap:memberOf`) — see [IAM NC Design — Federated Principal](../design/iam_nc.md#assumerolewithwebidentity--federated-principal-eg-ldap) for AND/OR examples.
+
+Role ARN format:
+
+```text
+arn:aws:iam::<owner_account_id>:role/ldap_user
+```
+
+Retrieve the owner account id from `account status` / identity JSON as needed for the ARN.
+
+> **Permission policy note:** Trust policy controls **who may assume** the role. What the assumed role may do on S3 is controlled by a **role permission / inline policy** (`PutRolePolicy` and related APIs — Phase 2). Until then, S3 access for an assumed role is governed primarily by the role’s filesystem identity (uid/gid).
+
+### Legacy: embedded `role_config` on an account
+
+Previously a role was embedded into an account via `role_config`. Different permission sets required different accounts. Prefer standalone IAM roles above; keep this only for older setups.
+
+```bash
+sudo node src/cmd/manage_nsfs.js account add \
+  --name ldap_role \
+  --uid 501 \
+  --gid 20 \
+  --new_buckets_path /private/tmp/noobaa-buckets \
+  --role_config '{"role_name":"ldap_user","assume_role_policy":{"statement":[{"effect":"allow","action":["sts:AssumeRoleWithWebIdentity"],"principal":["*"]}]}}'
+```
+
+Legacy Role ARN:
+
+```text
+arn:aws:sts::<role-account-access-key>:role/ldap_user
+```
+
+```bash
+sudo node src/cmd/manage_nsfs.js account status \
+  --name ldap_role \
+  --show_secrets
+```
+
+---
+
+## 7. Generate the web-identity JWT
+
+The JWT payload must contain `user` and `password`.
+
+**Important:** the signing secret must match `jwt_secret` in `/etc/noobaa-server/ldap_config`.
+
+```bash
+export JWT_SECRET=<jwt-signing-secret>
+
+# Token for fry
+TOKEN=$(node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign({
+  user: 'fry',
+  password: 'fry'
+}, process.env.JWT_SECRET));
+")
+
+# Token for leela
+TOKEN_LEELA=$(node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign({
+  user: 'leela',
+  password: 'leela'
+}, process.env.JWT_SECRET));
+")
+
+echo "Fry token:  $TOKEN"
+echo "Leela token: $TOKEN_LEELA"
+```
+
+### Unsigned token (only when `jwt_secret` is NOT set in ldap_config)
+
+```bash
+node -e "
+const jwt = require('jsonwebtoken');
+console.log(jwt.sign(
+  { user: 'fry', password: 'fry', type: 'ldap' },
+  undefined,
+  { algorithm: 'none' }
+));
+"
+```
+
+---
+
+## 8. Call AssumeRoleWithWebIdentity
+
+```bash
+export ROLE_ARN=arn:aws:iam::<owner_account_id>:role/ldap_user
+# Legacy role_config ARN instead:
+# export ROLE_ARN=arn:aws:sts::<role-account-access-key>:role/ldap_user
+```
+
+Call STS — **no caller AWS credentials required**:
+
+```bash
+aws sts assume-role-with-web-identity \
+  --endpoint-url https://127.0.0.1:7443 \
+  --role-arn "$ROLE_ARN" \
+  --role-session-name fry1 \
+  --web-identity-token "$TOKEN" \
+  --no-verify-ssl
+```
+
+Example successful response (placeholders):
+
+```json
+{
+  "Credentials": {
+    "AccessKeyId": "<TEMP_ACCESS_KEY>",
+    "SecretAccessKey": "<TEMP_SECRET_KEY>",
+    "SessionToken": "<SESSION_TOKEN>",
+    "Expiration": "2026-04-24T08:08:40+00:00"
+  },
+  "AssumedRoleUser": {
+    "AssumedRoleId": "<assumed-role-id>:fry1",
+    "Arn": "arn:aws:sts::<owner_or_key>:assumed-role/ldap_user/fry1"
+  },
+  "SourceIdentity": "cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com"
+}
+```
+
+Test with a different LDAP user (leela):
+
+```bash
+aws sts assume-role-with-web-identity \
+  --endpoint-url https://127.0.0.1:7443 \
+  --role-arn "$ROLE_ARN" \
+  --role-session-name leela-session \
+  --web-identity-token "$TOKEN_LEELA" \
+  --no-verify-ssl
+```
+
+---
+
+## 9. Use temporary credentials for S3
+
+Export the credentials from the STS response:
+
+```bash
+export TEMP_ACCESS_KEY=<TEMP_ACCESS_KEY>
+export TEMP_SECRET_KEY=<TEMP_SECRET_KEY>
+export TEMP_SESSION_TOKEN=<SESSION_TOKEN>
+```
+
+List buckets:
+
+```bash
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --endpoint-url https://127.0.0.1:6443 --no-verify-ssl s3 ls
+```
+
+If port `6443` is not available, try the HTTP endpoint:
+
+```bash
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --endpoint-url http://127.0.0.1:6001 --no-verify-ssl s3 ls
+```
+
+Create a bucket:
+
+```bash
+AWS_ACCESS_KEY_ID="$TEMP_ACCESS_KEY" \
+AWS_SECRET_ACCESS_KEY="$TEMP_SECRET_KEY" \
+AWS_SESSION_TOKEN="$TEMP_SESSION_TOKEN" \
+aws --region us-east-1 \
+  --endpoint-url http://127.0.0.1:6001 \
+  s3 mb s3://test-bucket-fry
+```
+
+---
+
+## 10. Troubleshooting
+
+### LDAP connection
+
+| Symptom | Check |
+| --- | --- |
+| `_connect: initial connect failed` | Can the NC host reach the LDAP URI in `ldap_config`? For the optional Docker test image: is the container running and are ports `1389`/`1636` mapped? For a real server: firewall, TLS, and correct host/port. |
+| `LDAP is not configured or not connected` | File exists at `/etc/noobaa-server/ldap_config`? Keys are `admin_user` / `admin_password`? Endpoint restarted after creating/updating it? |
+| Bind / search failures against a real server | Run `ldapsearch` with the same URI, bind DN, and base as `ldap_config`. Confirm `search_dn` / `dn_attribute` match your directory schema. |
+
+Example real-server check:
+
+```bash
+ldapsearch -H "$LDAP_URI" -x \
+  -D "$BIND_DN" -w "$BIND_PASSWORD" \
+  -b "$SEARCH_BASE" "(uid=someuser)" dn ou memberOf
+```
+
+### JWT / web identity
+
+| Symptom | Check |
+| --- | --- |
+| `INVALID_WEB_IDENTITY_TOKEN` | `jwt_secret` in ldap_config matches token signing secret |
+| `Missing a required claim: user` | JWT must include `user` and `password` fields |
+| `invalid signature` | Regenerate token with the correct secret |
+
+### Role / STS
+
+| Symptom | Check |
+| --- | --- |
+| `NO_SUCH_ROLE` | IAM role exists under the owner account (`CreateRole`); ARN owner id + role name match. For legacy: account has `role_config` and `role_name` matches. |
+| Access denied after LDAP bind | Trust policy `Principal.Federated` URI matches `ldap_config.uri` (scheme stripped). `Condition` (`ldap:ou` / `ldap:memberOf`) matches bind attributes. |
+| `issue with LDAP authentication` | Wrong username/password; check `search_dn` and `dn_attribute` |
+
+```bash
+# Get role
+aws iam get-role \  
+  --role-name ldap_user \
+  --endpoint-url https://127.0.0.1:7005 \
+  --no-verify-ssl
+```
+
+```bash
+# Legacy: verify role_config on NC account
+sudo node src/cmd/manage_nsfs.js account status \
+  --name ldap_role \
+  --show_secrets
+```

--- a/docs/design/iam_nc.md
+++ b/docs/design/iam_nc.md
@@ -34,7 +34,9 @@ Support IAM API:
 - Users: CreateUser, GetUser, UpdateUser, DeleteUser, ListUsers.  
 - Access Keys: CreateAccessKey, GetAccessKeyLastUsed, UpdateAccessKey, DeleteAccessKey, ListAccessKeys.
 ### Out of Scope
-At this point we will not support additional IAM resources (group, policy, role, etc).
+At this point we will not support additional IAM resources (group, policy, etc).
+
+> **Note:** IAM Roles are now in scope — see the [IAM Roles](#iam-roles) section below.
 
 ## Architecture
 ![IAM FLOW](https://github.com/user-attachments/assets/be89ae83-ca37-44e5-ac77-deea4199211d)
@@ -229,6 +231,502 @@ Example: 2 accounts (alice and bob) both of them have user with username Robert 
 ├── master_keys.json
 └── system.json
 ```
+
+---
+
+## IAM Roles
+
+### What is an IAM Role?
+
+An IAM Role is an identity with a set of permissions that defines what actions
+an identity is allowed to perform.
+It has two types of policies:
+- **Trust policy** (`assume_role_policy_document`) — controls **who** is allowed
+  to assume the role, and **via which STS action** (`AssumeRole` or `AssumeRoleWithWebIdentity`)
+- **Permissions policy** (`iam_role_policies`) — controls **what** the assumed
+  role is allowed to do on S3 resources (e.g. `s3:GetObject`, `s3:PutObject` on specific buckets). This will be added in Phase 2.
+
+> **Note:** When implemented, role inline policies will apply to S3 service only.
+
+A role can be assumed in two ways:
+- **`AssumeRole`** — a known NooBaa account (root or IAM user) assumes the role using its own credentials. This is the basic STS flow and should be the primary use case.
+- **`AssumeRoleWithWebIdentity`** — an external identity (e.g. an LDAP or OIDC-authenticated user) assumes the role by presenting a JWT token issued by an external identity provider. See the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md) for LDAP-specific setup.
+
+---
+
+### Why IAM Roles for NC?
+
+Previously, a role was embedded into an account by adding `role_config` to the account. Hence, for different permissions, different accounts had to be created.
+
+With the introduction of IAM roles, a role is a separate entity with its own
+`nsfs_account_config` (uid/gid) — independent of the owner account's identity.
+This allows multiple roles under one account, each with a different filesystem identity, without creating separate accounts.
+
+Phase 2: Introduce role policy (what can be done after the role is assumed)
+
+---
+
+### APIs
+
+The following IAM APIs need to be supported for full role lifecycle management:
+
+| API          | Description                                  |
+| ------------ | -------------------------------------------- |
+| `CreateRole` | Create a new role with a trust policy        |
+| `GetRole`    | Read role metadata and trust policy          |
+| `UpdateRole` | Update description or `max_session_duration` |
+| `DeleteRole` | Delete a role                                |
+| `ListRoles`  | List all roles under the requesting account  |
+
+Phase 2 APIs (future — after Phase 1 CRUD is complete):
+
+| API                | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `PutRolePolicy`    | Attach or replace an inline permission policy on a role |
+| `GetRolePolicy`    | Read a specific inline policy from a role               |
+| `DeleteRolePolicy` | Remove an inline policy from a role                     |
+| `ListRolePolicies` | List names of inline policies on a role                 |
+
+> **Note on role inline policies:** NC currently does not implement inline policies for IAM users. Role inline policies are also deferred to Phase 2 to maintain consistency.
+
+---
+
+### Trust Policy & Role JSON
+
+A trust policy is a JSON document that defines **who can assume the role** (`Principal`), **via which STS action** (`Action`), and optionally **required conditions** (`Condition`). It is separate from any permission policies that define what the assumed role can do.
+
+---
+
+#### `AssumeRole` — AWS Principal (Primary Flow)
+
+Used when a known NooBaa account (root or IAM user) assumes a role using its own long-term credentials.
+
+> **Note (not yet implemented for NC):** The current `AssumeRole` code (`sts_post_assume_role.js`) does not evaluate the trust policy (`assume_role_policy_document`) and resolves roles via `system_store` (containerized only). For NC, role lookup via `config_fs` / `AccountSpaceFS` and trust policy evaluation need to be implemented as part of Phase 1.
+
+**Allow a specific account to assume the role:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::<account_id>:root" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+**Allow any authenticated principal to assume the role:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "*" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+---
+
+#### `AssumeRoleWithWebIdentity` — Federated Principal (e.g. LDAP)
+
+Used when an external identity provider (LDAP etc.) authenticates the user. NooBaa validates the token details against the external provider and checks the trust policy.
+
+**Scope to a specific LDAP server (Federated principal):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity"
+  }]
+}
+```
+The `Federated` URI must match the LDAP server URI in `/etc/noobaa-server/ldap_config`. Matching 
+strips the `ldap://` / `ldaps://` prefix.
+
+**Federated principal + condition on a single LDAP attribute:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": { "ldap:ou": "Delivering Crew" }
+    }
+  }]
+}
+```
+
+**Federated principal + condition on a multi-valued LDAP attribute (group membership):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "ForAnyValue:StringEquals": { "ldap:ou": ["Delivering Crew", "Service Staff"] }
+    }
+  }]
+}
+```
+
+Condition keys use the `ldap:<attribute>` format. NooBaa strips the `ldap:` prefix and looks up the attribute value from the LDAP user entry returned after a successful bind. Supported operators: `StringEquals` (exact match) and `ForAnyValue:StringEquals` (any value in a multi-valued attribute matches the policy list).
+
+> For full LDAP setup instructions, see the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md).
+
+---
+
+### Current Request Flow (Phase 1)
+
+#### Flow 1: `AssumeRole` (Primary — NooBaa account assumes a role)
+
+```
+Client (NooBaa root account or IAM user)
+        │
+        │  1. Sign request with own AccessKey + SecretKey
+        │     Action=AssumeRole, RoleArn=arn:aws:iam::<owner_id>:role/<role_name>
+        ▼
+NooBaa STS
+  AssumeRole
+        │
+        ├─► 2. Authenticate caller — verify access key against NC accounts
+        ├─► 3. [TODO] Resolve role from RoleArn
+        │       └─ look up standalone role entity via config_fs / AccountSpaceFS
+        │          (currently uses system_store — containerized only)
+        ├─► 4. [TODO] Evaluate trust policy
+        │       ├─ Principal fit  (AWS ARN or "*")
+        │       └─ Action fit     (sts:AssumeRole)
+        └─► 5. Issue temporary credentials (AccessKeyId + SecretAccessKey + SessionToken)
+                scoped to the role's uid/gid
+
+Client
+        │  6. Use temporary credentials for S3 operations
+```
+
+---
+
+#### Flow 2: `AssumeRoleWithWebIdentity` (Federated — LDAP user assumes a role)
+
+```
+Client (external user, e.g. LDAP)
+        │
+        │  1. Build JWT: { user, password } signed with jwt_secret
+        ▼
+NooBaa STS
+  AssumeRoleWithWebIdentity
+        │
+        ├─► 2. Decode JWT, verify signature
+        ├─► 3. Bind to LDAP server, fetch user attributes
+        ├─► 4. [TODO] Resolve role from RoleArn
+        │       └─ look up role entity via config_fs / AccountSpaceFS
+        │          [Phase 2: look up standalone role entity by owner_id, role_name]
+        ├─► 5. [TODO] Evaluate trust policy
+        │       ├─ Principal fit  (Federated URI match / "*" / AWS ARN)
+        │       ├─ Action fit     (sts:AssumeRoleWithWebIdentity)
+        │       └─ Condition fit  (e.g. ldap:ou == "Engineering")
+        └─► 6. Issue temporary credentials (AccessKeyId + SecretAccessKey + SessionToken)
+                scoped to the role's uid/gid
+
+Client
+        │  7. Use temporary credentials for S3 operations
+```
+---
+
+### IAM Role Management Flow (CRUD)
+
+**CreateRole**
+
+```
+IAM Client
+        │
+        │  API: CreateRole
+        │  Body: RoleName, AssumeRolePolicyDocument
+        ▼
+NooBaa IAM endpoint
+        │
+        ├─► 1. Validate params (role_name, assume_role_policy_document, trust policy schema)
+        ├─► 2. Authorize request origin - allow root account only (TBD)
+        ├─► 3. Precondition checks
+        │       ├─ role_name must be unique per account
+        │       └─ max number of roles per account? (1000 as per iam_constants.js)
+        ├─► 4. Persist new role
+        │       └─ NC: write /etc/noobaa.conf.d/identities/<role_id>/identity.json
+        │              and /etc/noobaa.conf.d/identities/<account_id>/roles/<role_name>.symlink
+        └─► 5. Return role info
+                └─ Arn: arn:aws:iam::<owner_account_id>:role/<role_name>
+```
+
+**UpdateRole**
+
+```
+IAM Client
+        │
+        │  Action=UpdateRole, Body
+        ▼
+NooBaa IAM endpoint
+        │
+        ├─► 1. Validate params
+        ├─► 2. Find role by (owner_account_id, role_name)
+        ├─► 3. Apply updates
+        └─► 4. Return success
+```
+
+> **Note:** Deleting an account is only allowed if no roles are linked. Any other restrictions for DeleteRole are TBD.
+
+---
+
+### Schema — NC Role JSON File
+
+A new JSON schema for role files:
+
+```js
+{
+  "_id": "7f3a1c2d4e5b6f7a8b9c0d1e",
+  "name": "s3-read-role",
+  "owner": "6a2bdeabf5c8e167f92cb079",
+  "iam_path": "/",
+  "creation_date": "2026-07-03T09:00:00.000Z",
+  "description": "Role assumable by a trusted NooBaa account",
+  "nsfs_account_config": {"uid": 501, "gid": 501},
+  "max_session_duration": 3600,
+  "assume_role_policy_document": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": { "AWS": "arn:aws:iam::<owner_account_id>:root" },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+}
+```
+
+For the `AssumeRoleWithWebIdentity` (LDAP) variant, the `assume_role_policy_document` would instead use `Federated` principal and an optional `Condition` block. See the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md) for a full example.
+
+Phase 2 — append `iam_role_policies`:
+```js
+"iam_role_policies": [
+    {
+      "policy_name": "s3-read-write",
+      "policy_document": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+            "Resource": "*"
+          }
+        ]
+      }
+    }
+  ]
+```
+---
+
+### Code Changes
+
+1. Implement all role CRUD methods in `src/sdk/accountspace_fs.js` and `config_fs.js`
+2. Add support for `Principal.Federated` in `sts_rest.js` — `_is_principal_fit()`
+3. Load `assume_role_policy_document` from role entity via `config_fs` / role cache
+4. Implement LDAP and Keycloak condition evaluation for trust policy (`_is_identity_condition_fit`)
+5. Implement role cache load logic (similar to account cache)
+6. Schema changes for roles
+
+---
+
+### Diagrams
+
+#### Legacy Design vs New Design — Data Model
+
+```mermaid
+block-beta
+  columns 2
+
+  block
+    columns 1
+    a1["Current Design \nAccount\n──────────────\n_id\nname\naccess_keys[]\nnsfs_account_config\n  uid / gid\n  new_buckets_path\nrole_config\n  role_name\n  assume_role_policy"]
+  end
+
+  block
+    columns 1
+    a2["New Design\nAccount\n──────────────\n_id\nname\naccess_keys[]\nnsfs_account_config\n  uid / gid\n  new_buckets_path"]
+    r2["IAM Role\n──────────────\n_id\nowner  ──► Account._id\nname\niam_path\nassume_role_policy_document\ncreation_date\nmax_session_duration\nnsfs_account_config\n uid / gid"]
+  end
+```
+
+**Key difference:** In Legacy design the role trust policy is an embedded sub-document inside an account. In New design the role is a first-class entity that references the owner account via `owner`, allowing multiple roles per account and independent lifecycle management.
+
+---
+
+#### NC Config Directory Structure
+
+```
+/etc/noobaa.conf.d/
+│
+├── system.json                          ← system metadata
+│
+├── buckets/
+│   └── <bucket_name>.json
+│
+├── access_keys/
+│   └── <access_key>.symlink  ──────────────────────────────┐
+│                                                            │
+├── accounts_by_name/                                        │
+│   └── <account_name>.symlink ───────────────────────┐     │
+│                                                      │     │
+└── identities/                                        │     │
+    └── <account_id>/                                  │     │
+    │   ├── identity.json  ◄────────────────────────── ┘ ◄──┘
+    │   └── roles/                    ← New
+    │        └── <role_name>.symlink  ───────────────────────────► ../../<role_id>/identity.json
+    └── <role_id>
+             └── identity.json            ← Actual role json
+```
+
+---
+
+#### End-to-End Flow — Phase 2
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant IAM as NooBaa IAM
+    participant FS as Config Filesystem
+    actor Caller as Caller (NooBaa account or federated user)
+    participant STS as NooBaa STS
+    participant S3 as NooBaa S3
+
+    Note over Admin: Setup (done once)
+
+    Admin->>IAM: CreateRole<br/>RoleName + AssumeRolePolicyDocument
+    IAM->>FS: Write identities/<role_id>/identity.json<br/>+ Create identities/<acc_id>/roles/<role_name>.symlink
+    IAM-->>Admin: Arn: arn:aws:iam::<acc_id>:role/<role_name>
+
+    Note over Caller: Runtime
+
+    Caller->>STS: AssumeRole (or AssumeRoleWithWebIdentity)<br/>RoleArn + credentials / WebIdentityToken
+    STS->>STS: Authenticate caller
+    STS->>FS: Read identities/<acc_id>/roles/<role_name>.symlink → identities/<role_id>/identity.json
+    STS->>STS: Evaluate trust policy<br/>✔ Principal fit<br/>✔ Action fit<br/>✔ Condition fit (if any)
+    STS-->>Caller: Temporary credentials<br/>(AccessKeyId + SecretAccessKey + SessionToken)
+
+    Caller->>S3: S3 operation + SessionToken header
+    S3->>S3: Verify SessionToken JWT<br/>Act as role's uid/gid on filesystem
+    S3-->>Caller: S3 response
+```
+
+---
+
+### End-to-End Flow Summary
+
+**Step 1: Create Role**
+
+```
+CreateRole API called
+        ↓
+NooBaa creates:
+  /identities/<role_id>/identity.json            ← role data (uid/gid, trust policy)
+  /identities/<owner_id>/roles/<role_name>.symlink  → points to identity.json above
+```
+
+**Step 2: Caller Assumes the Role**
+
+```
+Caller (NooBaa account using AssumeRole,
+        or federated user using AssumeRoleWithWebIdentity)
+        │
+        │  "Want to assume Role A"
+        │  RoleArn = arn:aws:iam::<owner_id>:role/role-a
+        │  Credentials = AccessKey+SecretKey (AssumeRole)
+        │              OR WebIdentityToken/JWT (AssumeRoleWithWebIdentity)
+        ▼
+NooBaa STS
+    │
+    ├─ 1. Authenticate caller
+    │       AssumeRole: verify access key against NC accounts
+    │       AssumeRoleWithWebIdentity: verify JWT → bind with identity provider
+    │
+    ├─ 2. Find role  → /identities/<owner_id>/roles/role-a.symlink
+    │                → /identities/<role_id>/identity.json
+    │      → get trust policy
+    │
+    ├─ 3. Verify trust policy → Principal + Action + Condition match? YES ✓
+    │
+    └─ 4. Issue temporary credentials
+           SessionToken = JWT { temp_AccessKey, temp_SecretKey, assumed_role_access_key, role_id(new) }
+
+    Returns: AccessKeyId, SecretAccessKey, SessionToken
+```
+
+**Step 3: S3 Operation with Temp Credentials**
+
+```
+User
+    │
+    │  GET /my-bucket/file.txt
+    │  Authorization: Credential=temp_AccessKey, signed with temp_SecretKey
+    │  x-amz-security-token: <JWT>
+    ↓
+NooBaa S3
+    │
+    ├─ 1. Decode SessionToken (JWT) → get role_id
+    │
+    ├─ 2. Load Role → identities/<role_id>/identity.json
+    │
+    ├─ 3. Check bucket policy (if exists) → check role ARN/name against policy
+    │
+    └─ 4. Perform S3 operation as role's uid/gid
+```
+
+---
+
+### QnA
+
+**1. How can we know if we're looking at a user or a role when we read it?**
+
+Currently, as per `nsfs_account_schema.js`, we have `role_config`. For backward compatibility, we can keep `role_config` and add `assume_role_policy_document` which uses the AWS-compatible schema that can help us identify that it is a role.
+
+- `owner` = empty + `assume_role_policy_document` = empty → root account
+- `owner` = value + `assume_role_policy_document` = empty → IAM user
+- `owner` = value + `assume_role_policy_document` = value → Role
+
+> **Suggestion:** Introduce a `type` field for future purposes and easy identification.
+
+**2. How to list roles?**
+
+Since roles owned by an account will be inside `/etc/noobaa.conf.d/identities/<account_id>/roles/<role_name>.symlink`, listing roles works the same way as listing users:
+
+- `list_accounts()` → reads from `accounts_by_name/` → only accounts
+- `list_users_under_account()` → reads from `identities/<account_id>/users/` → only users
+- *(New)* `list_roles_under_account()` → reads from `identities/<account_id>/roles/` → only roles
+
+**3. What properties does a role have that users don't? And vice versa?**
+
+- Similar fields: `_id`, `name`, `creation_date`, `owner`, `iam_path`, `nsfs_account_config`
+- Extra fields for roles: `assume_role_policy_document`
+- Not applicable for roles (to be blocked/marked optional): `access_keys`, `allow_bucket_creation`, `email`, `master_key_id`
+
+**4. Do you need to have a bucket policy on principals of a role?**
+
+By default, a role operates with its own nsfs_account_config (uid/gid). Without iam_role_policies, no additional S3-level permission policy is enforced — resource access is governed purely by the role's own filesystem permissions (uid/gid).
+
+For bucket policy principal support, ARN matching for roles is required, but that can be done once CRUD operations for roles are implemented for NC.
+
+Phase 2: new field to be introduced : iam_role_policies. A role policy will define the permissions a user who assumed the role have
+---
 
 ## Other
 ### Terminology - AWS vs NooBaa

--- a/docs/design/iam_nc.md
+++ b/docs/design/iam_nc.md
@@ -35,7 +35,9 @@ Support IAM API:
 - Access Keys: CreateAccessKey, GetAccessKeyLastUsed, UpdateAccessKey, DeleteAccessKey, ListAccessKeys.
 - Inline User Policy: PutUserPolicy, GetUserPolicy, ListUserPolicies, DeleteUserPolicy
 ### Out of Scope
-At this point we will not support additional IAM resources (group, policy, role, etc).
+At this point we will not support additional IAM resources (group, policy, etc).
+
+> **Note:** IAM Roles are now in scope — see the [IAM Roles](#iam-roles) section below.
 
 ## Architecture
 ![IAM FLOW](https://github.com/user-attachments/assets/be89ae83-ca37-44e5-ac77-deea4199211d)
@@ -229,6 +231,560 @@ Example: 2 accounts (alice and bob) both of them have user with username Robert 
 ├── master_keys.json
 └── system.json
 ```
+
+---
+
+## IAM Roles
+
+### What is an IAM Role?
+
+An IAM Role is an identity with a set of permissions that defines what actions
+an identity is allowed to perform.
+It has two types of policies:
+- **Trust policy** (`assume_role_policy_document`) — controls **who** is allowed
+  to assume the role, and **via which STS action** (`AssumeRole` or `AssumeRoleWithWebIdentity`)
+- **Permissions policy** (`iam_role_policies`) — controls **what** the assumed
+  role is allowed to do on S3 resources (e.g. `s3:GetObject`, `s3:PutObject` on specific buckets). This will be added in Phase 2.
+
+> **Note:** When implemented, role inline policies will apply to S3 service only.
+
+A role can be assumed in two ways:
+- **`AssumeRole`** — a known NooBaa account (root or IAM user) assumes the role using its own credentials. This is the basic STS flow and should be the primary use case.
+- **`AssumeRoleWithWebIdentity`** — an external identity (e.g. an LDAP or OIDC-authenticated user) assumes the role by presenting a JWT token issued by an external identity provider. See the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md) for LDAP-specific setup.
+
+---
+
+### Why IAM Roles for NC?
+
+Previously, a role was embedded into an account by adding `role_config` to the account. Hence, for different permissions, different accounts had to be created.
+
+With the introduction of IAM roles, a role is a separate entity with a trust policy and (Phase 2) a role permission policy. As a result, roles have their own lifecycle independent of any account. We can have a **trust policy** (who is allowed to assume the role) and a **role policy** (what can be done after the role is assumed). The role also has its own `nsfs_account_config` (uid/gid) — independent of the owner account's identity — so multiple roles under one account can use different filesystem identities without creating separate accounts.
+
+> Roles are not LDAP-specific. The same model serves STS `AssumeRole` (AWS principals) and `AssumeRoleWithWebIdentity` (federated principals such as LDAP or OIDC).
+
+Phase 2: Introduce role inline permission policies (`PutRolePolicy` / `GetRolePolicy` / `DeleteRolePolicy` / `ListRolePolicies`). NC does not currently implement inline policies for IAM users; role inline policies are deferred to Phase 2 for consistency. When implemented, those policies are scoped to the **S3** service.
+
+---
+
+### APIs
+
+The following IAM APIs need to be supported for full role lifecycle management:
+
+| API          | Description                                  |
+| ------------ | -------------------------------------------- |
+| `CreateRole` | Create a new role with a trust policy        |
+| `GetRole`    | Read role metadata and trust policy          |
+| `UpdateRole` | Update description or `max_session_duration` |
+| `DeleteRole` | Delete a role                                |
+| `ListRoles`  | List all roles under the requesting account  |
+
+Phase 2 APIs (future — after Phase 1 CRUD is complete):
+
+| API                | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `PutRolePolicy`    | Attach or replace an inline permission policy on a role |
+| `GetRolePolicy`    | Read a specific inline policy from a role               |
+| `DeleteRolePolicy` | Remove an inline policy from a role                     |
+| `ListRolePolicies` | List names of inline policies on a role                 |
+
+> **Note on role inline policies:** NC currently does not implement inline policies for IAM users. Role inline policies are also deferred to Phase 2 to maintain consistency.
+
+---
+
+### Trust Policy & Role JSON
+
+A trust policy is a JSON document that defines **who can assume the role** (`Principal`), **via which STS action** (`Action`), and optionally **required conditions** (`Condition`). It is separate from any permission policies that define what the assumed role can do.
+
+---
+
+#### `AssumeRole` — AWS Principal (Primary Flow)
+
+Used when a known NooBaa account (root or IAM user) assumes a role using its own long-term credentials.
+
+> **Note (not yet implemented for NC):** The current `AssumeRole` code (`sts_post_assume_role.js`) does not evaluate the trust policy (`assume_role_policy_document`) and resolves roles via `system_store` (containerized only). For NC, role lookup via `config_fs` / `AccountSpaceFS` and trust policy evaluation need to be implemented as part of Phase 1.
+
+**Allow a specific account to assume the role:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::<account_id>:root" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+**Allow any authenticated principal to assume the role:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "*" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+---
+
+#### `AssumeRoleWithWebIdentity` — Federated Principal (e.g. LDAP)
+
+Used when an external identity provider (LDAP etc.) authenticates the user. NooBaa validates the token details against the external provider and checks the trust policy.
+
+**Scope to a specific LDAP server (Federated principal):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity"
+  }]
+}
+```
+
+The `Federated` value must match the LDAP server URI in `/etc/noobaa-server/ldap_config`. Matching strips the `ldap://` / `ldaps://` prefix.
+
+##### LDAP group / attribute conditions
+
+Condition keys use the `ldap:<attribute>` format. NooBaa strips the `ldap:` prefix and looks up the attribute on the LDAP user entry returned after a successful bind.
+
+| Operator | Use case | Behaviour |
+| --- | --- | --- |
+| `StringEquals` | Single-value LDAP attribute (e.g. `ou`) | Exact string match |
+| `ForAnyValue:StringEquals` | Multi-value LDAP attribute (e.g. `memberOf`) | At least one value in the user's list must match a value in the policy list |
+
+**Example 1 — Restrict by OU (department):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": { "ldap:ou": "Delivering Crew" }
+    }
+  }]
+}
+```
+
+**Example 2 — Restrict by group membership (`ldap:memberOf`):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "ForAnyValue:StringEquals": {
+        "ldap:memberOf": [
+          "cn=ship_crew,ou=people,dc=planetexpress,dc=com",
+          "cn=admin_staff,ou=people,dc=planetexpress,dc=com"
+        ]
+      }
+    }
+  }]
+}
+```
+
+**Example 3 — AND (OU and group):** all keys inside one `Condition` block must pass.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": { "ldap:ou": "Delivering Crew" },
+      "ForAnyValue:StringEquals": {
+        "ldap:memberOf": ["cn=ship_crew,ou=people,dc=planetexpress,dc=com"]
+      }
+    }
+  }]
+}
+```
+
+**Example 4 — OR (OU or group):** multiple statements; any matching Allow is sufficient.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": { "ldap:ou": "Delivering Crew" }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": { "Federated": "ldap://127.0.0.1:1389" },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "ForAnyValue:StringEquals": {
+          "ldap:memberOf": ["cn=ship_crew,ou=people,dc=planetexpress,dc=com"]
+        }
+      }
+    }
+  ]
+}
+```
+
+> For full LDAP setup instructions, see the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md).
+
+---
+
+### Current Request Flow (Phase 1)
+
+#### Flow 1: `AssumeRole` (Primary — NooBaa account assumes a role)
+
+```
+Client (NooBaa root account or IAM user)
+        │
+        │  1. Sign request with own AccessKey + SecretKey
+        │     Action=AssumeRole, RoleArn=arn:aws:iam::<owner_id>:role/<role_name>
+        ▼
+NooBaa STS
+  AssumeRole
+        │
+        ├─► 2. Authenticate caller — verify access key against NC accounts
+        ├─► 3. [TODO] Resolve role from RoleArn
+        │       └─ look up standalone role entity via config_fs / AccountSpaceFS
+        │          (currently uses system_store — containerized only)
+        ├─► 4. [TODO] Evaluate trust policy
+        │       ├─ Principal fit  (AWS ARN or "*")
+        │       └─ Action fit     (sts:AssumeRole)
+        └─► 5. Issue temporary credentials (AccessKeyId + SecretAccessKey + SessionToken)
+                scoped to the role's uid/gid
+
+Client
+        │  6. Use temporary credentials for S3 operations
+```
+
+---
+
+#### Flow 2: `AssumeRoleWithWebIdentity` (Federated — LDAP user assumes a role)
+
+```
+Client (external user, e.g. LDAP)
+        │
+        │  1. Build JWT: { user, password } signed with jwt_secret
+        ▼
+NooBaa STS
+  AssumeRoleWithWebIdentity
+        │
+        ├─► 2. Decode JWT, verify signature
+        ├─► 3. Bind to LDAP server, fetch user attributes
+        ├─► 4. [TODO] Resolve role from RoleArn
+        │       └─ look up role entity via config_fs / AccountSpaceFS
+        │          [Phase 2: look up standalone role entity by owner_id, role_name]
+        ├─► 5. [TODO] Evaluate trust policy
+        │       ├─ Principal fit  (Federated URI match / "*" / AWS ARN)
+        │       ├─ Action fit     (sts:AssumeRoleWithWebIdentity)
+        │       └─ Condition fit  (e.g. ldap:ou == "Engineering")
+        └─► 6. Issue temporary credentials (AccessKeyId + SecretAccessKey + SessionToken)
+                scoped to the role's uid/gid
+
+Client
+        │  7. Use temporary credentials for S3 operations
+```
+---
+
+### IAM Role Management Flow (CRUD)
+
+**CreateRole**
+
+```
+IAM Client
+        │
+        │  API: CreateRole
+        │  Body: RoleName, AssumeRolePolicyDocument
+        ▼
+NooBaa IAM endpoint
+        │
+        ├─► 1. Validate params (role_name, assume_role_policy_document, trust policy schema)
+        ├─► 2. Authorize request origin - allow root account only (TBD)
+        ├─► 3. Precondition checks
+        │       ├─ (owner_account_id, role_name) must be unique
+        │       │     (role name alone is not globally unique — same as containerized)
+        │       └─ max number of roles per account? (1000 as per iam_constants.js)
+        ├─► 4. Persist new role
+        │       └─ NC: write /etc/noobaa.conf.d/identities/<role_id>/identity.json
+        │              and /etc/noobaa.conf.d/identities/<account_id>/roles/<role_name>.symlink
+        └─► 5. Return role info
+                └─ Arn: arn:aws:iam::<owner_account_id>:role/<role_name>
+```
+
+**UpdateRole**
+
+```
+IAM Client
+        │
+        │  Action=UpdateRole, Body
+        ▼
+NooBaa IAM endpoint
+        │
+        ├─► 1. Validate params
+        ├─► 2. Find role by (owner_account_id, role_name)
+        ├─► 3. Apply updates
+        └─► 4. Return success
+```
+
+> **Note:** Deleting an account is only allowed if no roles are linked. Any other restrictions for DeleteRole are TBD.
+
+---
+
+### Schema — NC Role JSON File
+
+A new JSON schema for role files:
+
+```js
+{
+  "_id": "7f3a1c2d4e5b6f7a8b9c0d1e",
+  "name": "s3-read-role",
+  "owner": "6a2bdeabf5c8e167f92cb079",
+  "iam_path": "/",
+  "creation_date": "2026-07-03T09:00:00.000Z",
+  "description": "Role assumable by a trusted NooBaa account",
+  "nsfs_account_config": {"uid": 501, "gid": 501},
+  "max_session_duration": 3600,
+  "assume_role_policy_document": {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": { "AWS": "arn:aws:iam::<owner_account_id>:root" },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+}
+```
+
+For the `AssumeRoleWithWebIdentity` (LDAP) variant, the `assume_role_policy_document` would instead use `Federated` principal and an optional `Condition` block. See the [LDAP NC guide](../NooBaaNonContainerized/ldap_non_containerised.md) for a full example.
+
+Phase 2 — append `iam_role_policies`:
+```js
+"iam_role_policies": [
+    {
+      "policy_name": "s3-read-write",
+      "policy_document": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+            "Resource": "*"
+          }
+        ]
+      }
+    }
+  ]
+```
+---
+
+### Code Changes
+
+1. Implement all role CRUD methods in `src/sdk/accountspace_fs.js` and `config_fs.js`
+2. Add support for `Principal.Federated` in trust-policy evaluation (`_is_principal_fit()` / access policy utils) — LDAP URI match and OIDC/`iss` match
+3. Load `assume_role_policy_document` from role entity via `config_fs` / **role cache** (same pattern as account cache)
+4. Implement LDAP and Keycloak condition evaluation for trust policy (`_is_identity_condition_fit`) — including `ldap:ou` / `ldap:memberOf`
+5. Schema changes for roles (`name`, `owner`, `assume_role_policy_document`, …)
+---
+
+### Diagrams
+
+#### Legacy Design vs New Design — Data Model
+
+```mermaid
+block-beta
+  columns 2
+
+  block
+    columns 1
+    a1["Current Design \nAccount\n──────────────\n_id\nname\naccess_keys[]\nnsfs_account_config\n  uid / gid\n  new_buckets_path\nrole_config\n  role_name\n  assume_role_policy"]
+  end
+
+  block
+    columns 1
+    a2["New Design\nAccount\n──────────────\n_id\nname\naccess_keys[]\nnsfs_account_config\n  uid / gid\n  new_buckets_path"]
+    r2["IAM Role\n──────────────\n_id\nowner  ──► Account._id\nname\niam_path\nassume_role_policy_document\ncreation_date\nmax_session_duration\nnsfs_account_config\n uid / gid"]
+  end
+```
+
+**Key difference:** In Legacy design the role trust policy is an embedded sub-document inside an account. In New design the role is a first-class entity that references the owner account via `owner`, allowing multiple roles per account and independent lifecycle management.
+
+---
+
+#### NC Config Directory Structure
+
+```
+/etc/noobaa.conf.d/
+│
+├── system.json                          ← system metadata
+│
+├── buckets/
+│   └── <bucket_name>.json
+│
+├── access_keys/
+│   └── <access_key>.symlink  ──────────────────────────────┐
+│                                                            │
+├── accounts_by_name/                                        │
+│   └── <account_name>.symlink ───────────────────────┐     │
+│                                                      │     │
+└── identities/                                        │     │
+    └── <account_id>/                                  │     │
+    │   ├── identity.json  ◄────────────────────────── ┘ ◄──┘
+    │   └── roles/                    ← New
+    │        └── <role_name>.symlink  ───────────────────────────► ../../<role_id>/identity.json
+    └── <role_id>
+             └── identity.json            ← Actual role json
+```
+
+---
+
+#### End-to-End Flow — Phase 2
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant IAM as NooBaa IAM
+    participant FS as Config Filesystem
+    actor Caller as Caller (NooBaa account or federated user)
+    participant STS as NooBaa STS
+    participant S3 as NooBaa S3
+
+    Note over Admin: Setup (done once)
+
+    Admin->>IAM: CreateRole<br/>RoleName + AssumeRolePolicyDocument
+    IAM->>FS: Write identities/<role_id>/identity.json<br/>+ Create identities/<acc_id>/roles/<role_name>.symlink
+    IAM-->>Admin: Arn: arn:aws:iam::<acc_id>:role/<role_name>
+
+    Note over Caller: Runtime
+
+    Caller->>STS: AssumeRole (or AssumeRoleWithWebIdentity)<br/>RoleArn + credentials / WebIdentityToken
+    STS->>STS: Authenticate caller
+    STS->>FS: Read identities/<acc_id>/roles/<role_name>.symlink → identities/<role_id>/identity.json
+    STS->>STS: Evaluate trust policy<br/>✔ Principal fit<br/>✔ Action fit<br/>✔ Condition fit (if any)
+    STS-->>Caller: Temporary credentials<br/>(AccessKeyId + SecretAccessKey + SessionToken)
+
+    Caller->>S3: S3 operation + SessionToken header
+    S3->>S3: Verify SessionToken JWT<br/>Act as role's uid/gid on filesystem
+    S3-->>Caller: S3 response
+```
+
+---
+
+### End-to-End Flow Summary
+
+**Step 1: Create Role**
+
+```
+CreateRole API called
+        ↓
+NooBaa creates:
+  /identities/<role_id>/identity.json            ← role data (uid/gid, trust policy)
+  /identities/<owner_id>/roles/<role_name>.symlink  → points to identity.json above
+```
+
+**Step 2: Caller Assumes the Role**
+
+```
+Caller (NooBaa account using AssumeRole,
+        or federated user using AssumeRoleWithWebIdentity)
+        │
+        │  "Want to assume Role A"
+        │  RoleArn = arn:aws:iam::<owner_id>:role/role-a
+        │  Credentials = AccessKey+SecretKey (AssumeRole)
+        │              OR WebIdentityToken/JWT (AssumeRoleWithWebIdentity)
+        ▼
+NooBaa STS
+    │
+    ├─ 1. Authenticate caller
+    │       AssumeRole: verify access key against NC accounts
+    │       AssumeRoleWithWebIdentity: verify JWT → bind with identity provider
+    │
+    ├─ 2. Find role  → /identities/<owner_id>/roles/role-a.symlink
+    │                → /identities/<role_id>/identity.json
+    │      → get trust policy
+    │
+    ├─ 3. Verify trust policy → Principal + Action + Condition match? YES ✓
+    │
+    └─ 4. Issue temporary credentials
+           SessionToken = JWT { temp_AccessKey, temp_SecretKey, assumed_role_access_key, role_id(new) }
+
+    Returns: AccessKeyId, SecretAccessKey, SessionToken
+```
+
+**Step 3: S3 Operation with Temp Credentials**
+
+```
+User
+    │
+    │  GET /my-bucket/file.txt
+    │  Authorization: Credential=temp_AccessKey, signed with temp_SecretKey
+    │  x-amz-security-token: <JWT>
+    ↓
+NooBaa S3
+    │
+    ├─ 1. Decode SessionToken (JWT) → get role_id
+    │
+    ├─ 2. Load Role → identities/<role_id>/identity.json
+    │
+    ├─ 3. Check bucket policy (if exists) → check role ARN/name against policy
+    │
+    └─ 4. Perform S3 operation as role's uid/gid
+```
+
+---
+
+### QnA
+
+**1. How can we know if we're looking at a user or a role when we read it?**
+
+Currently, as per `nsfs_account_schema.js`, we have `role_config`. For backward compatibility, we can keep `role_config` and add `assume_role_policy_document` which uses the AWS-compatible schema that can help us identify that it is a role.
+
+- `owner` = empty + `assume_role_policy_document` = empty → root account
+- `owner` = value + `assume_role_policy_document` = empty → IAM user
+- `owner` = value + `assume_role_policy_document` = value → Role
+
+> **Suggestion:** Introduce a `type` field for future purposes and easy identification.
+
+**2. How to list roles?**
+
+Since roles owned by an account will be inside `/etc/noobaa.conf.d/identities/<account_id>/roles/<role_name>.symlink`, listing roles works the same way as listing users:
+
+- `list_accounts()` → reads from `accounts_by_name/` → only accounts
+- `list_users_under_account()` → reads from `identities/<account_id>/users/` → only users
+- *(New)* `list_roles_under_account()` → reads from `identities/<account_id>/roles/` → only roles
+
+**3. What properties does a role have that users don't? And vice versa?**
+
+- Similar fields: `_id`, `name`, `creation_date`, `owner`, `iam_path`, `nsfs_account_config`
+- Extra fields for roles: `assume_role_policy_document`
+- Not applicable for roles (to be blocked/marked optional): `access_keys`, `allow_bucket_creation`, `email`, `master_key_id`
+
+**4. Do you need to have a bucket policy on principals of a role?**
+
+By default, a role operates with its own nsfs_account_config (uid/gid). Without iam_role_policies, no additional S3-level permission policy is enforced — resource access is governed purely by the role's own filesystem permissions (uid/gid).
+
+For bucket policy principal support, ARN matching for roles is required, but that can be done once CRUD operations for roles are implemented for NC.
+
+Phase 2: new field to be introduced : iam_role_policies. A role policy will define the permissions a user who assumed the role have
+---
 
 ## Other
 ### Terminology - AWS vs NooBaa

--- a/docs/design/ldap.md
+++ b/docs/design/ldap.md
@@ -22,9 +22,9 @@ The configuration should include:
 uri (Required) – The FQDN of the external LDAP server, in the format:
 ldaps://[server-ip-or-hostname]:[port] (e.g., port 636 for LDAPS)
 
-admin (Required) – An administrator username with permission to execute search queries on the LDAP server.
+admin_user (Required) – An administrator username with permission to execute search queries on the LDAP server.
 
-secret (Required) – The password for the administrator account.
+admin_password (Required) – The password for the administrator account.
 
 search_dn (Required) – The distinguished name (DN) under which search queries will be performed.
 
@@ -44,8 +44,8 @@ for example:
 ```json
 {
   "uri": "ldap://ldap.example.com:636",
-  "admin": "cn=admin,dc=example,dc=com",
-  "secret": "SuperSecurePassword123",
+  "admin_user": "cn=admin,dc=example,dc=com",
+  "admin_password": "SuperSecurePassword123",
   "search_dn": "ou=users,dc=example,dc=com",
   "dn_attribute": "uid",
   "search_scope": "sub",


### PR DESCRIPTION
### Describe the Problem
Added document for NC LDAP integration via AssumeRoleWithWebIdentity with commands

### Explain the Changes
1. Added docs/NooBaaNonContainerized/ldap_non_containerised.md — end-to-end NC LDAP guide covering test LDAP server setup, ldap_config, nsfs.js, role_config via manage_nsfs.js, web-identity JWT, STS AssumeRoleWithWebIdentity, and S3 with temp creds.

### Issues: Fixed #xxx / Gap #xxx
1. N/A — documentation only.

### Testing Instructions:
1. 


- [x] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new end-to-end guide for enabling LDAP-based access in non-containerized NooBaa using IAM roles with web-identity (JWT), including prerequisites, local OpenLDAP testing, required configuration placement, role-account management, STS assume-role flow, using temporary credentials for S3, and troubleshooting for LDAP, JWT/web-identity, and role/STS issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->