### PR TITLE
GCP WIF (STS) | Namespace Monitor Fix

### DIFF
--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -185,20 +185,39 @@ class NamespaceMonitor {
     async test_gcs_resource(nsr) {
         let conn = this.nsr_connections_obj[nsr._id];
         if (!conn) {
-            conn = cloud_utils.create_google_storage_from_connection(nsr.connection.secret_key.unwrap());
+            try {
+                conn = cloud_utils.create_google_storage_from_connection(nsr.connection.secret_key.unwrap());
+            } catch (err) {
+                throw Object.assign(err, { code: err.code || 'AuthenticationFailed' });
+            }
             this.nsr_connections_obj[nsr._id] = conn;
         }
         const { target_bucket } = nsr.connection;
         const block_key = `test-delete-non-existing-gcs-key-${Date.now()}`;
         try {
-            await conn.bucket(target_bucket).file(block_key).delete();
+            // GCP does not distinguish bucket-not-found from object-not-found on delete (both return 404),
+            // so we first call bucket.exists(), then delete a non-existing test key.
+            const bucket = conn.bucket(target_bucket);
+            const [bucket_exists] = await bucket.exists();
+            if (!bucket_exists) {
+                throw Object.assign(new Error(`Google cloud bucket ${target_bucket} not found`), { code: S3Error.NoSuchBucket.code });
+            }
+            await bucket.file(block_key).delete();
         } catch (err) {
-            if (err.errors[0].reason === 'UserProjectAccessDenied' && nsr.is_readonly_namespace()) {
+            dbg.log1(`test_gcs_resource: on bucket ${target_bucket} got error (code=${err.code}, message: ${err.message})`);
+            const reason = err.errors?.[0]?.reason;
+            if (err.code === S3Error.NoSuchBucket.code) {
+                throw err;
+            }
+            if (reason === 'UserProjectAccessDenied' && nsr.is_readonly_namespace()) {
                 return;
             }
-            dbg.log1(`test_gcs_resource: on bucket ${target_bucket} got error:`, err);
             // https://cloud.google.com/storage/docs/json_api/v1/status-codes
-            if (err.errors[0].reason !== 'notFound') throw err;
+            // Delete of the non-existing test key is expected (bucket was verified above).
+            if (err.code === 404 || reason === 'notFound') {
+                return;
+            }
+            throw err;
         }
     }
 


### PR DESCRIPTION
### Describe the Problem
A couple of improvements in the namespace monitor when the namespace resource is GCP.

### Explain the Changes
1. Wrap `create_google_storage_from_connection` with try and catch to control the mapping for the report in case of failure.
2. Add a check of bucket existence before deleting the existing key to match the change that was added in backingstore in `test_store_validity` in PR #9704.
3. Avoid printing the whole error, and printing only the `code` and the `message`.

### Issues: Fixed #9710
1. A comment from Code Rabbit was raised after the code review was finished and opened a gap to fix the suggested.

### Testing Instructions:
For the full steps, see [comment](https://github.com/noobaa/noobaa-core/pull/9697#issuecomment-4680190094).
Create 2 namespaces for GCP WIF (STS), and GCP checks that it is in `Ready` phase:
Partial output (I removed the target bucket name):

```bash
nb namespacestore list -n test1
NAME               TYPE                   TARGET-BUCKET   PROVIDER-STORAGE-CLASS   PHASE   AGE
shira-gcp-ns       google-cloud-storage   ***    standard                 Ready   1m14s
shira-gcp-sts-ns   google-cloud-storage   ***    standard                 Ready   1m20s
```

In the logs of noobaa-core pod you can see:
```bash
Jun-21 5:57:46.769 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcp-ns type GOOGLE, 6a377d10a2f37d002220be9a finished successfully..
Jun-21 5:57:46.919 [BGWorkers/32]    [L0] core.server.bg_services.namespace_monitor:: update_last_monitoring: monitoring namespace shira-gcp-sts-ns type GOOGLE_STS, 6a377d0aa2f37d002220be99 finished successfully..
```

Set higher debug level: `nb system set-debug-level 3 -n test1`
I deleted one of the target buckets and could see:

```bash
nb namespacestore list -n test1
NAME               TYPE                   TARGET-BUCKET   PROVIDER-STORAGE-CLASS   PHASE      AGE
shira-gcp-ns       google-cloud-storage   ***    standard                 Rejected   5m11s
shira-gcp-sts-ns   google-cloud-storage   ***    standard                 Ready      5m17s
```

In the logs of noobaa-core pod you can see:
```bash
Jun-21 6:20:32.463 [BGWorkers/32]    [L1] core.server.bg_services.namespace_monitor:: test_namespace_resource_validity: namespace resource shira-gcp-ns has an unexpected error
Jun-21 6:14:31.331 [BGWorkers/32]    [L1] core.server.bg_services.namespace_monitor:: test_gcs_resource: on bucket shira-gcp-04 got error (code=404, message: No such object: shira-gcp-04/test-delete-non-existing-gcs-key-1782022470987)
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage monitoring cleanup by verifying bucket existence before deleting test objects, preventing misleading deletion failures.
  * Strengthened error handling around authentication and access: missing buckets are treated as fatal, while expected “not found” outcomes and read-only access denials are handled appropriately.
  * Updated diagnostics to log both error codes and messages for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->