### PR TITLE
[Backport into 5.21] NC | dont use arrow functions in tests

### DIFF
--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -1095,6 +1095,10 @@ mocha.describe('manage_nsfs cli', function() {
             const config_file_path = config_fs.get_config_json_path();
             await fs_utils.file_delete(config_file_path);
         });
+        mocha.afterEach(async () => {
+            const timestampfile = path.join(config_fs.config_root, config.NC_LIFECYCLE_CONFIG_DIR_NAME, 'lifecycle.timestamp');
+            await fs_utils.file_delete(timestampfile);
+        });
 
         mocha.it('cli lifecycle should run with LOCAL TZ', async function() {
             now = new Date();
@@ -1107,21 +1111,24 @@ mocha.describe('manage_nsfs cli', function() {
         });
 
         mocha.it('cli lifecycle shouldn\'t run twice with LOCAL TZ', async function() {
+            now = new Date();
+            format_time = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
+            // Write a fresh timestamp to simulate lifecycle having already run in this window.
+            const timestampfile = path.join(config_fs.config_root, config.NC_LIFECYCLE_CONFIG_DIR_NAME, 'lifecycle.timestamp');
+            await fs_utils.create_path(path.dirname(timestampfile));
+            await fs_utils.replace_file(timestampfile, new Date().toISOString());
             const new_config_options = { NC_LIFECYCLE_RUN_TIME: format_time, NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5, NC_LIFECYCLE_TZ: 'LOCAL' };
             await config_fs.update_config_json_file(JSON.stringify(new_config_options));
             const res = await exec_manage_cli(type, '', { config_root, disable_service_validation: true });
             const parsed = JSON.parse(res);
             assert.equal(parsed.response.code, ManageCLIResponse.LifecycleWorkerNotRunning.code);
-            // remove the timestamp file to allow next tests to run
-            const timestampfile = path.join(config_fs.config_root, config.NC_LIFECYCLE_CONFIG_DIR_NAME, 'lifecycle.timestamp');
-            await fs_utils.file_delete(timestampfile);
         });
 
         mocha.it('cli lifecycle shouldn\'t run before NC_LIFECYCLE_RUN_TIME with LOCAL TZ', async function() {
             now = new Date();
-            const in_one_minute = new Date(now);
-            in_one_minute.setMinutes(now.getMinutes() + 1);
-            format_time = `${in_one_minute.getHours().toString().padStart(2, '0')}:${in_one_minute.getMinutes().toString().padStart(2, '0')}`;
+            const in_five_minutes = new Date(now);
+            in_five_minutes.setMinutes(now.getMinutes() + 5);
+            format_time = `${in_five_minutes.getHours().toString().padStart(2, '0')}:${in_five_minutes.getMinutes().toString().padStart(2, '0')}`;
             const new_config_options = { NC_LIFECYCLE_RUN_TIME: format_time, NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5, NC_LIFECYCLE_TZ: 'LOCAL' };
             await config_fs.update_config_json_file(JSON.stringify(new_config_options));
             const res = await exec_manage_cli(type, '', { config_root, disable_service_validation: true });
@@ -1154,9 +1161,9 @@ mocha.describe('manage_nsfs cli', function() {
 
         mocha.it('cli lifecycle shouldn\'t run before NC_LIFECYCLE_RUN_TIME with UTC TZ', async function() {
             now = new Date();
-            const in_one_minute = new Date(now); // Create a copy to avoid modifying 'now'
-            in_one_minute.setUTCMinutes(now.getUTCMinutes() + 1);
-            format_time = `${in_one_minute.getUTCHours().toString().padStart(2, '0')}:${in_one_minute.getUTCMinutes().toString().padStart(2, '0')}`;
+            const in_five_minutes = new Date(now);
+            in_five_minutes.setUTCMinutes(now.getUTCMinutes() + 5);
+            format_time = `${in_five_minutes.getUTCHours().toString().padStart(2, '0')}:${in_five_minutes.getUTCMinutes().toString().padStart(2, '0')}`;
             const new_config_options = { NC_LIFECYCLE_RUN_TIME: format_time, NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5, NC_LIFECYCLE_TZ: 'UTC' };
             await config_fs.update_config_json_file(JSON.stringify(new_config_options));
             const res = await exec_manage_cli(type, '', { config_root, disable_service_validation: true });

--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -895,7 +895,7 @@ mocha.describe('manage_nsfs cli', function() {
         let account_options = { config_root, name, new_buckets_path, distinguished_name, access_key, secret_key };
         const new_user = 'newuser';
 
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await fs_utils.create_fresh_path(new_buckets_path);
             await fs_utils.file_must_exist(new_buckets_path);
@@ -905,7 +905,7 @@ mocha.describe('manage_nsfs cli', function() {
             await set_path_permissions_and_owner(new_buckets_path_new_dn, { uid: 2222, gid: 2222 }, 0o700);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(50000); // eslint-disable-line no-invalid-this
             await delete_fs_user_by_platform(new_user);
         });

--- a/src/test/integration_tests/nc/cli/test_nc_health.js
+++ b/src/test/integration_tests/nc/cli/test_nc_health.js
@@ -166,7 +166,7 @@ mocha.describe('nsfs nc health', function() {
                 gid: 1312
             }
         };
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             config.NSFS_NC_CONF_DIR = config_root;
             const https_port = 6443;
@@ -184,7 +184,7 @@ mocha.describe('nsfs nc health', function() {
             }
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             fs_utils.folder_delete(new_buckets_path);
             fs_utils.folder_delete(path.join(new_buckets_path, 'bucket1'));

--- a/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
+++ b/src/test/integration_tests/nsfs/test_bucketspace_versioning.js
@@ -205,7 +205,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
         accounts.push(res.email);
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         fs_utils.folder_delete(tmp_fs_root);
         for (const email of accounts) {
@@ -2989,7 +2989,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             await create_object(`${dir1_version_dir}/${version_key}`, version_body, 'null');
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(0); // eslint-disable-line no-invalid-this
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3133,7 +3133,7 @@ mocha.describe('bucketspace namespace_fs - versioning', function() {
             file_pointer = await create_object(`${full_path}/${en_version_key}`, en_version_body, versionID_1, true);
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
             fs_utils.folder_delete(tmp_fs_root);
             for (const email of accounts) {
@@ -3814,7 +3814,7 @@ mocha.describe('List-objects', function() {
         await create_object(`${dir1_version_dir}/${dir_version_key_2}`, version_body, 'mtime-crkfjr98uiv4-ino-guu6');
     });
 
-    mocha.after(async () => {
+    mocha.after(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         if (file_pointer) await file_pointer.close(DEFAULT_FS_CONFIG);
         fs_utils.folder_delete(tmp_fs_root);
@@ -3823,7 +3823,7 @@ mocha.describe('List-objects', function() {
         }
     });
 
-    mocha.beforeEach(async () => {
+    mocha.beforeEach(async function() {
         this.timeout(0); // eslint-disable-line no-invalid-this
         await fs_utils.create_fresh_path(full_path2, 0o777);
         await P.delay(100); // sometime we saw that the check failed although the path is created a line before

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -319,7 +319,7 @@ async function create_fs_user_by_platform(new_user, new_password, uid, gid) {
     } else {
         const create_group_cmd = `groupadd -g ${gid} ${new_user}`;
         await os_utils.exec(create_group_cmd, { return_stdout: true });
-        const create_user_cmd = `useradd -c ${new_user} -m ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
+        const create_user_cmd = `useradd -c ${new_user} ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
         await os_utils.exec(create_user_cmd, { return_stdout: true });
     }
 }
@@ -336,7 +336,15 @@ async function delete_fs_user_by_platform(name) {
         await os_utils.exec(delete_user_home_cmd, { return_stdout: true });
     } else {
         const delete_user_cmd = `userdel -r ${name}`;
-        await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        try {
+            await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        } catch (err) {
+            // don't throw error if user doesn't exist
+            // error code 6 is "specified user doesn't exist"
+            if (err.code !== 6) {
+                throw err;
+            }
+        }
     }
 }
 

--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -115,7 +115,8 @@ describe('noobaa nc - lifecycle - lock check', () => {
         const lifecyle_run_date = new Date();
         lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() - 1);
         await config_fs.create_config_json_file(JSON.stringify({
-            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
+            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date),
+            NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5
         }));
         const res = await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', config_root }, undefined, undefined);
         await config_fs.delete_config_json_file();
@@ -124,9 +125,9 @@ describe('noobaa nc - lifecycle - lock check', () => {
         expect(parsed_res.message).toBe(ManageCLIResponse.LifecycleSuccessful.message);
     });
 
-    it('nc lifecycle - change run time to 1 minute in the future - should fail ', async () => {
+    it('nc lifecycle - change run time to 10 minute in the future - should fail ', async () => {
         const lifecyle_run_date = new Date();
-        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 1);
+        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 10);
         await config_fs.create_config_json_file(JSON.stringify({
             NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
         }));

--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -2201,7 +2201,7 @@ async function create_object(object_sdk, bucket, key, size, is_old, tagging) {
  */
 async function update_version_xattr(bucket, key, version_id) {
     const older_time = new Date();
-    older_time.setDate(yesterday.getDate() - 5); // 5 days ago
+    older_time.setDate(older_time.getDate() - 5); // 5 days ago
 
     const target_path = path.join(root_path, bucket, path.dirname(key), '.versions', `${path.basename(key)}_${version_id}`);
     const file = await nb_native().fs.open(config_fs.fs_context, target_path, config.NSFS_OPEN_READ_MODE,

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -179,6 +179,13 @@ mocha.describe('dynamic supplemental groups - get_fs_context flow', function() {
         config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_supplemental_groups_enabled_backup;
     });
 
+    mocha.it('test delete user by platform doesnt throw if user does not exist', async function() {
+        if (process.platform === 'darwin') {
+            this.skip(); // eslint-disable-line no-invalid-this
+        }
+        await test_utils.delete_fs_user_by_platform("non_existing_user");
+    });
+
     mocha.it('get_fs_context with uid/gid and dynamic enabled - supplemental groups resolved, readdir succeeds', async function() {
         const nsfs_account_config = { uid: NON_ROOT4_UID, gid: NON_ROOT4_GID };
         const fs_context = await native_fs_utils.get_fs_context(nsfs_account_config, '');


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.21] NC | lifecycle - modify test lock_check times
2. [Backport into 5.21] NC | don't copy home dir on useradd
3. [Backport into 5.21] NC | fix lifecycle test date calculation
4. [Backport into 5.21] NC | more lifecycle tests timing issues
5. [Backport into 5.21] NC | dont use arrow functions in tests
