### PR TITLE
[Backport into 5.21] Fix - restrict default_resource updates to eligible accounts only

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1308,6 +1308,15 @@ function get_default_pool(system) {
     return system.pools_by_name[config.DEFAULT_POOL_NAME];
 }
 
+// update only bootstrap/default-pool accounts (legacy install state), not operator
+// skip no-op updates when account already points to the selected optimal pool
+function _is_default_resource_update_candidate(account, optimal_pool_id) {
+    return account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL &&
+        account.default_resource &&
+        account.default_resource.is_default_pool &&
+        String(account.default_resource._id) !== String(optimal_pool_id);
+}
+
 async function get_optimal_non_default_pool_id() {
     for (const pool of system_store.data.pools) {
         // skip backingstore_pool.
@@ -1332,10 +1341,7 @@ async function update_account_default_resource() {
 
                 if (optimal_pool_id) {
                     const updates = system_store.data.accounts
-                        .filter(account =>
-                            account.email.unwrap() !== config.OPERATOR_ACCOUNT_EMAIL &&
-                            account.default_resource
-                        )
+                        .filter(account => _is_default_resource_update_candidate(account, optimal_pool_id))
                         .map(account => ({
                             _id: account._id,
                             $set: {


### PR DESCRIPTION
(cherry picked from commit faa6345173cd2d39f5712989b78034239f871d1e) (cherry picked from commit cce449f46397a0facfbd65ef4d68c8ae124dabae)

### Describe the Problem
Backport PR: #9700 

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1.  [DFBUGS-7395](https://redhat.atlassian.net/browse/DFBUGS-7395)

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
