### PR TITLE
Block Store Google | Code Changes in `test_store_validity`

### DIFF
--- a/src/agent/block_store_services/block_store_google.js
+++ b/src/agent/block_store_services/block_store_google.js
@@ -262,19 +262,34 @@ class BlockStoreGoogle extends BlockStoreBase {
         };
     }
 
+    /**
+     * GCP does not distinguish bucket-not-found from object-not-found on delete (both return 404),
+     * so we first call bucket.exists(), then delete a non-existing test key.
+     * (Note: there were cases in the past where the bucket was not existing and the message was about the object)
+     */
     async test_store_validity() {
         const block_key = this._block_key(`test-delete-non-existing-key-${Date.now()}`);
         try {
+            const [bucket_exists] = await this.bucket.exists();
+            if (!bucket_exists) {
+                dbg.error('google cloud bucket not found:', _.omit(this.cloud_info, 'google'));
+                throw new RpcError('STORAGE_NOT_EXIST', `google cloud bucket ${this.cloud_info.target_bucket} not found`);
+            }
             const file = this.bucket.file(block_key);
             await file.delete();
         } catch (err) {
-            if (err.code !== 404) {
-                dbg.error('in _test_cloud_service - delete failed:', err, _.omit(this.cloud_info, 'access_keys'));
-                if (err.code === 403) {
-                    throw new RpcError('AUTH_FAILED', `access denied to the s3 bucket ${this.cloud_info.target_bucket}. got error ${err}`);
-                }
-                dbg.warn(`unexpected error (code=${err.code}) from file.delete during test. ignoring..`);
+            if (err.rpc_code === 'STORAGE_NOT_EXIST') {
+                throw err;
             }
+            // Delete of the non-existing test key is expected (bucket was verified above).
+            if (err.code === 404) {
+                return;
+            }
+            dbg.error('in _test_cloud_service - delete failed:', err, _.omit(this.cloud_info, 'google'));
+            if (err.code === 403) {
+                throw new RpcError('AUTH_FAILED', `access denied to the google cloud bucket ${this.cloud_info.target_bucket}. got error code: ${err.code}, message: ${err.message}`);
+            }
+            dbg.warn(`unexpected error (code=${err.code}, message: ${err.message}) from test_store_validity. ignoring..`);
         }
     }
 


### PR DESCRIPTION
### Describe the Problem
As part of testing the epic that is related to GCP WIF (STS), I found a couple of bugs in GCP inside the function `test_store_validity`:
- The private key might be printed in the logs in case of an error.
- When the underlying storage was deleted (by deleting the target bucket in GCP console) the backing store was still in phase Ready.

### Explain the Changes
1. Check if the error code `404` comes from a non-existing bucket or a non-existing object, instead of treating all 404s as success.
2. Replace this part `_.omit(this.cloud_info, 'access_keys')` with `_.omit(this.cloud_info, 'google')` to avoid logging the private key.
3. Edit the message by replacing copy-paste "s3 bucket" with "google cloud bucket".

Notes:
- My first approach was to check it by checking the `err.message` but an AI tool raised that the error message can be in an object if the bucket does not exist ([link](https://github.com/googleapis/nodejs-storage/issues/1183)).
I understand that for this precision, we had to pay by using 2 API calls (1 to delete the file and another to check if the bucket exists).
- I chose to use bucket `exists` as it wraps the `getMetadata` (which is used in the code in the function `_handle_error`), and I found that using it, the code is cleaner.
- I still doubt whether we need to log the error and not just the error code and message (it floods the logs):
https://github.com/noobaa/noobaa-core/blob/f4215252bec72d1fdac592742e900cce665052ff/src/agent/block_store_services/block_store_google.js#L272

### Issues: 
None was reported:
1. Before the fix, when deleting the underlying storage, the phase of the backing store was still `Ready`.
2. After the fix it is in phase `Rejected` and in the core logs you can see:

```bash
Jun-15 8:03:09.891 [HostedAgents/33] [ERROR] CONSOLE:: RPC._on_request: ERROR srv agent_api.test_store_validity reqid 9@ws://[::1]:42386/(fufpzye) connid wss://localhost:8443/(fucbmdq) Error: google cloud bucket shira-gcp-03 not found
    at BlockStoreGoogle.test_store_validity (/root/node_modules/noobaa-core/src/agent/block_store_services/block_store_google.js:288:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async Agent.test_store_validity (/root/node_modules/noobaa-core/src/agent/agent.js:936:9)
    at async /root/node_modules/noobaa-core/src/rpc/rpc.js:340:32
    at async RPC._on_request (/root/node_modules/noobaa-core/src/rpc/rpc.js:348:25)
Jun-15 8:03:09.897 [WebServer/34] [ERROR] core.rpc.rpc:: RPC._request: response ERROR srv agent_api.test_store_validity reqid 9@ws://[::1]:42386/(fufpzye) connid ws://[::1]:42386/(fufpzye) params null took [336.8+3.7=340.5] [RpcError: google cloud bucket shira-gcp-03 not found] { rpc_code: 'STORAGE_NOT_EXIST' }
Jun-15 8:03:09.898 [WebServer/34]    [L0] core.server.node_services.nodes_monitor:: encountered an error in _test_store_validity.  [RpcError: google cloud bucket shira-gcp-03 not found] { rpc_code: 'STORAGE_NOT_EXIST' }
Jun-15 8:03:09.898 [WebServer/34]  [WARN] core.server.node_services.nodes_monitor:: encountered an error in _test_store [RpcError: google cloud bucket shira-gcp-03 not found] { rpc_code: 'STORAGE_NOT_EXIST' }
Jun-15 8:03:09.898 [WebServer/34] [ERROR] core.server.node_services.nodes_monitor:: got STORAGE_NOT_EXIST error from node noobaa-internal-agent-6a2f9237a94dc1002225f05f google cloud bucket shira-gcp-03 not found
Jun-15 8:03:09.899 [WebServer/34]    [L0] core.server.node_services.nodes_monitor:: noobaa-internal-agent-6a2f9237a94dc1002225f05f not readable. reasons: target storage do not exist (Mon Jun 15 2026 08:03:09 GMT+0000 (Coordinated Universal Time))
Jun-15 8:03:09.899 [WebServer/34]    [L0] core.server.node_services.nodes_monitor:: noobaa-internal-agent-6a2f9237a94dc1002225f05f not writable. reasons: target storage do not exist (Mon Jun 15 2026 08:03:09 GMT+0000 (Coordinated Universal Time))
```

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create GCP backingstore (you can reference the [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/backing-store-crd.md)). For example, I used the CLI command: `nb backingstore create google-cloud-storage -n test1 shira-gcp-bs --target-bucket shira-gcp-03`.
3. Delete the underlying storage (by deleting the target bucket in GCP console).
4. Results:
- Do not see the private key printed in the logs.
- Expect the backingstore to be in phase `Rejected` (after re-creating the target bucket it moved back to `Ready`).

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage validation behavior by more precisely mapping errors—distinguishing missing buckets from permission issues, and treating missing test objects as an expected outcome.

* **Tests**
  * Updated the storage validity test to check bucket existence up front and to use explicit 403/404 and bucket-missing handling for clearer, more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->