### PR TITLE
[Backport into 5.18] remove push directive so we will not run tests on merge

### DIFF
--- a/.github/workflows/Validate-package-lock.yaml
+++ b/.github/workflows/Validate-package-lock.yaml
@@ -1,5 +1,5 @@
 name: Validate package-lock.json Tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-package-lock-validation:

--- a/.github/workflows/ceph-nsfs-s3-tests.yaml
+++ b/.github/workflows/ceph-nsfs-s3-tests.yaml
@@ -1,5 +1,5 @@
 name: NSFS Ceph S3 Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   nsfs-ceph-s3-tests:

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -1,5 +1,5 @@
 name: Ceph S3 Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   ceph-s3-tests:

--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -1,5 +1,5 @@
 name: Jest Unit Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   run-jest-unit-tests:

--- a/.github/workflows/nc_unit.yml
+++ b/.github/workflows/nc_unit.yml
@@ -1,5 +1,5 @@
 name: Non Containerized Unit Tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-nc-unit-tests:

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -1,5 +1,5 @@
 name: Unit Tests with Postgres
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-unit-tests-postgres:

--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -1,5 +1,5 @@
 name: Build & Sanity SSL
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-sanity-ssl-tests:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,5 +1,5 @@
 name: Build & Sanity
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-sanity-tests:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,5 +1,5 @@
 name: Unit Tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.18] remove push directive so we will not run tests on merge