### PR TITLE
Nodes Monitor | Fix Minor Log Error Message

### DIFF
--- a/src/server/node_services/nodes_monitor.js
+++ b/src/server/node_services/nodes_monitor.js
@@ -1695,7 +1695,7 @@ class NodesMonitor extends EventEmitter {
             if (!item.node_from_store) reasons.push('node not stored yet');
             if (!item.node.rpc_address) reasons.push('no rpc_address');
             if (item.storage_not_exist) reasons.push(`target storage do not exist (${new Date(item.storage_not_exist)})`);
-            if (item.auth_failed) reasons.push(`failed to authenticate on target storage (${new Date(item.storage_not_exist)})`);
+            if (item.auth_failed) reasons.push(`failed to authenticate on target storage (${new Date(item.auth_failed)})`);
             if (item.io_detention && item.n2n_errors) reasons.push(`in detention (n2n_errors at ${new Date(item.n2n_errors)})`);
             if (item.io_detention && item.gateway_errors) reasons.push(`in detention (gateway_errors at ${new Date(item.gateway_errors)})`);
             if (item.io_detention && item.io_test_errors) reasons.push(`in detention (io_test_errors at ${new Date(item.io_test_errors)})`);


### PR DESCRIPTION
### Describe the Problem
While I'm working on another epic, I saw this minor typo bug and suggested fixing it.

### Explain the Changes
1. In `nodes_monitor.js`, in the condition of `if (item.auth_failed)` print the date of `item.auth_failed` (instead of `item.storage_not_exist`).

### Issues: 
None was reported:
1. Before the fix, it prints with `Invalid Date` in case `item.storage_not_exist` is `undefined`.
```bash
[WebServer/34]    [L0] core.server.node_services.nodes_monitor:: noobaa-internal-agent-6a2e779b48609d00225fa1af not readable. reasons: failed to authenticate on target storage (Invalid Date)
```
2. After the fix, it would print the actual date:
```bash
[WebServer/34]    [L0] core.server.node_services.nodes_monitor:: noobaa-internal-agent-6a2e779b48609d00225fa1af not readable. reasons: failed to authenticate on target storage (Sun Jun 14 2026 10:15:24 GMT+0000 (Coordinated Universal Time))
```

### Testing Instructions:
#### Manual Tests
To test the change, I had to make a couple of code changes in addition to the fix to get the `auth_failed` report.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the timestamp shown for authentication failure events. The reported failure time now matches the actual authentication failure field, improving monitoring accuracy and troubleshooting for security-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->