### PR TITLE
NC | Replace Mocha arrow functions to prevent timeout propagation

### DIFF
--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -895,7 +895,7 @@ mocha.describe('manage_nsfs cli', function() {
         let account_options = { config_root, name, new_buckets_path, distinguished_name, access_key, secret_key };
         const new_user = 'newuser';
 
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -905,7 +905,7 @@ mocha.describe('manage_nsfs cli', function() {
             await set_path_permissions_and_owner(new_buckets_path_new_dn, { uid: 2222, gid: 2222 }, 0o700);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await delete_fs_user_by_platform(new_user);
         });

--- a/src/test/integration_tests/nc/cli/test_nc_health.js
+++ b/src/test/integration_tests/nc/cli/test_nc_health.js
@@ -166,7 +166,7 @@ mocha.describe('nsfs nc health', function() {
                 gid: 1312
             }
         };
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             config.NSFS_NC_CONF_DIR = config_root;
             const https_port = 6443;
@@ -184,7 +184,7 @@ mocha.describe('nsfs nc health', function() {
             }
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             fs_utils.folder_delete(new_buckets_path);
             fs_utils.folder_delete(path.join(new_buckets_path, 'bucket1'));

--- a/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
+++ b/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
@@ -205,7 +205,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         accounts.push(res.email);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         fs_utils.folder_delete(tmp_fs_root);
         for (const email of accounts) {
@@ -2989,7 +2989,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             await create_object(`${dir1_version_dir}/${version_key}`, version_body, 'null');
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(0); // eslint-disable-line no-invalid-this
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3133,7 +3133,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             file_pointer = await create_object(`${full_path}/${en_version_key}`, en_version_body, versionID_1, true);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3814,7 +3814,7 @@ mocha.describe('List-objects', function() {
         await create_object(`${dir1_version_dir}/${dir_version_key_2}`, version_body, 'mtime-crkfjr98uiv4-ino-guu6');
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
         fs_utils.folder_delete(tmp_fs_root);
@@ -3823,7 +3823,7 @@ mocha.describe('List-objects', function() {
         }
     });
 
-    mocha.beforeEach(async () => {
+    mocha.beforeEach(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         await fs_utils.create_fresh_path(full_path2, 0o777);
         await P.delay(100); // sometime we saw that the check failed although the path is created a line before


### PR DESCRIPTION
### Describe the Problem 
Mocha discourages the use of arrow functions because they inherit the parent context (`this`) instead of creating their own. As a result, any configuration applied through `this` affects the entire surrounding `describe` block rather than a single test. See: https://mochajs.org/features/arrow-functions/

Starting with Mocha 11.7.6, a bug fix changed timeout propagation behavior so that timeouts set on a `describe` context are inherited by all tests within that suite (see: https://github.com/mochajs/mocha/releases/tag/v11.7.6, `https://github.com/mochajs/mocha/issues/5422`).

Several of our tests call `timeout(0)` while using arrow functions. Because the timeout is applied through the inherited `describe` context, it propagates to all tests in the suite. This effect is amplified when `timeout(0)` is invoked from `beforeEach`, causing the timeout to be repeatedly applied across the entire suite. These timeouts are not cleared after test execution, resulting in approximately 190 unresolved timers remaining when the test run completes.

Additionally, some tests set non-zero timeout values while using arrow functions. Due to the same propagation behavior, those timeout values can affect unrelated tests and eventually expire, leading to unexpected test failures.

### Explain the Changes
1. Replace arrow functions with regular function expressions in Mocha tests to ensure timeout settings are scoped correctly and do not propagate through the parent context.

### Gaps
1. we have hundreds of arrow functions used in tests. they are currently harmless as they do not call any ctx functions. but might cause issues in the future 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mocha test lifecycle hooks across integration test suites to ensure proper behavior during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->