### PR TITLE
[Backport into 5.21] CI | removing building arm64 and ppc64le after pushing the commit

### DIFF
--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -1,5 +1,5 @@
 name: Build arm64 image
-on: [ push, pull_request ]
+on: [pull_request]
 
 jobs:
   build-arm64-image:

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -1,5 +1,5 @@
 name: Build ppc64le image
-on: [ push, pull_request ]
+on: [pull_request]
 
 jobs:
   build-ppc64le-image:


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.21] CI | removing building arm64 and ppc64le after pushing the commit