### PR TITLE
Analyze Resource | GCP Log Printings

### DIFF
--- a/src/tools/diagnostics/analyze_resource/analyze_resource_cloud_vendor.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_cloud_vendor.js
@@ -32,7 +32,7 @@ function get_cloud_vendor(resource_type, connection_basic_details) {
                 connection_basic_details.endpoint);
             break;
         case 'google-cloud-storage':
-            cloud_vendor = new AnalyzeGcp(credentials.private_key_json);
+            cloud_vendor = new AnalyzeGcp(credentials.private_key_json_path);
             break;
         default:
             throw new Error(`Could not create cloud vendor client of ${resource_type}`);
@@ -49,8 +49,8 @@ function get_credentials(resource_type) {
         const secret_access_key = new SensitiveString(fs.readFileSync(secret_access_key_path).toString().trim());
         return { access_key, secret_access_key };
     } else if (credentials_properties.length === 1) { // "google-cloud-storage" case
-        const private_key_json = `${secret_path}/${get_credentials_properties(resource_type)}`;
-        return { private_key_json };
+        const private_key_json_path = `${secret_path}/${credentials_properties[0]}`;
+        return { private_key_json_path };
     } else {
         throw new Error(`Could not get credentials from ${resource_type}`);
     }

--- a/src/tools/diagnostics/analyze_resource/analyze_resource_gcp.js
+++ b/src/tools/diagnostics/analyze_resource/analyze_resource_gcp.js
@@ -10,16 +10,16 @@ const CloudVendor = require('./analyze_resource_cloud_vendor_abstract');
 
 /**
  * @typedef {{
- *      private_key_json: JSON, 
+ *      private_key_json_path: string,
  * }} AnalyzeGcpSpec
  */
 
 class AnalyzeGcp extends CloudVendor {
 
-    constructor(private_key_json) {
+    constructor(private_key_json_path) {
         super(); // Constructors for derived classes must contain a 'super' call.
         const gcs_params = {
-            keyFilename: private_key_json,
+            keyFilename: private_key_json_path,
         };
         this.gcs = new Storage(gcs_params);
     }
@@ -32,11 +32,12 @@ class AnalyzeGcp extends CloudVendor {
         const [files] = await this.gcs
             .bucket(bucket)
             .getFiles(options);
-        dbg.log0(`List object response: ${inspect(files)}`);
+        const file_names = (files || []).map(f => f.name);
+        dbg.log0(`List object response: ${file_names.length} files`, file_names);
 
         this.file = '';
-        if (files && files.length > 0) {
-            this.file = files[0].name;
+        if (file_names.length > 0) {
+            this.file = file_names[0];
         }
     }
 
@@ -55,14 +56,17 @@ class AnalyzeGcp extends CloudVendor {
 
     async write_object(bucket, key) {
         dbg.log0(`Calling GCP bucket(${bucket}).file(${key}).createWriteStream`);
-        const stream = await this.gcs
+        const stream = this.gcs
             .bucket(bucket)
             .file(key)
             .createWriteStream();
-        await buffer_utils.write_to_stream(stream, ''); //write an empty file
+
+        let status;
         stream.on('response', resp => {
-            dbg.log0(`Write of ${key} response: ${inspect(resp)}`);
+            status = resp?.status;
         });
+        await buffer_utils.write_to_stream(stream, ''); // write an empty file
+        dbg.log0(`Write of ${key} done, status=${status ?? 'unknown'}`);
     }
 
     async delete_object(bucket, key) {


### PR DESCRIPTION
### Describe the Problem
Improve the analyze resource printings to avoid printing the private key in case of GCP.

### Explain the Changes
1. Improve the JSDoc and variable name to reflect that the passed argument is a path (`private_key_json_path` instead of `private_key_json`).
2. Change the logs for `List object response` so the logs contain only the file names.
3. Edit the function `write_object` as I couldn't see the previous logs before ("...Write of").

### Issues: 
1. none

### Testing Instructions:
1. Build the images and install NooBaa system on Rancher Desktop (see [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/dev_guide/deply_noobaa_on_minikube_or_rancher_desktop.md)).
_Note: `nb` is an alias that runs the local operator from `build/_output/bin` (alias created by `devenv`)._
2. Create GCP backingstore (you can reference the [guide](https://github.com/noobaa/noobaa-operator/blob/master/doc/backing-store-crd.md)). For example, I used the CLI command: `nb backingstore create google-cloud-storage -n test1 <bs-name> --target-bucket <target-name>`.
3. Run the analyze resource: `nb diagnostics analyze backingstore <backingstore-name> -n test1`.
4. Check that the job runs and you can see the output from the commands and the created logs.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated cloud resource diagnostic authentication to use file-based credential paths instead of in-memory credential content.
  * Improved Google Cloud Storage resource analysis by deriving file listings more robustly and adding clearer upload completion logging based on the transfer status.
  * Enhanced diagnostics output with better visibility into discovered file counts and names during analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->