### PR TITLE
Migrating to AWS SDK V3 | Block Store S3 | Missing Property `code` vs `Code` in catch

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -96,6 +96,7 @@ class BlockStoreS3 extends BlockStoreBase {
             }
 
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err); // only relevant when using AWS SDK v3
             if (err.code === 'NoSuchKey') {
                 // first time init, continue without usage info
                 dbg.log0('BlockStoreS3 init: no usage path');
@@ -178,6 +179,7 @@ class BlockStoreS3 extends BlockStoreBase {
             };
         } catch (err) {
             dbg.error('_read_block failed:', err, _.omit(this.cloud_info, 'access_keys'));
+            noobaa_s3_client.fix_error_object(err); // only relevant when using AWS SDK v3
             if (err.code === 'NoSuchBucket') {
                 throw new RpcError('STORAGE_NOT_EXIST', `s3 bucket ${this.cloud_info.target_bucket} not found. got error ${err}`);
             } else if (err.code === 'AccessDenied') {
@@ -209,6 +211,7 @@ class BlockStoreS3 extends BlockStoreBase {
             });
         } catch (err) {
             dbg.error('_write_block failed:', err, _.omit(this.cloud_info, 'access_keys'));
+            noobaa_s3_client.fix_error_object(err); // only relevant when using AWS SDK v3
             if (err.code === 'NoSuchBucket') {
                 throw new RpcError('STORAGE_NOT_EXIST', `s3 bucket ${this.cloud_info.target_bucket} not found. got error ${err}`);
             } else if (err.code === 'AccessDenied') {
@@ -277,6 +280,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 });
             }
         } catch (err) {
+            noobaa_s3_client.fix_error_object(err); // only relevant when using AWS SDK v3
             // NoSuchKey is expected
             if (err.code !== 'NoSuchKey') {
                 if (err.code === 'NoSuchBucket') {


### PR DESCRIPTION
### Describe the Problem
While I'm working on another epic, I saw this bug and suggested fixing it.
In PR #9067 the code in file `block_store_s3.js` was migrated to use AWS SDK V3, but the errors when using the new SDK do not contain the property `code`, but `Code`. I noticed this when I deleted the underlying storage (used AWS web console and deleted the target bucket), and the backing store still remained `Ready` instead of moving to `Rejected`.

### Explain the Changes
1. Use the function `noobaa_s3_client.fix_error_object` in the catch clauses in file `block_store_s3.js`.

### Issues: 
None was reported.
I noticed that before the change, upon deleting the underlying storage of a backing store, it remained in the `Ready` phase. 

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create AWS backingstore (you can reference the [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/backing-store-crd.md)). For example, I used the CLI command: `nb backingstore create aws-s3 shira-bs-aws -n test1`.
4. Delete the underlying storage (by deleting the target bucket in the AWS console) - expect the backing store to be in phase `Rejected` (after re-creating the target bucket, it moved back to `Ready`).

`kubectl get backingstore -n test1`

```bash
NAME                           TYPE      PHASE      AGE
noobaa-default-backing-store   pv-pool   Ready      4m5s
shira-bs-aws                   aws-s3    Rejected   2m4s
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in error handling for S3 storage operations to ensure more reliable error reporting across initialization, reads, writes, and validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->