### PR TITLE
replace arrow functions with normal function for mocha tests

### DIFF
--- a/src/test/external_tests/different_clients/test_go_sdkv2_script.js
+++ b/src/test/external_tests/different_clients/test_go_sdkv2_script.js
@@ -16,7 +16,7 @@ const { run_go_sdk_v2_client_script } = require('./run_go_sdkv2_client_script');
 
 mocha.describe('Go AWS SDK V2 Client script execution', function() {
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         const account_info = await rpc_client.account.read_account({ email: EMAIL, });
         console.log('test_go_sdkv2_script: account_info', account_info);
         const admin_access_key = account_info.access_keys[0].access_key.unwrap();

--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -48,7 +48,7 @@ let coretest_endpoint_iam;
 mocha.describe('IAM integration tests', async function() {
     this.timeout(50000); // eslint-disable-line no-invalid-this
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         // we want to make sure that we run this test with a couple of forks (by default setup it is 0)
         if (is_nc_coretest) {
             config_root = path.join(TMP_PATH, 'test_nc_iam');
@@ -81,7 +81,7 @@ mocha.describe('IAM integration tests', async function() {
         iam_account = generate_iam_client(access_key, secret_key, coretest_endpoint_iam);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         if (is_nc_coretest) {
             fs_utils.folder_delete(`${config_root}`);
         }
@@ -181,7 +181,7 @@ mocha.describe('IAM integration tests', async function() {
             const username2 = 'Fuji';
             let access_key_id;
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 // create a user
                 const input = {
                     UserName: username2
@@ -191,7 +191,7 @@ mocha.describe('IAM integration tests', async function() {
                 _check_status_code_ok(response);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 // delete a user
                 const input = {
                     UserName: username2
@@ -292,7 +292,7 @@ mocha.describe('IAM integration tests', async function() {
             const policy_name = 'AllAccessPolicy';
             const iam_user_inline_policy_document = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}';
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 // create a user
                 const input = {
                     UserName: username3
@@ -302,7 +302,7 @@ mocha.describe('IAM integration tests', async function() {
                 _check_status_code_ok(response);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 // delete a user
                 const input = {
                     UserName: username3
@@ -387,7 +387,7 @@ mocha.describe('IAM integration tests', async function() {
 
             const user_tags = [user_tag_1, user_tag_2];
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 // create a user
                 const input = {
                     UserName: username4
@@ -397,7 +397,7 @@ mocha.describe('IAM integration tests', async function() {
                 _check_status_code_ok(response);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 // delete a user
                 const input = {
                     UserName: username4
@@ -476,7 +476,7 @@ mocha.describe('IAM integration tests', async function() {
             const instance_profile_name = 'my_instance_profile_name';
             const policy_arn = 'arn:aws:iam::123456789012:policy/billing-access';
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 // create a user
                 const input = {
                     UserName: username5
@@ -486,7 +486,7 @@ mocha.describe('IAM integration tests', async function() {
                 _check_status_code_ok(response);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 // delete a user
                 const input = {
                     UserName: username5
@@ -963,7 +963,7 @@ mocha.describe('IAM integration tests', async function() {
             let iam_user_client;
 
             mocha.describe('IAM CreateUser API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -971,7 +971,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1039,7 +1039,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM GetUser API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1047,7 +1047,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1085,7 +1085,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM UpdateUser API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     // create 2 users
                     await create_iam_user(iam_account, username);
                     await create_iam_user(iam_account, username2);
@@ -1096,7 +1096,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     // delete 2 users
                     await delete_iam_user(iam_account, username);
@@ -1180,7 +1180,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM DeleteUser API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1188,7 +1188,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1264,7 +1264,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM ListUsers API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1272,7 +1272,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1323,7 +1323,7 @@ mocha.describe('IAM integration tests', async function() {
             let iam_user_client;
 
             mocha.describe('IAM CreateAccessKey API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1331,7 +1331,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_access_key_iam_user(iam_account, access_key_id_2, username);
                     await delete_iam_user(iam_account, username);
@@ -1384,7 +1384,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM GetAccessKeyLastUsed API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1392,7 +1392,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1428,7 +1428,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM UpdateAccessKey API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1438,7 +1438,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_access_key_iam_user(iam_account, access_key_id_2, username);
                     await delete_iam_user(iam_account, username);
@@ -1520,7 +1520,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM DeleteAccessKey API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1530,7 +1530,7 @@ mocha.describe('IAM integration tests', async function() {
                     iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                 });
@@ -1605,7 +1605,7 @@ mocha.describe('IAM integration tests', async function() {
             });
 
             mocha.describe('IAM ListAccessKeys API', async function() {
-                mocha.before(async () => {
+                mocha.before(async function() {
                     await create_iam_user(iam_account, username);
                     const res = await create_access_key_iam_user(iam_account, username);
                     access_key_id = res.access_key_id;
@@ -1614,7 +1614,7 @@ mocha.describe('IAM integration tests', async function() {
                     await create_iam_user(iam_account, username2);
                 });
 
-                mocha.after(async () => {
+                mocha.after(async function() {
                     await delete_access_key_iam_user(iam_account, access_key_id, username);
                     await delete_iam_user(iam_account, username);
                     await delete_iam_user(iam_account, username2);
@@ -1711,7 +1711,7 @@ mocha.describe('IAM integration tests', async function() {
                 ]
             });
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 await create_iam_user(iam_account, username);
                 await create_iam_user(iam_account, username2);
                 const res = await create_access_key_iam_user(iam_account, username);
@@ -1720,7 +1720,7 @@ mocha.describe('IAM integration tests', async function() {
                 iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 await delete_access_key_iam_user(iam_account, access_key_id, username);
                 await delete_inline_user_policy(iam_account, username, policy_name_multiple_statements);
                 await delete_inline_user_policy(iam_account, username, policy_name_to_replace);
@@ -2013,7 +2013,7 @@ mocha.describe('IAM integration tests', async function() {
 
             const user_tags = [user_tag_1, user_tag_2];
 
-            mocha.before(async () => {
+            mocha.before(async function() {
                 await create_iam_user(iam_account, username);
                 const res = await create_access_key_iam_user(iam_account, username);
                 access_key_id = res.access_key_id;
@@ -2021,7 +2021,7 @@ mocha.describe('IAM integration tests', async function() {
                 iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
             });
 
-            mocha.after(async () => {
+            mocha.after(async function() {
                 await delete_access_key_iam_user(iam_account, access_key_id, username);
                 await delete_iam_user(iam_account, username);
             });

--- a/src/test/integration_tests/api/s3/test_chunked_upload.js
+++ b/src/test/integration_tests/api/s3/test_chunked_upload.js
@@ -29,7 +29,7 @@ mocha.describe('S3 basic chunked upload tests', async function() {
 
     let s3;
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         const account_info = await rpc_client.account.read_account({ email: EMAIL, });
         const s3_client_params = {
             endpoint: coretest.get_http_address(),

--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -40,7 +40,7 @@ const object_io = new ObjectIO();
 object_io.set_verification_mode();
 
 // eslint-disable-next-line max-lines-per-function
-mocha.describe('lifecycle', () => {
+mocha.describe('lifecycle', function() {
 
     let s3;
     mocha.before(async function() {
@@ -67,67 +67,67 @@ mocha.describe('lifecycle', () => {
     mocha.describe('bucket-lifecycle-data-representation', function() {
         this.timeout(60000);
 
-        mocha.it('test rules length', async () => {
+        mocha.it('test rules length', async function() {
             await commonTests.test_rules_length(Bucket, Key, s3);
         });
-        mocha.it('test rule status', async () => {
+        mocha.it('test rule status', async function() {
             await commonTests.test_rule_status(Bucket, Key, s3);
         });
-        mocha.it('test expiration date', async () => {
+        mocha.it('test expiration date', async function() {
             await commonTests.test_expiration_date(Bucket, Key, s3);
         });
-        mocha.it('test rule filter', async () => {
+        mocha.it('test rule filter', async function() {
             await commonTests.test_rule_filter(Bucket, Key, s3);
         });
-        mocha.it('test expiration days', async () => {
+        mocha.it('test expiration days', async function() {
             await commonTests.test_expiration_days(Bucket, Key, s3);
         });
-        mocha.it('test filter tag', async () => {
+        mocha.it('test filter tag', async function() {
             await commonTests.test_filter_tag(Bucket, TagName, TagValue, s3);
         });
-        mocha.it('test and tag', async () => {
+        mocha.it('test and tag', async function() {
             await commonTests.test_and_tag(Bucket, TagName, TagValue, TagName2, TagValue2, s3);
         });
-        mocha.it('test and tags prefix days', async () => {
+        mocha.it('test and tags prefix days', async function() {
             await commonTests.test_and_tag_prefix(Bucket, Key, TagName, TagValue, TagName2, TagValue2, s3);
         });
-        mocha.it('test rule id', async () => {
+        mocha.it('test rule id', async function() {
             await commonTests.test_rule_id(Bucket, Key, s3);
         });
-        mocha.it('test rule size', async () => {
+        mocha.it('test rule size', async function() {
             await commonTests.test_filter_size(Bucket, s3);
         });
-        mocha.it('test and prefix size', async () => {
+        mocha.it('test and prefix size', async function() {
             await commonTests.test_and_prefix_size(Bucket, Key, s3);
         });
-        mocha.it('test version', async () => {
+        mocha.it('test version', async function() {
             await commonTests.test_version(Bucket, Key, s3);
         });
-        mocha.it('test multipath', async () => {
+        mocha.it('test multipath', async function() {
             await commonTests.test_multipart(Bucket, Key, s3);
         });
-        mocha.it('test rule ID length', async () => {
+        mocha.it('test rule ID length', async function() {
             await commonTests.test_rule_id_length(Bucket, Key, s3);
         });
-        mocha.it('test rule duplicate ID', async () => {
+        mocha.it('test rule duplicate ID', async function() {
             await commonTests.test_rule_duplicate_id(Bucket, Key, s3);
         });
-        mocha.it('test rule status value', async () => {
+        mocha.it('test rule status value', async function() {
             await commonTests.test_rule_status_value(Bucket, Key, s3);
         });
-        mocha.it('test invalid filter format', async () => {
+        mocha.it('test invalid filter format', async function() {
             await commonTests.test_invalid_filter_format(Bucket, Key, s3);
         });
-        mocha.it('test invalid expiration date format', async () => {
+        mocha.it('test invalid expiration date format', async function() {
             await commonTests.test_invalid_expiration_date_format(Bucket, Key, s3);
         });
-        mocha.it('test expiration with multiple fields', async () => {
+        mocha.it('test expiration with multiple fields', async function() {
             await commonTests.test_expiration_multiple_fields(Bucket, Key, s3);
         });
-        mocha.it('test AbortIncompleteMultipartUpload with tags', async () => {
+        mocha.it('test AbortIncompleteMultipartUpload with tags', async function() {
             await commonTests.test_abortincompletemultipartupload_with_tags(Bucket, Key, s3);
         });
-        mocha.it('test AbortIncompleteMultipartUpload with object sizes', async () => {
+        mocha.it('test AbortIncompleteMultipartUpload with object sizes', async function() {
             await commonTests.test_abortincompletemultipartupload_with_sizes(Bucket, Key, s3);
         });
     });
@@ -177,7 +177,7 @@ mocha.describe('lifecycle', () => {
             assert.strictEqual(actualLength, 0, `listObjectResult actual ${actualLength} !== expected 0`);
         }
 
-        mocha.it('test prefix, absolute date expiration', async () => {
+        mocha.it('test prefix, absolute date expiration', async function() {
             const key = crypto.randomUUID();
             const prefix = key.split('-')[0];
             const age = 17;
@@ -190,7 +190,7 @@ mocha.describe('lifecycle', () => {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
-        mocha.it('test prefix, absolute date and tags expiration', async () => {
+        mocha.it('test prefix, absolute date and tags expiration', async function() {
             const key = crypto.randomUUID();
             const prefix = key.split('-')[0];
             const age = 17;
@@ -205,7 +205,7 @@ mocha.describe('lifecycle', () => {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
-        mocha.it('test size less, absolute date expiration', async () => {
+        mocha.it('test size less, absolute date expiration', async function() {
             const key = crypto.randomUUID();
             const age = 17;
             const size = 64;
@@ -217,7 +217,7 @@ mocha.describe('lifecycle', () => {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
-        mocha.it('test size interval, absolute date expiration', async () => {
+        mocha.it('test size interval, absolute date expiration', async function() {
             const key = crypto.randomUUID();
             const age = 17;
             const gt = 1;
@@ -231,7 +231,7 @@ mocha.describe('lifecycle', () => {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
-        mocha.it('test size less, relative days expiration', async () => {
+        mocha.it('test size less, relative days expiration', async function() {
             const key = crypto.randomUUID();
             const object_age = 2;
             const days = 1;
@@ -244,7 +244,7 @@ mocha.describe('lifecycle', () => {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
-        mocha.it('test tag, relative days expiration', async () => {
+        mocha.it('test tag, relative days expiration', async function() {
             const key = crypto.randomUUID();
             const object_age = 2;
             const days = 1;
@@ -408,7 +408,7 @@ mocha.describe('lifecycle', () => {
             return obj_id;
         }
 
-        mocha.it('lifecycle - delete multipart after 30 days', async () => {
+        mocha.it('lifecycle - delete multipart after 30 days', async function() {
             const days = 30;
             const multi_bucket_key = 'test-lifecycle-multipart1';
             const obj_id = await create_mock_multipart_upload(multi_bucket_key, multipart_bucket, days, 45, 7);
@@ -419,7 +419,7 @@ mocha.describe('lifecycle', () => {
             await verify_multipart_deleted(obj_id, multi_bucket_key, 0);
         });
 
-        mocha.it('lifecycle - should not delete multipart after 30 days, before expiration', async () => {
+        mocha.it('lifecycle - should not delete multipart after 30 days, before expiration', async function() {
             const days = 30;
             const multi_bucket_key = 'test-lifecycle-multipart2';
             // create_time updated to 29 days and expire is 30 days, do not delete any multipart
@@ -431,7 +431,7 @@ mocha.describe('lifecycle', () => {
             await verify_multipart_deleted(obj_id, multi_bucket_key, 7);
         });
 
-        mocha.it('lifecycle - delete multipart after 30 days, with prfix', async () => {
+        mocha.it('lifecycle - delete multipart after 30 days, with prfix', async function() {
             const days = 30;
             const multi_bucket_key_prefix = 'prefix-test-lifecycle-multipart3';
             const multi_bucket_key = 'test-lifecycle-multipart3';
@@ -624,7 +624,7 @@ mocha.describe('lifecycle', () => {
             }
         }
 
-        mocha.it('lifecycle - version object expired', async () => {
+        mocha.it('lifecycle - version object expired', async function() {
             const age = 30;
             const version_count = 10;
             const version_bucket_key = 'test-lifecycle-version1-1';
@@ -636,7 +636,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(version_count + 1, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version object not expired', async () => {
+        mocha.it('lifecycle - version object not expired', async function() {
             const age = 5;
             const version_count = 10;
             const version_bucket_key = 'test-lifecycle-version2-0';
@@ -648,7 +648,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(version_count, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version not expiration', async () => {
+        mocha.it('lifecycle - version not expiration', async function() {
             const days = 30;
             const version_count = 10;
             const newnon_current_version = 1;
@@ -666,7 +666,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(2, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version expiration - only NewerNoncurrentVersions exceeded', async () => {
+        mocha.it('lifecycle - version expiration - only NewerNoncurrentVersions exceeded', async function() {
             const days = 35;
             const version_count = 10;
             const newnon_current_version = 5;
@@ -683,7 +683,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(7, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version expiration - only NoncurrentDays exceeded', async () => {
+        mocha.it('lifecycle - version expiration - only NoncurrentDays exceeded', async function() {
             const days = 45;
             const version_count = 10;
             const newnon_current_version = 100;
@@ -701,7 +701,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(11, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version expiration - both NoncurrentDays and NewerNoncurrentVersions exceeded', async () => {
+        mocha.it('lifecycle - version expiration - both NoncurrentDays and NewerNoncurrentVersions exceeded', async function() {
             const days = 30;
             const version_count = 10;
             const newnon_current_version = 1;
@@ -718,7 +718,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(2, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version not expiration - delete marker true', async () => {
+        mocha.it('lifecycle - version not expiration - delete marker true', async function() {
             const days = 30;
             const version_count = 10;
             const noncurrent_days = 15;
@@ -734,7 +734,7 @@ mocha.describe('lifecycle', () => {
             await verify_version_deleted(1, version_bucket_key);
         });
 
-        mocha.it('lifecycle - version expiration all - delete marker true', async () => {
+        mocha.it('lifecycle - version expiration all - delete marker true', async function() {
             const days = 30;
             const version_count = 10;
             const noncurrent_days = 15;
@@ -820,7 +820,7 @@ mocha.describe('lifecycle', () => {
             assert.ok(valid, `expected rule ${expected_id} to match`);
         };
 
-        mocha.it('should select rule with longest prefix', async () => {
+        mocha.it('should select rule with longest prefix', async function() {
             // Skip test if DB is not PostgreSQL
             if (config.DB_TYPE !== 'postgres') return;
             const rules = [
@@ -835,7 +835,7 @@ mocha.describe('lifecycle', () => {
             });
         });
 
-        mocha.it('should select rule with more tags when prefix is same', async () => {
+        mocha.it('should select rule with more tags when prefix is same', async function() {
             // Skip test if DB is not PostgreSQL
             if (config.DB_TYPE !== 'postgres') return;
             const rules = [
@@ -854,7 +854,7 @@ mocha.describe('lifecycle', () => {
             });
         });
 
-        mocha.it('should select rule with narrower size span when prefix and tags are matching', async () => {
+        mocha.it('should select rule with narrower size span when prefix and tags are matching', async function() {
             // Skip test if DB is not PostgreSQL
             if (config.DB_TYPE !== 'postgres') return;
             const rules = [
@@ -870,7 +870,7 @@ mocha.describe('lifecycle', () => {
             });
         });
 
-        mocha.it('should fallback to first matching rule if all filters are equal', async () => {
+        mocha.it('should fallback to first matching rule if all filters are equal', async function() {
             // Skip test if DB is not PostgreSQL
             if (config.DB_TYPE !== 'postgres') return;
             const rules = [

--- a/src/test/integration_tests/api/s3/test_notifications.js
+++ b/src/test/integration_tests/api/s3/test_notifications.js
@@ -63,7 +63,7 @@ mocha.describe('notifications', function() {
     this.timeout(40000); // eslint-disable-line no-invalid-this
     let s3;
 
-    describe('notifications', () => {
+    describe('notifications', function() {
 
         mocha.before(async function() {
 
@@ -112,7 +112,7 @@ mocha.describe('notifications', function() {
             http_server.close();
         });
 
-        mocha.it('set/get notif conf s3ops', async () => {
+        mocha.it('set/get notif conf s3ops', async function() {
 
             server_done = false;
             expect_test = true;
@@ -133,7 +133,7 @@ mocha.describe('notifications', function() {
             assert.strictEqual(get.TopicConfigurations[0].Id, 'system_test_http_no_event');
         });
 
-        mocha.it('simple notif put', async () => {
+        mocha.it('simple notif put', async function() {
             const res = await s3.putObject({
                 Bucket: bucket,
                 Key: 'f1',
@@ -149,7 +149,7 @@ mocha.describe('notifications', function() {
         });
 
 
-        mocha.it('simple notif delete', async () => {
+        mocha.it('simple notif delete', async function() {
             await s3.deleteObject({
                 Bucket: bucket,
                 Key: 'f1',
@@ -164,7 +164,7 @@ mocha.describe('notifications', function() {
         });
 
 
-        mocha.it('notifications with event filtering', async () => {
+        mocha.it('notifications with event filtering', async function() {
 
             expect_test = true;
             const set = await s3.putBucketNotificationConfiguration({
@@ -202,7 +202,7 @@ mocha.describe('notifications', function() {
             await notify_await_result({timeout: 2000});
         });
 
-        mocha.it('multipart', async () => {
+        mocha.it('multipart', async function() {
             const res_create = await s3.createMultipartUpload({
                 Bucket: bucket,
                 Key: 'mp1'

--- a/src/test/integration_tests/api/s3/test_nsfs_versioning_gpfs.js
+++ b/src/test/integration_tests/api/s3/test_nsfs_versioning_gpfs.js
@@ -62,7 +62,7 @@ mocha.describe('namespace_fs gpfs- versioning', async function() {
             console.log(`gpfs_root_path - ${gpfs_root_path} doesn't exist. Skipping test`);
             this.skip(); // eslint-disable-line no-invalid-this
         }
-        //mocha.after(async () => fs_utils.folder_delete(tmp_fs_root));
+        //mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_root); });
     });
 
     mocha.it('set bucket versioning - Enabled', async function() {

--- a/src/test/integration_tests/api/s3/test_s3_encryption.js
+++ b/src/test/integration_tests/api/s3/test_s3_encryption.js
@@ -58,22 +58,22 @@ async function get_s3_instances() {
     return { aws_s3, local_s3 };
 }
 
-mocha.describe('Bucket Encryption Operations', async () => {
+mocha.describe('Bucket Encryption Operations', async function() {
     // Skip test if DB is not PostgreSQL
     if (config.DB_TYPE !== 'postgres') return;
 
     const BKT = 'sloth-bucket-encryption';
     let local_s3;
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         [, local_s3] = Object.values(await get_s3_instances());
     });
 
-    mocha.it('should create bucket', async () => {
+    mocha.it('should create bucket', async function() {
         await local_s3.createBucket({ Bucket: BKT });
     });
 
-    mocha.it('should get default bucket encryption without encryption configured', async () => {
+    mocha.it('should get default bucket encryption without encryption configured', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {
@@ -89,7 +89,7 @@ mocha.describe('Bucket Encryption Operations', async () => {
         assert.deepEqual(res_without_metadata, expected_response);
     });
 
-    mocha.it('should configure bucket encryption', async () => {
+    mocha.it('should configure bucket encryption', async function() {
         const params = {
             Bucket: BKT,
             ServerSideEncryptionConfiguration: {
@@ -105,7 +105,7 @@ mocha.describe('Bucket Encryption Operations', async () => {
         await local_s3.putBucketEncryption(params);
     });
 
-    mocha.it('should get bucket encryption', async () => {
+    mocha.it('should get bucket encryption', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {
@@ -121,11 +121,11 @@ mocha.describe('Bucket Encryption Operations', async () => {
         assert.deepEqual(res_without_metadata, expected_response);
     });
 
-    mocha.it('should delete bucket encryption', async () => {
+    mocha.it('should delete bucket encryption', async function() {
         await local_s3.deleteBucketEncryption({ Bucket: BKT });
     });
 
-    mocha.it('should get default bucket encryption without encryption configured', async () => {
+    mocha.it('should get default bucket encryption without encryption configured', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {
@@ -153,7 +153,7 @@ mocha.describe('Bucket Encryption Operations', async () => {
         await copy_part(local_s3, BKT);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         await local_s3.deleteBucket({ Bucket: BKT });
     });
 });
@@ -195,7 +195,7 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         await rpc_client.bucket.create_bucket({ name: BKT, namespace: { read_resources, write_resource } });
     });
 
-    mocha.it('should get default bucket encryption without encryption configured', async () => {
+    mocha.it('should get default bucket encryption without encryption configured', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {
@@ -211,7 +211,7 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         assert.deepEqual(res_without_metadata, expected_response);
     });
 
-    mocha.it('should configure bucket encryption', async () => {
+    mocha.it('should configure bucket encryption', async function() {
         const params = {
             Bucket: BKT,
             ServerSideEncryptionConfiguration: {
@@ -227,7 +227,7 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         await local_s3.putBucketEncryption(params);
     });
 
-    mocha.it('should get bucket encryption', async () => {
+    mocha.it('should get bucket encryption', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {
@@ -243,11 +243,11 @@ mocha.describe('Bucket Namespace S3 Encryption Operations', async function() {
         assert.deepEqual(res_without_metadata, expected_response);
     });
 
-    mocha.it('should delete bucket encryption', async () => {
+    mocha.it('should delete bucket encryption', async function() {
         await local_s3.deleteBucketEncryption({ Bucket: BKT });
     });
 
-    mocha.it('should get default bucket encryption without encryption configured', async () => {
+    mocha.it('should get default bucket encryption without encryption configured', async function() {
         const res = await local_s3.getBucketEncryption({ Bucket: BKT });
         const expected_response = {
             ServerSideEncryptionConfiguration: {

--- a/src/test/integration_tests/api/s3/test_s3_list_buckets.js
+++ b/src/test/integration_tests/api/s3/test_s3_list_buckets.js
@@ -50,7 +50,7 @@ mocha.describe('s3_ops', function() {
         coretest.log('S3 CONFIG', s3.config);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         let delete_bucket;
         for (const bucket of bucket_names) {
                 delete_bucket = new DeleteBucketCommand({

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -372,7 +372,7 @@ mocha.describe('md_store', function() {
             return md_store.delete_chunks_by_ids(_.map(chunks, '_id'));
         });
 
-        mocha.it('find_chunks_by_dedup_key()', async () => {
+        mocha.it('find_chunks_by_dedup_key()', async function() {
             if (config.DB_TYPE !== 'postgres') return; // feature uses SQL path
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
             const chunk = {
@@ -402,7 +402,7 @@ mocha.describe('md_store', function() {
             assert(chunksArr[0].frags[0].blocks.length >= 1);
         });
 
-        mocha.it('test find_chunks_by_dedup_key - dedup_key doesnt exist in DB', async () => {
+        mocha.it('test find_chunks_by_dedup_key - dedup_key doesnt exist in DB', async function() {
             if (config.DB_TYPE !== 'postgres') return; // feature uses SQL path
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
             const chunksArr = await md_store.find_chunks_by_dedup_key(bucket, [Buffer.from('unknownkey').toString('base64')]);
@@ -410,7 +410,7 @@ mocha.describe('md_store', function() {
             assert(chunksArr.length === 0);
         });
 
-        mocha.it('find_chunks_by_dedup_key empty dedup_key array passed', async () => {
+        mocha.it('find_chunks_by_dedup_key empty dedup_key array passed', async function() {
             if (config.DB_TYPE !== 'postgres') return; // feature uses SQL path
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
 
@@ -419,7 +419,7 @@ mocha.describe('md_store', function() {
             assert(chunksArr.length === 0);
         });
 
-        mocha.it('find_chunks_by_dedup_key - multiple chunks with multiple frags and blocks', async () => {
+        mocha.it('find_chunks_by_dedup_key - multiple chunks with multiple frags and blocks', async function() {
             if (config.DB_TYPE !== 'postgres') return;
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
             const frag1a = { _id: md_store.make_md_id() };
@@ -464,7 +464,7 @@ mocha.describe('md_store', function() {
             assert(res_chunk2.frags[0].blocks.length === 1);
         });
 
-        mocha.it('find_chunks_by_dedup_key - excludes deleted chunks', async () => {
+        mocha.it('find_chunks_by_dedup_key - excludes deleted chunks', async function() {
             if (config.DB_TYPE !== 'postgres') return;
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
             const chunk = {
@@ -485,7 +485,7 @@ mocha.describe('md_store', function() {
             assert(result.length === 0);
         });
 
-        mocha.it('find_chunks_by_dedup_key - excludes deleted blocks', async () => {
+        mocha.it('find_chunks_by_dedup_key - excludes deleted blocks', async function() {
             if (config.DB_TYPE !== 'postgres') return;
             const bucket = { _id: md_store.make_md_id(), system: { _id: system_id } };
             const chunk = {

--- a/src/test/integration_tests/nc/cli/test_nc_bucket_logging.js
+++ b/src/test/integration_tests/nc/cli/test_nc_bucket_logging.js
@@ -21,7 +21,7 @@ mocha.describe('cli logging flow', async function() {
     const bucket_path = path.join(TMP_PATH, 'log_bucket');
     const pers_log_path = path.join(TMP_PATH, 'pers_logs');
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await fs_utils.create_fresh_path(pers_log_path);
         await fs_utils.create_fresh_path(bucket_path);
         await fs_utils.file_must_exist(bucket_path);

--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -38,11 +38,11 @@ set_nc_config_dir_in_config(config_root);
 
 mocha.describe('manage_nsfs cli', function() {
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await fs_utils.create_fresh_path(root_path);
         config.NC_MASTER_KEYS_FILE_LOCATION = '';
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await fs_utils.folder_delete(`${config_root}`);
         await fs_utils.folder_delete(`${root_path}`);
         await fs_utils.file_delete(path.join(config_root, 'master_keys.json'));
@@ -86,11 +86,11 @@ mocha.describe('manage_nsfs cli', function() {
             gid: 2222,
         };
 
-        mocha.before(async () => {
+        mocha.before(async function() {
             config.NSFS_NC_CONF_DIR = config_root;
             await fs_utils.create_fresh_path(root_path);
         });
-        mocha.after(async () => {
+        mocha.after(async function() {
             await fs_utils.folder_delete(config_root);
             await fs_utils.folder_delete(root_path);
         });
@@ -845,7 +845,7 @@ mocha.describe('manage_nsfs cli', function() {
         const account1_options_for_delete = { config_root, name: name1 };
         const account2_options = { config_root, name: 'account2', new_buckets_path, uid, gid, access_key: 'BISiDSnjaaE7OKD5N7hB', secret_key };
         const account2_options_for_delete = { config_root, name: name2 };
-        mocha.before(async () => {
+        mocha.before(async function() {
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
             await set_path_permissions_and_owner(new_buckets_path, { uid, gid }, 0o700);
@@ -853,7 +853,7 @@ mocha.describe('manage_nsfs cli', function() {
             await exec_manage_cli(type, action, account1_options);
             await exec_manage_cli(type, action, account2_options);
         });
-        mocha.after(async () => {
+        mocha.after(async function() {
             await fs_utils.folder_delete(new_buckets_path);
             const action = ACTIONS.DELETE;
             await exec_manage_cli(type, action, account1_options_for_delete);
@@ -966,10 +966,10 @@ mocha.describe('manage_nsfs cli', function() {
         this.timeout(50000); // eslint-disable-line no-invalid-this
         const type = TYPES.IP_WHITELIST;
         const config_options = { ENDPOINT_FORKS: 1, UV_THREADPOOL_SIZE: 4 };
-        mocha.before(async () => {
+        mocha.before(async function() {
             await config_fs.create_config_json_file(JSON.stringify(config_options));
         });
-        mocha.after(async () => {
+        mocha.after(async function() {
             const config_file_path = config_fs.get_config_json_path();
             await fs_utils.file_delete(config_file_path);
         });
@@ -1088,14 +1088,14 @@ mocha.describe('manage_nsfs cli', function() {
         let now = new Date();
         let format_time = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
         const config_options = { NC_LIFECYCLE_RUN_TIME: format_time, NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5, NC_LIFECYCLE_TZ: 'LOCAL' };
-        mocha.before(async () => {
+        mocha.before(async function() {
             await config_fs.create_config_json_file(JSON.stringify(config_options));
         });
-        mocha.after(async () => {
+        mocha.after(async function() {
             const config_file_path = config_fs.get_config_json_path();
             await fs_utils.file_delete(config_file_path);
         });
-        mocha.afterEach(async () => {
+        mocha.afterEach(async function() {
             const timestampfile = path.join(config_fs.config_root, config.NC_LIFECYCLE_CONFIG_DIR_NAME, 'lifecycle.timestamp');
             await fs_utils.file_delete(timestampfile);
         });

--- a/src/test/integration_tests/nc/cli/test_nc_health.js
+++ b/src/test/integration_tests/nc/cli/test_nc_health.js
@@ -66,12 +66,12 @@ const tmp_lifecycle_logs_dir_path = path.join(TMP_PATH, 'test_lifecycle_logs');
 mocha.describe('nsfs nc health', function() {
     let Health;
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await fs_utils.create_fresh_path(root_path);
         await fs_utils.create_fresh_path(config_root_invalid);
         await nb_native().fs.mkdir(DEFAULT_FS_CONFIG, bucket_storage_path, 0o770);
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         fs_utils.folder_delete(config_root);
         fs_utils.folder_delete(root_path);
         fs_utils.folder_delete(config_root_invalid);
@@ -196,7 +196,7 @@ mocha.describe('nsfs nc health', function() {
             await fs_utils.folder_delete(config_root);
         });
 
-        mocha.afterEach(async () => {
+        mocha.afterEach(async function() {
             await fs_utils.file_delete(config_fs.config_json_path);
             restore_health_if_needed(Health);
             config.NC_HEALTH_BUCKETS_COUNT_LIMIT_WARNING = orig_health_buckets_count_limit;
@@ -790,21 +790,21 @@ mocha.describe('health - lifecycle', function() {
     const Health = new NSFSHealth({ config_root, config_fs, lifecycle: true });
     const orig_lifecycle_logs_dir = config.NC_LIFECYCLE_LOGS_DIR;
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await fs_utils.create_fresh_path(config_root);
         config.NC_LIFECYCLE_LOGS_DIR = tmp_lifecycle_logs_dir_path;
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         fs_utils.folder_delete(config_root);
         config.NC_LIFECYCLE_LOGS_DIR = orig_lifecycle_logs_dir;
     });
 
-    mocha.beforeEach(async () => {
+    mocha.beforeEach(async function() {
         await config_fs.create_config_json_file(JSON.stringify({ NC_LIFECYCLE_LOGS_DIR: tmp_lifecycle_logs_dir_path }));
     });
 
-    mocha.afterEach(async () => {
+    mocha.afterEach(async function() {
         fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
         await config_fs.delete_config_json_file();
     });

--- a/src/test/integration_tests/nc/cli/test_nc_online_upgrade_s3_integrations.js
+++ b/src/test/integration_tests/nc/cli/test_nc_online_upgrade_s3_integrations.js
@@ -59,7 +59,7 @@ mocha.describe('online upgrade S3 bucket operations tests', function() {
 
     let s3_client;
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         const admin_keys = (await rpc_client.account.read_account({ email: EMAIL, })).access_keys;
         s3_creds.credentials = {
             accessKeyId: admin_keys[0].access_key.unwrap(),
@@ -69,11 +69,11 @@ mocha.describe('online upgrade S3 bucket operations tests', function() {
         s3_client = new S3(s3_creds);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         await folder_delete(new_buckets_path);
     });
 
-    mocha.afterEach(async () => {
+    mocha.afterEach(async function() {
         // restore config dir
         const orig_config_dir = NC_CORETEST_CONFIG_FS.config_dir_version;
         await update_system_json(NC_CORETEST_CONFIG_FS, orig_config_dir);

--- a/src/test/integration_tests/nc/lifecycle/test_nc_lifecycle_expiration.js
+++ b/src/test/integration_tests/nc/lifecycle/test_nc_lifecycle_expiration.js
@@ -90,7 +90,7 @@ mocha.describe('nc lifecycle - check expiration header', async function() {
         assert.ok(valid, `expected rule ${expected_id} to match`);
     };
 
-    mocha.it('should select rule with longest prefix', async () => {
+    mocha.it('should select rule with longest prefix', async function() {
         const rules = [
             generate_lifecycle_rule(10, 'short-prefix', 'lifecycle-test1/', [], undefined, undefined),
             generate_lifecycle_rule(17, 'long-prefix', 'lifecycle-test1/logs/', [], undefined, undefined),
@@ -103,7 +103,7 @@ mocha.describe('nc lifecycle - check expiration header', async function() {
         });
     });
 
-    mocha.it('should select rule with more tags when prefix is same', async () => {
+    mocha.it('should select rule with more tags when prefix is same', async function() {
         const rules = [
             generate_lifecycle_rule(5, 'one-tag', 'lifecycle-test2/', [{ Key: 'env', Value: 'prod' }], undefined, undefined),
             generate_lifecycle_rule(9, 'two-tags', 'lifecycle-test2/', [
@@ -120,7 +120,7 @@ mocha.describe('nc lifecycle - check expiration header', async function() {
         });
     });
 
-    mocha.it('should select rule with narrower size span when prefix and tags are matching', async () => {
+    mocha.it('should select rule with narrower size span when prefix and tags are matching', async function() {
         const rules = [
             generate_lifecycle_rule(4, 'wide-range', 'lifecycle-test3/', [], 100, 10000),
             generate_lifecycle_rule(6, 'narrow-range', 'lifecycle-test3/', [], 1000, 5000),
@@ -134,7 +134,7 @@ mocha.describe('nc lifecycle - check expiration header', async function() {
         });
     });
 
-    mocha.it('should fallback to first matching rule if all filters are equal', async () => {
+    mocha.it('should fallback to first matching rule if all filters are equal', async function() {
         const rules = [
             generate_lifecycle_rule(7, 'rule-a', 'lifecycle/test4/', [], 0, 10000),
             generate_lifecycle_rule(11, 'rule-b', 'lifecycle/test4/', [], 0, 10000),

--- a/src/test/integration_tests/nc/test_nc_with_a_couple_of_forks.js
+++ b/src/test/integration_tests/nc/test_nc_with_a_couple_of_forks.js
@@ -40,7 +40,7 @@ mocha.describe('operations with a couple of forks', async function() {
     this.timeout(50000); // eslint-disable-line no-invalid-this
     const bucket_path = path.join(TMP_PATH, 'bucket1');
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         // we want to make sure that we run this test with a couple of forks (by default setup it is 0)
         const current_setup_options = get_current_setup_options();
         const same_setup = _.isEqual(current_setup_options, setup_options);
@@ -56,7 +56,7 @@ mocha.describe('operations with a couple of forks', async function() {
         s3_admin = generate_s3_client(res.access_key, res.secret_key, CORETEST_ENDPOINT);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         fs_utils.folder_delete(`${config_root}`);
         fs_utils.folder_delete(`${new_bucket_path_param}`);
     });
@@ -235,7 +235,7 @@ const s3_uid6001 = generate_s3_client(access_details.access_key,
         const fork_base_port = config.ENDPOINT_PORT + 1;
         const Health = new NSFSHealth({ config_root, https_port, config_fs, fork_base_port });
 
-        mocha.before(async () => {
+        mocha.before(async function() {
             await create_system_json(config_fs);
         });
 

--- a/src/test/integration_tests/nsfs/test_nsfs_integration.js
+++ b/src/test/integration_tests/nsfs/test_nsfs_integration.js
@@ -111,7 +111,7 @@ mocha.describe('bucket operations - namespace_fs', function() {
         }
         CORETEST_ENDPOINT = coretest.get_http_address();
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await fs_utils.folder_delete(tmp_fs_root);
         if (is_nc_coretest) {
             await delete_fs_user_by_platform(no_permissions_dn);
@@ -1308,8 +1308,8 @@ mocha.describe('nsfs account configurations', function() {
         if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
     });
 
-    mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root1 + bucket_path, 0o770));
-    mocha.after(async () => {
+    mocha.before(async function() { await fs_utils.create_fresh_path(tmp_fs_root1 + bucket_path, 0o770); });
+    mocha.after(async function() {
         for (const bucket_name of [bucket_name1, data_bucket, non_nsfs_bucket2]) {
             try {
                 await rpc_client.bucket.delete_bucket({ name: bucket_name });
@@ -1889,7 +1889,7 @@ mocha.describe('Namespace s3_bucket_policy', function() {
         s3_client = generate_s3_client(access_key.unwrap(), secret_key.unwrap(), CORETEST_ENDPOINT);
         s3_anon_client = generate_anon_s3_client(CORETEST_ENDPOINT);
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await fs_utils.file_delete(path.join(s3_new_ns_buckets_path, KEY));
         await fs_utils.folder_delete(s3_new_ns_buckets_path);
         await fs_utils.folder_delete(tmp_fs_root);
@@ -2250,19 +2250,19 @@ mocha.describe('Presigned URL tests', function() {
         await fs_utils.folder_delete(fs_path);
     });
 
-    it('fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data', async () => {
+    it('fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data', async function() {
         const data = await fetchData(valid_default_presigned_url);
         assert.equal(data, presigned_body);
     });
 
-    it('fetch valid presigned URL - 604800 seconds - should return object data - with valid date + expiry in seconds', async () => {
+    it('fetch valid presigned URL - 604800 seconds - should return object data - with valid date + expiry in seconds', async function() {
         const now = new Date();
         const valid_url_with_date = valid_default_presigned_url + '&X-Amz-Date=' + now.toISOString() + '&X-Amz-Expires=' + 604800;
         const data = await fetchData(valid_url_with_date);
         assert.equal(data, presigned_body);
     });
 
-    it('fetch invalid presigned URL - 604800 seconds - epoch expiry + with future date', async () => {
+    it('fetch invalid presigned URL - 604800 seconds - epoch expiry + with future date', async function() {
         const now = new Date();
         // Add one hour (3600000 milliseconds)
         const one_hour_in_ms = 60 * 60 * 1000;
@@ -2272,7 +2272,7 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(future_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - 604800 expiry seconds + with future date', async () => {
+    it('fetch invalid presigned URL - 604800 expiry seconds + with future date', async function() {
         const now = new Date();
         // Add one hour (3600000 milliseconds)
         const one_hour_in_ms = 60 * 60 * 1000;
@@ -2282,7 +2282,7 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(future_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - 604800 seconds - epoch expiry - URL expired', async () => {
+    it('fetch invalid presigned URL - 604800 seconds - epoch expiry - URL expired', async function() {
         const expired_presigned_url = cloud_utils.get_signed_url(presigned_url_params, 1);
         // wait for 2 seconds before fetching the url
         await P.delay(2000);
@@ -2290,7 +2290,7 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(expired_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - 604800 expiry seconds - URL expired', async () => {
+    it('fetch invalid presigned URL - 604800 expiry seconds - URL expired', async function() {
         const now = new Date();
         const expired_presigned_url = cloud_utils.get_signed_url(presigned_url_params, 1) + '&X-Amz-Date=' + now.toISOString() + '&X-Amz-Expires=' + 1;
         // wait for 2 seconds before fetching the url
@@ -2299,14 +2299,14 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(expired_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - expiry expoch - expire in bigger than limit', async () => {
+    it('fetch invalid presigned URL - expiry expoch - expire in bigger than limit', async function() {
         const invalid_expiry = 604800 + 10;
         const invalid_expiry_presigned_url = cloud_utils.get_signed_url(presigned_url_params, invalid_expiry);
         const expected_err = new S3Error(S3Error.AuthorizationQueryParametersErrorWeek);
         await assert_throws_async(fetchData(invalid_expiry_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - expire in bigger than limit', async () => {
+    it('fetch invalid presigned URL - expire in bigger than limit', async function() {
         const now = new Date();
         const invalid_expiry = 604800 + 10;
         const invalid_expiry_presigned_url = cloud_utils.get_signed_url(presigned_url_params, invalid_expiry) + '&X-Amz-Date=' + now.toISOString() + '&X-Amz-Expires=' + invalid_expiry;
@@ -2314,7 +2314,7 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(invalid_expiry_presigned_url), expected_err.message);
     });
 
-    it('fetch invalid presigned URL - throw an error on exipray with a negative number', async () => {
+    it('fetch invalid presigned URL - throw an error on exipray with a negative number', async function() {
         const now = new Date();
         const invalid_expiry = -7;
         const invalid_expiry_presigned_url = cloud_utils.get_signed_url(presigned_url_params, invalid_expiry) + '&X-Amz-Date=' + now.toISOString() + '&X-Amz-Expires=' + invalid_expiry;
@@ -2322,7 +2322,7 @@ mocha.describe('Presigned URL tests', function() {
         await assert_throws_async(fetchData(invalid_expiry_presigned_url), expected_err.message);
     });
 
-    it('get-object - fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data + return response headers', async () => {
+    it('get-object - fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data + return response headers', async function() {
         const response_queries = {
             ResponseContentDisposition: response_content_disposition,
             ResponseContentLanguage: response_content_language,
@@ -2340,7 +2340,7 @@ mocha.describe('Presigned URL tests', function() {
         assert.deepStrictEqual(headers.get('expires'), response_expires.toUTCString());
     });
 
-    it('head-object - fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data + return response headers', async () => {
+    it('head-object - fetch valid presigned URL - 604800 seconds - epoch expiry - should return object data + return response headers', async function() {
         const response_queries = {
             ResponseContentDisposition: response_content_disposition,
             ResponseContentLanguage: response_content_language,
@@ -2396,7 +2396,7 @@ mocha.describe('response headers test - regular request', function() {
         await fs_utils.folder_delete(fs_path);
     });
 
-    it('get-object - response headers', async () => {
+    it('get-object - response headers', async function() {
         const res = await s3_client.getObject({
             Bucket: response_header_bucket,
             Key: response_header_object,
@@ -2413,7 +2413,7 @@ mocha.describe('response headers test - regular request', function() {
         assert.deepStrictEqual(res.Expires, response_expires);
     });
 
-    it('head-object - response headers', async () => {
+    it('head-object - response headers', async function() {
         const res = await s3_client.headObject({
             Bucket: response_header_bucket,
             Key: response_header_object,

--- a/src/test/unit_tests/internal/test_namespace_cache.js
+++ b/src/test/unit_tests/internal/test_namespace_cache.js
@@ -396,7 +396,7 @@ async function create_namespace_cache_and_read_obj({ recorder, object_sdk, ttl_m
     return { ns_cache, obj, hub, cache };
 }
 
-mocha.describe('namespace caching: upload scenarios', () => {
+mocha.describe('namespace caching: upload scenarios', function() {
     let recorder;
     const ttl_ms = 2000;
     const object_sdk = {
@@ -408,7 +408,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
         recorder = new Recorder();
     });
 
-    mocha.it('cache object during upload', async () => {
+    mocha.it('cache object during upload', async function() {
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
             namespace_hub: new MockNamespace({ type: 'hub', recorder, slow_write: true }),
@@ -437,7 +437,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
         assert(cache_obj.create_time === ret.last_modified_time);
     });
 
-    mocha.it('hub upload failure: object not cached', async () => {
+    mocha.it('hub upload failure: object not cached', async function() {
         const ns_cache = new NamespaceCache({
             namespace_hub: new MockNamespace({ type: 'hub', recorder, trigger_err: 'write' }),
             namespace_nb: new MockNamespace({ type: 'cache', recorder, trigger_err: 'write'}),
@@ -461,7 +461,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
         }
     });
 
-    mocha.it('cache upload failure: return hub status and object not cached', async () => {
+    mocha.it('cache upload failure: return hub status and object not cached', async function() {
         const cache = new MockNamespace({ type: 'cache', recorder, trigger_err: 'write' });
         const ns_cache = new NamespaceCache({
             namespace_hub: new MockNamespace({ type: 'hub', recorder }),
@@ -488,7 +488,7 @@ mocha.describe('namespace caching: upload scenarios', () => {
 
 });
 
-mocha.describe('namespace caching: read scenarios and fresh objects', () => {
+mocha.describe('namespace caching: read scenarios and fresh objects', function() {
     let recorder;
     const ttl_ms = 2000;
     const object_sdk = {
@@ -499,7 +499,7 @@ mocha.describe('namespace caching: read scenarios and fresh objects', () => {
         recorder = new Recorder();
     });
 
-    mocha.it('cache object during read', async () => {
+    mocha.it('cache object during read', async function() {
         const size = 8;
         const { ns_cache, obj } = await create_namespace_cache_and_read_obj({ recorder, size, ttl_ms, object_sdk });
 
@@ -527,7 +527,7 @@ mocha.describe('namespace caching: read scenarios and fresh objects', () => {
         validate_metric(obj.bucket, ns_cache, 'cache_object_read_count', 2);
     });
 
-    mocha.it('failure in cache upload while success in hub read', async () => {
+    mocha.it('failure in cache upload while success in hub read', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder, trigger_err: 'write' });
         const ns_cache = new NamespaceCache({
@@ -556,7 +556,7 @@ mocha.describe('namespace caching: read scenarios and fresh objects', () => {
         assert(_.isUndefined(cache_obj_create_time));
     });
 
-    mocha.it('failure in hub upload', async () => {
+    mocha.it('failure in hub upload', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true, trigger_err: 'read' });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -584,7 +584,7 @@ mocha.describe('namespace caching: read scenarios and fresh objects', () => {
         assert(_.isUndefined(cache_obj_create_time));
     });
 
-    mocha.it('fresh object still cached if precondition (e.g. if-etag) is set by s3 client', async () => {
+    mocha.it('fresh object still cached if precondition (e.g. if-etag) is set by s3 client', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -614,7 +614,7 @@ mocha.describe('namespace caching: read scenarios and fresh objects', () => {
 
 });
 
-mocha.describe('namespace caching: read scenarios that object is cached', () => {
+mocha.describe('namespace caching: read scenarios that object is cached', function() {
     let recorder;
     const ttl_ms = 100;
     const object_sdk = {
@@ -625,7 +625,7 @@ mocha.describe('namespace caching: read scenarios that object is cached', () => 
         recorder = new Recorder();
     });
 
-    mocha.it('update cache_last_valid_time', async () => {
+    mocha.it('update cache_last_valid_time', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -656,7 +656,7 @@ mocha.describe('namespace caching: read scenarios that object is cached', () => 
         }, 2000, 100);
     });
 
-    mocha.it('cache_last_valid_time updated after etag mismatch', async () => {
+    mocha.it('cache_last_valid_time updated after etag mismatch', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -697,7 +697,7 @@ mocha.describe('namespace caching: read scenarios that object is cached', () => 
         }, 2000, 100);
     });
 
-    mocha.it.skip('read from hub if read from cache fails', async () => {
+    mocha.it.skip('read from hub if read from cache fails', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder, trigger_err: 'read' });
         const ns_cache = new NamespaceCache({
@@ -729,7 +729,7 @@ mocha.describe('namespace caching: read scenarios that object is cached', () => 
         assert(read_obj_stream_time > params.object_md.cache_last_valid_time);
     });
 
-    mocha.it('cache object that has inline read performed', async () => {
+    mocha.it('cache object that has inline read performed', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, inline_read: true });
         const cache = new MockNamespace({ type: 'cache', recorder, trigger_err: 'read' });
         const ns_cache = new NamespaceCache({
@@ -773,7 +773,7 @@ mocha.describe('namespace caching: read scenarios that object is cached', () => 
 
 });
 
-mocha.describe('namespace caching: proxy get request with partNumber query to hub', () => {
+mocha.describe('namespace caching: proxy get request with partNumber query to hub', function() {
     let recorder;
     const ttl_ms = 2000;
     const object_sdk = {
@@ -784,7 +784,7 @@ mocha.describe('namespace caching: proxy get request with partNumber query to hu
         recorder = new Recorder();
     });
 
-    mocha.it('proxy get request with partNumber query to hub', async () => {
+    mocha.it('proxy get request with partNumber query to hub', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -822,7 +822,7 @@ mocha.describe('namespace caching: proxy get request with partNumber query to hu
 
 });
 
-mocha.describe('namespace caching: large objects', () => {
+mocha.describe('namespace caching: large objects', function() {
     let recorder;
     const ttl_ms = 2000;
     const free = 10;
@@ -838,7 +838,7 @@ mocha.describe('namespace caching: large objects', () => {
         recorder = new Recorder();
     });
 
-    mocha.it('large object not cached during upload', async () => {
+    mocha.it('large object not cached during upload', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -860,7 +860,7 @@ mocha.describe('namespace caching: large objects', () => {
         assert(_.isUndefined(cache_obj_create_time));
     });
 
-    mocha.it('large object not cached during read', async () => {
+    mocha.it('large object not cached during read', async function() {
         const { obj } = await create_namespace_cache_and_read_obj({
             recorder, size: free + 10, ttl_ms, object_sdk });
         await P.delay(100);
@@ -869,7 +869,7 @@ mocha.describe('namespace caching: large objects', () => {
     });
 });
 
-mocha.describe('namespace caching: range read scenarios', () => {
+mocha.describe('namespace caching: range read scenarios', function() {
     let recorder;
     const ttl_ms = 2000;
     const object_sdk = {
@@ -882,7 +882,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         _.set(object_sdk, 'object_io.upload_object_range', params => mock_upload_object_range(recorder, params, object_sdk));
     });
 
-    mocha.it('range read case success', async () => {
+    mocha.it('range read case success', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -973,7 +973,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         validate_metric(obj.bucket, ns_cache, 'cache_range_read_miss_count', 2);
     });
 
-    mocha.it('range read case if-etag mismatch', async () => {
+    mocha.it('range read case if-etag mismatch', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true, trigger_err: 'if-match-etag' });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -1013,7 +1013,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         }
     });
 
-    mocha.it('range read case: part cached if precondition if-match set by s3 client matches object md', async () => {
+    mocha.it('range read case: part cached if precondition if-match set by s3 client matches object md', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -1047,7 +1047,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         }, 2000, 100);
     });
 
-    mocha.it('range read case: part not cached if precondition if-match set by s3 client does not match object md', async () => {
+    mocha.it('range read case: part not cached if precondition if-match set by s3 client does not match object md', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -1080,7 +1080,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         assert(cache_obj.num_parts === 0);
     });
 
-    mocha.it('range read case: part not cached if other precondition than if-match is set by s3 client', async () => {
+    mocha.it('range read case: part not cached if other precondition than if-match is set by s3 client', async function() {
         const hub = new MockNamespace({ type: 'hub', recorder, slow_write: true });
         const cache = new MockNamespace({ type: 'cache', recorder });
         const ns_cache = new NamespaceCache({
@@ -1113,7 +1113,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         assert(cache_obj.num_parts === 0);
     });
 
-    mocha.it('cache entire small file after range read', async () => {
+    mocha.it('cache entire small file after range read', async function() {
         const size = block_size - 100;
         const start = size - 100;
         // end is exclusive
@@ -1131,7 +1131,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         }, 2000, 100);
     });
 
-    mocha.it('large range not cached', async () => {
+    mocha.it('large range not cached', async function() {
         const free = 100;
         const object_sdk_large_range_read = {
             should_run_triggers: () => null,
@@ -1155,7 +1155,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
         }
     });
 
-    mocha.it('range read falls back to hub read if read from cache fails', async () => {
+    mocha.it('range read falls back to hub read if read from cache fails', async function() {
         const size = block_size * 2;
         let start = block_size - 2;
         // end is exclusive
@@ -1201,7 +1201,7 @@ mocha.describe('namespace caching: range read scenarios', () => {
 
 });
 
-mocha.describe('namespace caching: delete scenario', () => {
+mocha.describe('namespace caching: delete scenario', function() {
     let recorder;
     const ttl_ms = 2000;
     const object_sdk = {
@@ -1212,7 +1212,7 @@ mocha.describe('namespace caching: delete scenario', () => {
         recorder = new Recorder();
     });
 
-    mocha.it('delete object from both cache and hub', async () => {
+    mocha.it('delete object from both cache and hub', async function() {
         const { ns_cache, obj } = await create_namespace_cache_and_read_obj({ recorder, size: 8, ttl_ms, object_sdk });
 
         await P.wait_until(() => {
@@ -1239,7 +1239,7 @@ mocha.describe('namespace caching: delete scenario', () => {
         }
     });
 
-    mocha.it('cache obj is still deleted if hub delete failure (should cache obj be kept?)', async () => {
+    mocha.it('cache obj is still deleted if hub delete failure (should cache obj be kept?)', async function() {
         const { ns_cache, obj } = await create_namespace_cache_and_read_obj({ recorder, size: 8, ttl_ms, object_sdk,
             trigger_hub_err: 'delete'});
 
@@ -1267,7 +1267,7 @@ mocha.describe('namespace caching: delete scenario', () => {
         */
     });
 
-    mocha.it('delete multiple objects: error in cache', async () => {
+    mocha.it('delete multiple objects: error in cache', async function() {
         const { ns_cache, obj } = await create_namespace_cache_and_read_obj({ recorder, size: 8, ttl_ms, object_sdk,
             trigger_cache_err: 'multi-deletes' });
 
@@ -1285,7 +1285,7 @@ mocha.describe('namespace caching: delete scenario', () => {
         }
     });
 
-    mocha.it('delete multiple objects: error in hub', async () => {
+    mocha.it('delete multiple objects: error in hub', async function() {
         const { ns_cache, obj } = await create_namespace_cache_and_read_obj({ recorder, size: 8, ttl_ms, object_sdk,
             trigger_hub_err: 'multi-deletes' });
 

--- a/src/test/unit_tests/nsfs/test_bucketspace_fs.js
+++ b/src/test/unit_tests/nsfs/test_bucketspace_fs.js
@@ -324,7 +324,7 @@ mocha.describe('bucketspace_fs', function() {
         test: 'test',
     };
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([CONFIG_SUBDIRS.IDENTITIES,
             CONFIG_SUBDIRS.ACCOUNTS_BY_NAME, CONFIG_SUBDIRS.ACCESS_KEYS, CONFIG_SUBDIRS.BUCKETS
         ], async dir =>
@@ -343,7 +343,7 @@ mocha.describe('bucketspace_fs', function() {
 
         }
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         fs_utils.folder_delete(`${config_root}`);
         fs_utils.folder_delete(`${new_buckets_path}`);
     });

--- a/src/test/unit_tests/nsfs/test_bucketspace_fs_vectors.js
+++ b/src/test/unit_tests/nsfs/test_bucketspace_fs_vectors.js
@@ -129,7 +129,7 @@ mocha.describe('bucketspace_fs vectors', function() {
     const other_sdk = make_dummy_object_sdk(other_account);
     const no_create_sdk = make_dummy_object_sdk(no_create_account);
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([
             CONFIG_SUBDIRS.IDENTITIES,
             CONFIG_SUBDIRS.ACCOUNTS_BY_NAME,
@@ -156,7 +156,7 @@ mocha.describe('bucketspace_fs vectors', function() {
         }
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         await fs_utils.folder_delete(config_root);
         await fs_utils.folder_delete(new_buckets_path);
     });

--- a/src/test/unit_tests/nsfs/test_namespace_fs.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs.js
@@ -101,15 +101,15 @@ mocha.describe('namespace_fs', function() {
         stats: endpoint_stats_collector.instance(),
     });
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.create_fresh_path(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
 
     mocha.describe('list_objects', function() {
 
@@ -1130,15 +1130,15 @@ mocha.describe('namespace_fs folders tests', function() {
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
     const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '2', namespace_resource_id: undefined });
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.create_fresh_path(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
 
     mocha.describe('folders xattr', function() {
         const dir_1 = 'a/b/c/';
@@ -1661,7 +1661,7 @@ mocha.describe('nsfs_symlinks_validations', function() {
     const dummy_object_sdk = make_dummy_object_sdk(tmp_fs_path);
     const ns = new NamespaceFS({ bucket_path: bucket_full_path, bucket_id: '1', namespace_resource_id: undefined });
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await fs_utils.create_fresh_path(`${bucket_full_path}`);
         await P.all(_.map(expected_dirs, async dir =>
             fs_utils.create_fresh_path(`${bucket_full_path}/${dir}`)));
@@ -1672,11 +1672,11 @@ mocha.describe('nsfs_symlinks_validations', function() {
 
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         await P.all(_.map(expected_files, async file =>
             fs_utils.folder_delete(`${bucket_full_path}/${file}`)));
     });
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
 
     mocha.describe('without_symlinks', function() {
         mocha.it('without_symlinks:list iner dir', async function() {
@@ -1795,15 +1795,15 @@ mocha.describe('namespace_fs copy object', function() {
     const ns_tmp_bucket_path = `${tmp_fs_path}/${src_bkt}`;
     const ns_tmp = new NamespaceFS({ bucket_path: ns_tmp_bucket_path, bucket_id: '3', namespace_resource_id: undefined });
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([src_bkt, upload_bkt], async buck =>
             fs_utils.create_fresh_path(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await P.all(_.map([src_bkt, upload_bkt], async buck =>
             fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
 
     mocha.describe('upload_object (copy)', function() {
         const upload_key = 'upload_key_1';
@@ -2221,11 +2221,11 @@ mocha.describe('namespace_fs copy object', function() {
         const tmp_fs_path_tagging = path.join(TMP_PATH, 'test_namespace_fs_tagging');
         const ns_tmp_bucket_path_tagging = `${tmp_fs_path_tagging}/${src_bkt}`;
         const ns_tmp_tagging = new NamespaceFS({ bucket_path: ns_tmp_bucket_path_tagging, bucket_id: '3', namespace_resource_id: undefined });
-        mocha.before(async () => {
+        mocha.before(async function() {
             await P.all(_.map([src_bkt, upload_bkt_tagging], async buck =>
                 fs_utils.create_fresh_path(`${tmp_fs_path_tagging}/${buck}`)));
         });
-        mocha.after(async () => {
+        mocha.after(async function() {
             await P.all(_.map([src_bkt, upload_bkt_tagging], async buck =>
                 fs_utils.folder_delete(`${tmp_fs_path_tagging}/${buck}`)));
             await fs_utils.folder_delete(tmp_fs_path_tagging);

--- a/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
@@ -64,15 +64,15 @@ mocha.describe('namespace_fs mpu optimization tests', function() {
         stats: endpoint_stats_collector.instance(),
     });
 
-    mocha.before(async () => {
+    mocha.before(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.create_fresh_path(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => {
+    mocha.after(async function() {
         await P.all(_.map([src_bkt, upload_bkt, mpu_bkt], async buck =>
             fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
     });
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_path));
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
 
     mocha.it('MPU | MIX | 10000 different size', async function() {
         this.timeout(2000000); // eslint-disable-line no-invalid-this

--- a/src/test/unit_tests/nsfs/test_nsfs_versioning.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_versioning.js
@@ -42,9 +42,9 @@ mocha.describe('namespace_fs - versioning', function() {
     const tmp_fs_root = path.join(TMP_PATH, 'test_nsfs_versioning');
     const ns_tmp_bucket_path = `${tmp_fs_root}/${bucket_name}`;
 
-    mocha.before(async () => fs_utils.create_fresh_path(tmp_fs_root, 0o777));
-    mocha.before(async () => fs_utils.create_fresh_path(ns_tmp_bucket_path, 0o770));
-    mocha.after(async () => fs_utils.folder_delete(tmp_fs_root));
+    mocha.before(async function() { await fs_utils.create_fresh_path(tmp_fs_root, 0o777); });
+    mocha.before(async function() { await fs_utils.create_fresh_path(ns_tmp_bucket_path, 0o770); });
+    mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_root); });
 
     const dummy_object_sdk = make_dummy_object_sdk(true);
     const dummy_object_sdk_no_nsfs_config = make_dummy_object_sdk(false);

--- a/src/test/unit_tests/util_functions_tests/test_kmeans.js
+++ b/src/test/unit_tests/util_functions_tests/test_kmeans.js
@@ -8,7 +8,7 @@ const kmeans = require('../../../util/kmeans');
 
 mocha.describe('kmeans errors', function() {
 
-    mocha.it('should throw an error if there aren\'t 2 arguments', () => {
+    mocha.it('should throw an error if there aren\'t 2 arguments', function() {
         let was_thrown = false;
         try {
             kmeans.run();
@@ -18,7 +18,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if there aren\'t 2 arguments');
     });
 
-    mocha.it('should throw an error if there isn\'t options', () => {
+    mocha.it('should throw an error if there isn\'t options', function() {
         let was_thrown = false;
         try {
             kmeans.run([]);
@@ -28,7 +28,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if there isn\'t options');
     });
 
-    mocha.it('should throw an error if K isn\'t in options', () => {
+    mocha.it('should throw an error if K isn\'t in options', function() {
         let was_thrown = false;
         try {
             kmeans.run([], { sloth: 1 });
@@ -38,7 +38,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if K isn\'t in options');
     });
 
-    mocha.it('should throw an error if K isn\'t in good range', () => {
+    mocha.it('should throw an error if K isn\'t in good range', function() {
         let was_thrown = false;
         try {
             kmeans.run([], { k: 0 });
@@ -48,7 +48,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if K isn\'t in good range');
     });
 
-    mocha.it('should throw an error if K larger than number of vectors', () => {
+    mocha.it('should throw an error if K larger than number of vectors', function() {
         let was_thrown = false;
         try {
             kmeans.run([], { k: 1 });
@@ -58,7 +58,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if K larger than number of vectors');
     });
 
-    mocha.it('should throw an error if distance isn\'t a function', () => {
+    mocha.it('should throw an error if distance isn\'t a function', function() {
         let was_thrown = false;
         try {
             kmeans.run([1], { k: 1, distance: {} });
@@ -68,7 +68,7 @@ mocha.describe('kmeans errors', function() {
         assert(was_thrown, 'should throw an error if distance isn\'t a function');
     });
 
-    mocha.it('should throw an error if distance isn\'t a function with 2 parameters', () => {
+    mocha.it('should throw an error if distance isn\'t a function with 2 parameters', function() {
         let was_thrown = false;
         try {
             kmeans.run([1], { k: 1, distance: (a, b, c) => (a + b + c) });
@@ -82,7 +82,7 @@ mocha.describe('kmeans errors', function() {
 
 mocha.describe('kmeans working', function() {
 
-    mocha.it('handle noise in vector', () => {
+    mocha.it('handle noise in vector', function() {
         const result = kmeans.run([
             [26],
             [4],


### PR DESCRIPTION
### Describe the Problem
using arrow functions in mocha is problematic as it passes the parent context(`this`) to the test function instead of creating a new one. causing issues when calling functions through context. see https://mochajs.org/features/arrow-functions/ #9722 

### Explain the Changes
1. replace arrow functions to prevent future failures in case context will be called in them. also to prevent people from copying the wrong way of calling mocha functions

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Mocha test suite, `before`/`after`, `beforeEach`/`afterEach`, and `it` callback syntax across many test files to use `async function`/`function()` instead of async arrow functions.
  * Kept existing test logic and assertions the same, focusing on consistent Mocha lifecycle behavior through improved callback semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->