### PR TITLE
[Backport into 5.22] NC | dont use arrow functions in tests

### DIFF
--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -895,7 +895,7 @@ mocha.describe('manage_nsfs cli', function() {
         let account_options = { config_root, name, new_buckets_path, distinguished_name, access_key, secret_key };
         const new_user = 'newuser';
 
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -905,7 +905,7 @@ mocha.describe('manage_nsfs cli', function() {
             await set_path_permissions_and_owner(new_buckets_path_new_dn, { uid: 2222, gid: 2222 }, 0o700);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await delete_fs_user_by_platform(new_user);
         });

--- a/src/test/integration_tests/nc/cli/test_nc_health.js
+++ b/src/test/integration_tests/nc/cli/test_nc_health.js
@@ -166,7 +166,7 @@ mocha.describe('nsfs nc health', function() {
                 gid: 1312
             }
         };
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             config.NSFS_NC_CONF_DIR = config_root;
             const https_port = 6443;
@@ -184,7 +184,7 @@ mocha.describe('nsfs nc health', function() {
             }
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             fs_utils.folder_delete(new_buckets_path);
             fs_utils.folder_delete(path.join(new_buckets_path, 'bucket1'));

--- a/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
+++ b/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
@@ -205,7 +205,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         accounts.push(res.email);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         fs_utils.folder_delete(tmp_fs_root);
         for (const email of accounts) {
@@ -2989,7 +2989,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             await create_object(`${dir1_version_dir}/${version_key}`, version_body, 'null');
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(0); // eslint-disable-line no-invalid-this
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3133,7 +3133,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             file_pointer = await create_object(`${full_path}/${en_version_key}`, en_version_body, versionID_1, true);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3814,7 +3814,7 @@ mocha.describe('List-objects', function() {
         await create_object(`${dir1_version_dir}/${dir_version_key_2}`, version_body, 'mtime-crkfjr98uiv4-ino-guu6');
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
         fs_utils.folder_delete(tmp_fs_root);
@@ -3823,7 +3823,7 @@ mocha.describe('List-objects', function() {
         }
     });
 
-    mocha.beforeEach(async () => {
+    mocha.beforeEach(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         await fs_utils.create_fresh_path(full_path2, 0o777);
         await P.delay(100); // sometime we saw that the check failed although the path is created a line before


### PR DESCRIPTION
### Explain the Changes
NC | dont use arrow functions in tests

(cherry picked from commit cac88c2d881e4d82c2ab60967f8ad2f6d1898d43)

