### PR TITLE
[Backport into 5.18] NC | dont use arrow functions in tests

### DIFF
--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -317,7 +317,7 @@ async function create_fs_user_by_platform(new_user, new_password, uid, gid) {
     } else {
         const create_group_cmd = `groupadd -g ${gid} ${new_user}`;
         await os_utils.exec(create_group_cmd, { return_stdout: true });
-        const create_user_cmd = `useradd -c ${new_user} -m ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
+        const create_user_cmd = `useradd -c ${new_user} ${new_user} -p $(openssl passwd -1 ${new_password}) -u ${uid} -g ${gid} `;
         await os_utils.exec(create_user_cmd, { return_stdout: true });
     }
 }
@@ -334,7 +334,15 @@ async function delete_fs_user_by_platform(name) {
         await os_utils.exec(delete_user_home_cmd, { return_stdout: true });
     } else {
         const delete_user_cmd = `userdel -r ${name}`;
-        await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        try {
+            await os_utils.exec(delete_user_cmd, { return_stdout: true });
+        } catch (err) {
+            // don't throw error if user doesn't exist
+            // error code 6 is "specified user doesn't exist"
+            if (err.code !== 6) {
+                throw err;
+            }
+        }
     }
 }
 

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
@@ -116,7 +116,8 @@ describe('noobaa nc - lifecycle - lock check', () => {
         const lifecyle_run_date = new Date();
         lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() - 1);
         await config_fs.create_config_json_file(JSON.stringify({
-            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
+            NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date),
+            NC_LIFECYCLE_RUN_DELAY_LIMIT_MINS: 5
         }));
         const res = await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', config_root }, undefined, undefined);
         await config_fs.delete_config_json_file();
@@ -125,9 +126,9 @@ describe('noobaa nc - lifecycle - lock check', () => {
         expect(parsed_res.message).toBe(ManageCLIResponse.LifecycleSuccessful.message);
     });
 
-    it('nc lifecycle - change run time to 1 minute in the future - should fail ', async () => {
+    it('nc lifecycle - change run time to 10 minute in the future - should fail ', async () => {
         const lifecyle_run_date = new Date();
-        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 1);
+        lifecyle_run_date.setMinutes(lifecyle_run_date.getMinutes() + 10);
         await config_fs.create_config_json_file(JSON.stringify({
             NC_LIFECYCLE_RUN_TIME: date_to_run_time_format(lifecyle_run_date)
         }));

--- a/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/jest_tests/test_nc_lifecycle_posix_integration.test.js
@@ -2215,7 +2215,7 @@ async function update_file_mtime(target_path) {
  */
 async function update_version_xattr(bucket, key, version_id) {
     const older_time = new Date();
-    older_time.setDate(yesterday.getDate() - 5); // 5 days ago
+    older_time.setDate(older_time.getDate() - 5); // 5 days ago
 
     const target_path = path.join(root_path, bucket, path.dirname(key), '.versions', `${path.basename(key)}_${version_id}`);
     const file = await nb_native().fs.open(config_fs.fs_context, target_path, config.NSFS_OPEN_READ_MODE,

--- a/src/test/unit_tests/test_nc_health.js
+++ b/src/test/unit_tests/test_nc_health.js
@@ -162,7 +162,7 @@ mocha.describe('nsfs nc health', function() {
                 gid: 1312
             }
         };
-        mocha.before(async () => {
+        mocha.before(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             config.NSFS_NC_CONF_DIR = config_root;
             const https_port = 6443;
@@ -180,7 +180,7 @@ mocha.describe('nsfs nc health', function() {
             }
         });
 
-        mocha.after(async () => {
+        mocha.after(async function() {
             this.timeout(5000);// eslint-disable-line no-invalid-this
             fs_utils.folder_delete(new_buckets_path);
             fs_utils.folder_delete(path.join(new_buckets_path, 'bucket1'));


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.18] NC | lifecycle - modify test lock_check times
2. [Backport into 5.18] NC | don't copy home dir on useradd
3. [Backport into 5.18] NC | fix lifecycle test date calculation
4. [Backport into 5.18] NC | dont use arrow functions in tests
