### PR TITLE
Support PutRolePolicy and DeleteRolePolicy for IAM Roles

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -1075,6 +1075,47 @@ module.exports = {
                 system: 'admin'
             }
         },
+        put_role_policy: {
+            doc: 'Put role policy',
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['role_name', 'policy_name', 'policy_document'],
+                properties: {
+                    role_name: {
+                        type: 'string',
+                    },
+                    policy_name: {
+                        type: 'string',
+                    },
+                    policy_document: {
+                        $ref: 'common_api#/definitions/iam_user_policy_document',
+                    },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
+        delete_role_policy: {
+            doc: 'Delete role policy',
+            method: 'DELETE',
+            params: {
+                type: 'object',
+                required: ['role_name', 'policy_name'],
+                properties: {
+                    role_name: {
+                        type: 'string',
+                    },
+                    policy_name: {
+                        type: 'string',
+                    },
+                }
+            },
+            auth: {
+                system: 'admin'
+            }
+        },
         list_user_policies: {
             doc: 'List user policies',
             method: 'GET',

--- a/src/endpoint/iam/iam_constants.js
+++ b/src/endpoint/iam/iam_constants.js
@@ -25,6 +25,8 @@ const IAM_ACTIONS = Object.freeze({
     UPDATE_ROLE: 'update_role',
     DELETE_ROLE: 'delete_role',
     LIST_ROLES: 'list_roles',
+    PUT_ROLE_POLICY: 'put_role_policy',
+    DELETE_ROLE_POLICY: 'delete_role_policy',
 });
 
 const IAM_ACTIONS_USER_INLINE_POLICY = [
@@ -60,6 +62,8 @@ const ACTION_MESSAGE_TITLE_MAP = Object.freeze({
     'update_role': 'UpdateRole',
     'delete_role': 'DeleteRole',
     'list_roles': 'ListRoles',
+    'put_role_policy': 'PutRolePolicy',
+    'delete_role_policy': 'DeleteRolePolicy',
 });
 
 const ACCESS_KEY_STATUS_ENUM = Object.freeze({
@@ -81,7 +85,7 @@ const DEFAULT_MAX_SESSION_DURATION_SECS = 3600;
 const IAM_DEFAULT_PATH = '/';
 const AWS_NOT_USED = 'N/A'; // can be used in case the region or the service name were not used
 const IAM_SERVICE_SMALL_LETTERS = 'iam';
-const AWS_LIMIT_CHARS_USER_INlINE_POLICY = 2048;
+const AWS_LIMIT_CHARS_INLINE_POLICY = 2048;
 const AWS_LIMIT_CHARS_POLICY_DOCUMENT = 131072;
 
 // parameter names in camel case style
@@ -120,7 +124,7 @@ exports.MAX_TAGS = MAX_TAGS;
 exports.MAX_NUMBER_OF_ACCESS_KEYS = MAX_NUMBER_OF_ACCESS_KEYS;
 exports.MAX_NUMBER_OF_IAM_ROLES = MAX_NUMBER_OF_IAM_ROLES;
 exports.DEFAULT_MAX_SESSION_DURATION_SECS = DEFAULT_MAX_SESSION_DURATION_SECS;
-exports.AWS_LIMIT_CHARS_USER_INlINE_POLICY = AWS_LIMIT_CHARS_USER_INlINE_POLICY;
+exports.AWS_LIMIT_CHARS_INLINE_POLICY = AWS_LIMIT_CHARS_INLINE_POLICY;
 exports.AWS_LIMIT_CHARS_POLICY_DOCUMENT = AWS_LIMIT_CHARS_POLICY_DOCUMENT;
 exports.IAM_DEFAULT_PATH = IAM_DEFAULT_PATH;
 exports.AWS_NOT_USED = AWS_NOT_USED;

--- a/src/endpoint/iam/iam_rest.js
+++ b/src/endpoint/iam/iam_rest.js
@@ -78,6 +78,8 @@ const ACTIONS = Object.freeze({
     'GetRole': 'get_role',
     'UpdateRole': 'update_role',
     'DeleteRole': 'delete_role',
+    'PutRolePolicy': 'put_role_policy',
+    'DeleteRolePolicy': 'delete_role_policy',
     'ListRoles': 'list_roles',
     'ListRoleTags': 'list_role_tags',
     'ListSAMLProviders': 'list_saml_providers',
@@ -118,6 +120,9 @@ const IAM_OPS = js_utils.deep_freeze({
     post_update_role: require('./ops/iam_update_role'),
     post_delete_role: require('./ops/iam_delete_role'),
     post_list_roles: require('./ops/iam_list_roles'),
+    // role policy
+    post_put_role_policy: require('./ops/iam_put_role_policy'),
+    post_delete_role_policy: require('./ops/iam_delete_role_policy'),
     // other (currently ops that return empty or NoSuchEntity error - just not to fail them)
     post_list_groups_for_user: require('./ops/iam_list_groups_for_user'),
     post_list_account_aliases: require('./ops/iam_list_account_aliases'),

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -230,7 +230,7 @@ function validate_tagging_params(action, params) {
 }
 
 /**
- * validate_policy_params will call the aquivalent function for each action in user policy API
+ * validate_policy_params will call the equivalent function for each action in user and role policy APIs
  * @param {string} action
  * @param {object} params
  */
@@ -247,6 +247,12 @@ function validate_policy_params(action, params) {
             break;
         case iam_constants.IAM_ACTIONS.LIST_USER_POLICIES:
             validate_list_user_policies(params);
+            break;
+        case iam_constants.IAM_ACTIONS.PUT_ROLE_POLICY:
+            validate_put_role_policy(params);
+            break;
+        case iam_constants.IAM_ACTIONS.DELETE_ROLE_POLICY:
+            validate_delete_role_policy(params);
             break;
         default:
             throw new RpcError('INTERNAL_ERROR', `${action} is not supported`);
@@ -618,6 +624,38 @@ function validate_list_roles(params) {
         validate_marker(params.marker);
         validate_max_items(params.max_items);
         validate_iam_path(params.iam_path_prefix, iam_constants.IAM_ROLE_PARAMETER_NAME.IAM_PATH_PREFIX);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+ /**
+ * validate_put_role_policy checks the params for put_role_policy action
+ * @param {object} params
+ */
+function validate_put_role_policy(params) {
+    try {
+        check_required_role_name(params);
+        validate_role_name(params.role_name, iam_constants.IAM_ROLE_PARAMETER_NAME.ROLE_NAME);
+        check_required_policy_name(params);
+        validate_policy_name(params.policy_name, iam_constants.IAM_ROLE_PARAMETER_NAME.POLICY_NAME);
+        check_required_policy_document(params);
+        validate_policy_document(params.policy_document, iam_constants.IAM_ROLE_PARAMETER_NAME.POLICY_DOCUMENT);
+    } catch (err) {
+        translate_rpc_error(err);
+    }
+}
+
+/**
+ * validate_delete_role_policy checks the params for delete_role_policy action
+ * @param {object} params
+ */
+function validate_delete_role_policy(params) {
+    try {
+        check_required_role_name(params);
+        validate_role_name(params.role_name, iam_constants.IAM_ROLE_PARAMETER_NAME.ROLE_NAME);
+        check_required_policy_name(params);
+        validate_policy_name(params.policy_name, iam_constants.IAM_ROLE_PARAMETER_NAME.POLICY_NAME);
     } catch (err) {
         translate_rpc_error(err);
     }

--- a/src/endpoint/iam/ops/iam_delete_role_policy.js
+++ b/src/endpoint/iam/ops/iam_delete_role_policy.js
@@ -7,22 +7,19 @@ const iam_constants = require('../iam_constants');
 const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
 
 /**
- * https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateRole.html
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteRolePolicy.html
  */
-async function update_role(req, res) {
+async function delete_role_policy(req, res) {
     const params = {
         role_name: req.body.role_name,
-        description: req.body.description,
-        max_session_duration: req.body.max_session_duration === undefined ?
-            undefined : Number(req.body.max_session_duration),
+        policy_name: req.body.policy_name,
     };
-    dbg.log1('IAM UPDATE ROLE', params);
-    iam_utils.validate_params(iam_constants.IAM_ACTIONS.UPDATE_ROLE, params);
-    await req.account_sdk.update_role(params);
+    dbg.log1('IAM DELETE ROLE POLICY', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.DELETE_ROLE_POLICY, params);
+    await req.account_sdk.delete_role_policy(params);
 
     return {
-        UpdateRoleResponse: {
-            UpdateRoleResult: {},
+        DeleteRolePolicyResponse: {
             ResponseMetadata: {
                 RequestId: req.request_id,
             }
@@ -31,7 +28,7 @@ async function update_role(req, res) {
 }
 
 module.exports = {
-    handler: update_role,
+    handler: delete_role_policy,
     body: {
         type: CONTENT_TYPE_APP_FORM_URLENCODED,
     },

--- a/src/endpoint/iam/ops/iam_put_role_policy.js
+++ b/src/endpoint/iam/ops/iam_put_role_policy.js
@@ -1,0 +1,49 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const dbg = require('../../../util/debug_module')(__filename);
+const iam_utils = require('../iam_utils');
+const iam_constants = require('../iam_constants');
+const { CONTENT_TYPE_APP_FORM_URLENCODED } = require('../../../util/http_utils');
+
+/**
+ * https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutRolePolicy.html
+ */
+async function put_role_policy(req, res) {
+    const params = {
+        role_name: req.body.role_name,
+        policy_name: req.body.policy_name,
+        policy_document: req.body.policy_document,
+    };
+    dbg.log1('IAM PUT ROLE POLICY', params);
+    iam_utils.validate_params(iam_constants.IAM_ACTIONS.PUT_ROLE_POLICY, params);
+    params.policy_document = JSON.parse(params.policy_document);
+
+    try {
+        await req.account_sdk.put_role_policy(params);
+    } catch (err) {
+        dbg.error('put_role_policy failed with params', params, 'error:', err);
+        if (err.rpc_code === 'INVALID_SCHEMA' || err.rpc_code === 'INVALID_SCHEMA_PARAMS') {
+            iam_utils.throw_malformed_policy_document_error();
+        }
+        throw err;
+    }
+
+    return {
+        PutRolePolicyResponse: {
+            ResponseMetadata: {
+                RequestId: req.request_id,
+            }
+        }
+    };
+}
+
+module.exports = {
+    handler: put_role_policy,
+    body: {
+        type: CONTENT_TYPE_APP_FORM_URLENCODED,
+    },
+    reply: {
+        type: 'xml',
+    },
+};

--- a/src/sdk/account_sdk.js
+++ b/src/sdk/account_sdk.js
@@ -300,6 +300,19 @@ class AccountSDK {
         return accountspace.list_roles(params, this);
     }
 
+    ////////////////////
+    // ROLE POLICY  //
+    ////////////////////
+
+    async put_role_policy(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.put_role_policy(params, this);
+    }
+
+    async delete_role_policy(params) {
+        const accountspace = this._get_accountspace();
+        return accountspace.delete_role_policy(params, this);
+    }
 }
 
 // EXPORTS

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -623,6 +623,20 @@ class AccountSpaceFS {
         return { members, is_truncated };
     }
 
+    async put_role_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.PUT_ROLE_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
+    async delete_role_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.DELETE_ROLE_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        const { code, http_code, type } = IamError.NotImplemented;
+        throw new IamError({ code, message: 'NotImplemented', http_code, type });
+    }
+
     ////////////////////////
     // INTERNAL FUNCTIONS //
     ////////////////////////

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -156,6 +156,14 @@ class AccountSpaceNB {
     async list_roles(params, account_sdk) {
         return account_sdk.rpc_client.account.list_roles(params);
     }
+
+    async put_role_policy(params, account_sdk) {
+        return account_sdk.rpc_client.account.put_role_policy(params);
+    }
+
+    async delete_role_policy(params, account_sdk) {
+        return account_sdk.rpc_client.account.delete_role_policy(params);
+    }
 }
 
 // EXPORTS

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -999,6 +999,9 @@ interface AccountSpace {
     update_role(params: object, account_sdk: AccountSDK): Promise<any>;
     delete_role(params: object, account_sdk: AccountSDK): Promise<any>;
     list_roles(params: object, account_sdk: AccountSDK): Promise<any>;
+    // role policy
+    put_role_policy(params: object, account_sdk: AccountSDK): Promise<any>;
+    delete_role_policy(params: object, account_sdk: AccountSDK): Promise<any>;
 }
 
 

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1215,12 +1215,23 @@ function _verify_can_delete_account(req, account_to_delete) {
     }
 }
 
+/**
+ * returns all non-deleted IAM roles for the given owner account
+ * @param {string|nb.ID} account_id
+ * @returns {nb.IamRole[]}
+ */
 function _list_active_iam_roles_for_account(account_id) {
+    const account_id_str = String(account_id);
     const iam_roles_by_owner = system_store.data.iam_roles_by_owner || {};
-    const indexed_roles = iam_roles_by_owner[account_id] || [];
+    const indexed_roles = iam_roles_by_owner[account_id_str] || [];
     return _.filter(indexed_roles, role => !role.deleted);
 }
 
+/**
+ * validates role creation constraints for the target account
+ * @param {string} role_name
+ * @param {nb.IamRole[]} account_roles
+ */
 function _validate_create_role_preconditions(role_name, account_roles) {
     if (account_roles.length >= MAX_NUMBER_OF_IAM_ROLES) {
         const message_with_details = `Cannot exceed quota for RolesPerAccount: ${MAX_NUMBER_OF_IAM_ROLES}.`;
@@ -1234,6 +1245,12 @@ function _validate_create_role_preconditions(role_name, account_roles) {
     }
 }
 
+/**
+ * returns an IAM role by name from a role list
+ * @param {nb.IamRole[]} account_roles
+ * @param {string} role_name
+ * @returns {nb.IamRole|undefined}
+ */
 function _find_iam_role_by_name(account_roles, role_name) {
     return _.find(account_roles, role => role.name === role_name);
 }
@@ -1601,7 +1618,7 @@ async function put_user_policy(req) {
     const requesting_account = req.account;
     dbg.log1(`AccountSpaceNB.${action}`, req.rpc_params);
     const requested_account = account_util.validate_and_return_requested_account(req.rpc_params, action, requesting_account);
-    const iam_user_policies = requested_account.iam_user_policies || [];
+    const iam_user_policies = [...(requested_account.iam_user_policies || [])];
     const index_of_iam_user_policy = account_util._get_iam_user_policy_index(iam_user_policies, req.rpc_params.policy_name);
     const iam_user_policy_to_add = {
         policy_name: req.rpc_params.policy_name,
@@ -1643,7 +1660,7 @@ async function delete_user_policy(req) {
     dbg.log1(`AccountSpaceNB.${action}`, req.rpc_params);
     const requesting_account = req.account;
     const requested_account = account_util.validate_and_return_requested_account(req.rpc_params, action, requesting_account);
-    const iam_user_policies = requested_account.iam_user_policies || [];
+    const iam_user_policies = [...(requested_account.iam_user_policies || [])];
     const iam_user_policy_index = account_util._check_user_policy_exists(action, iam_user_policies, req.rpc_params.policy_name);
     iam_user_policies.splice(iam_user_policy_index, 1);
 
@@ -1788,6 +1805,69 @@ async function delete_role(req) {
     });
 }
 
+async function put_role_policy(req) {
+    const action = IAM_ACTIONS.PUT_ROLE_POLICY;
+    const requesting_account = req.account;
+    account_util._check_if_requesting_account_is_root_account(action, requesting_account,
+        { role_name: req.rpc_params.role_name, path: IAM_DEFAULT_PATH }, 'ROLE');
+
+    const account_roles = _list_active_iam_roles_for_account(requesting_account._id);
+    const role_to_update = _find_iam_role_by_name(account_roles, req.rpc_params.role_name);
+    if (!role_to_update) {
+        const message_with_details = `The role with name ${req.rpc_params.role_name} cannot be found.`;
+        throw new RpcError('NO_SUCH_ENTITY', message_with_details);
+    }
+
+    const iam_role_policies = [...(role_to_update.iam_role_policies || [])];
+    const policy_index = account_util._get_iam_user_policy_index(iam_role_policies, req.rpc_params.policy_name);
+    const iam_role_policy_to_add = {
+        policy_name: req.rpc_params.policy_name,
+        policy_document: req.rpc_params.policy_document,
+    };
+    if (policy_index === -1) {
+        iam_role_policies.push(iam_role_policy_to_add);
+    } else {
+        iam_role_policies[policy_index] = iam_role_policy_to_add;
+    }
+
+    account_util._check_total_policy_size(iam_role_policies, req.rpc_params.role_name, 'role');
+    await system_store.make_changes({
+        update: {
+            iam_roles: [{
+                _id: role_to_update._id,
+                $set: { iam_role_policies },
+            }]
+        }
+    });
+}
+
+async function delete_role_policy(req) {
+    const action = IAM_ACTIONS.DELETE_ROLE_POLICY;
+    const requesting_account = req.account;
+    account_util._check_if_requesting_account_is_root_account(action, requesting_account,
+        { role_name: req.rpc_params.role_name, path: IAM_DEFAULT_PATH }, 'ROLE');
+
+    const account_roles = _list_active_iam_roles_for_account(requesting_account._id);
+    const role_to_delete = _find_iam_role_by_name(account_roles, req.rpc_params.role_name);
+    if (!role_to_delete) {
+        const message_with_details = `The role with name ${req.rpc_params.role_name} cannot be found.`;
+        throw new RpcError('NO_SUCH_ENTITY', message_with_details);
+    }
+
+    const iam_role_policies = [...(role_to_delete.iam_role_policies || [])];
+    const policy_index = account_util._check_user_policy_exists(action, iam_role_policies, req.rpc_params.policy_name, 'role');
+    iam_role_policies.splice(policy_index, 1);
+
+    await system_store.make_changes({
+        update: {
+            iam_roles: [{
+                _id: role_to_delete._id,
+                $set: { iam_role_policies },
+            }]
+        }
+    });
+}
+
 // EXPORTS
 exports.create_account = create_account;
 exports.create_external_user_account = create_external_user_account;
@@ -1816,6 +1896,8 @@ exports.get_role = get_role;
 exports.update_role = update_role;
 exports.delete_role = delete_role;
 exports.list_roles = list_roles;
+exports.put_role_policy = put_role_policy;
+exports.delete_role_policy = delete_role_policy;
 exports.create_user = create_user;
 exports.get_user = get_user;
 exports.update_user = update_user;

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -14,7 +14,7 @@ const pool_server = require('../server/system_services/pool_server');
 const { OP_NAME_TO_ACTION } = require('../endpoint/sts/sts_rest');
 const { create_arn_for_user, create_arn_for_role, get_action_message_title, get_owner_account_id } = require('../endpoint/iam/iam_utils');
 const { IAM_ACTIONS, MAX_NUMBER_OF_ACCESS_KEYS, IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM,
-    IAM_ACTIONS_USER_INLINE_POLICY, AWS_LIMIT_CHARS_USER_INlINE_POLICY } = require('../endpoint/iam/iam_constants');
+    IAM_ACTIONS_USER_INLINE_POLICY, AWS_LIMIT_CHARS_INLINE_POLICY } = require('../endpoint/iam/iam_constants');
 
 const demo_access_keys = Object.freeze({
     access_key: new SensitiveString('123'),
@@ -435,9 +435,9 @@ function _throw_error_no_such_entity_access_key(action, access_key_id) {
     throw new RpcError('NO_SUCH_ENTITY', message_with_details);
 }
 
-function _throw_error_no_such_entity_policy(action, policy_name) {
-    dbg.error(`AccountSpaceNB.${action} The user policy with name does not exist`, policy_name);
-    const message_with_details = `The user policy with name ${policy_name} cannot be found.`;
+function _throw_error_no_such_entity_policy(action, policy_name, entity = 'user') {
+    dbg.error(`AccountSpaceNB.${action} The ${entity} policy with name does not exist`, policy_name);
+    const message_with_details = `The ${entity} policy with name ${policy_name} cannot be found.`;
     throw new RpcError('NO_SUCH_ENTITY', message_with_details);
 }
 
@@ -595,10 +595,10 @@ function _list_access_keys_from_account(requesting_account, account, on_itself) 
     return members;
 }
 
-function _check_user_policy_exists(action, iam_user_policies, policy_name) {
+function _check_user_policy_exists(action, iam_user_policies, policy_name, entity = 'user') {
     const iam_user_policy_index = _get_iam_user_policy_index(iam_user_policies, policy_name);
     if (iam_user_policy_index === -1) {
-        _throw_error_no_such_entity_policy(action, policy_name);
+        _throw_error_no_such_entity_policy(action, policy_name, entity);
     }
     return iam_user_policy_index;
 }
@@ -609,10 +609,10 @@ function _get_iam_user_policy_index(iam_user_policies, policy_name) {
     return iam_user_policy_index;
 }
 
-function _check_total_policy_size(iam_user_policies, username) {
+function _check_total_policy_size(iam_user_policies, username, entity = 'user') {
     const total_chars_size = _get_total_size_of_policies(iam_user_policies);
-    if (total_chars_size > AWS_LIMIT_CHARS_USER_INlINE_POLICY) {
-        const message_with_details = `Maximum policy size of ${AWS_LIMIT_CHARS_USER_INlINE_POLICY} bytes exceeded for user ${username}`;
+    if (total_chars_size > AWS_LIMIT_CHARS_INLINE_POLICY) {
+        const message_with_details = `Maximum policy size of ${AWS_LIMIT_CHARS_INLINE_POLICY} bytes exceeded for ${entity} ${username}`;
         throw new RpcError('LIMIT_EXCEEDED', message_with_details);
     }
 }


### PR DESCRIPTION
### Describe the Problem
NooBaa IAM had role creation/deletion, but missing inline role policy APIs (`PutRolePolicy`, `DeleteRolePolicy`).

### Explain the Changes
1. Added IAM API routing and handlers for `PutRolePolicy` and `DeleteRolePolicy` (`iam_rest` + new ops files), including malformed policy translation to `MalformedPolicyDocument`.
2. Added action constants and validation flow in `iam_constants/iam_utils` (role name, policy name, policy document checks) reusing existing policy validators.
3. Added RPC/account API methods and SDK wiring (`account_api`, `account_sdk`, `accountspace_nb`, `accountspace_fs`, `nb.d.ts`) to expose both APIs end-to-end.

// TODO
4. Trust and Role policy Validations - can be moved to separate PR.

### Issues: Fixed #xxx / Gap #xxx
1. EPIC: https://redhat.atlassian.net/browse/MCGI-330

### Testing Instructions:
1. Try putRolePolicy and deleteRolePolicy apis using below commands:

`$ AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url <endpoint-url> iam create-role --role-name test-role  --assume-role-policy-document file://trust-policy.json --path / --max-session-duration 3600` (create role)

`$ AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url <endpoint-url> iam put-role-policy --role-name test-role --policy-name allow-list-buckets --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"*"}]}'` (put role policy)

`$ AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url <endpoint-url> iam delete-role-policy --role-name test-role --policy-name allow-list-buckets` (delete role policy)

`$ AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> aws --no-verify-ssl --endpoint-url <endpoint-url> iam delete-role --role-name test-role` (delete role)

> $ cat trust-policy.json
{
"Version": "2012-10-17",
"Statement": [
{
"Effect": "Allow",
"Principal": {
"AWS": "arn:aws:iam::6a1ff4c334ef1400227bb371:root"
},
"Action": "sts:AssumeRole"
}
]
}


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `PutRolePolicy` to create or update inline policies attached to IAM roles.
- Added `DeleteRolePolicy` to remove inline policies from IAM roles.
- Both operations are restricted to administrator access, validate required parameters (including policy document content where applicable), and return structured XML responses.

**Bug Fixes**
- Improved inline-policy size-limit enforcement and clarified “no such entity” / “limit exceeded” error messaging for better troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->