### PR TITLE
Add Leader Election module to noobaa core

### DIFF
--- a/config.js
+++ b/config.js
@@ -672,6 +672,22 @@ config.KUBE_API_ENDPOINTS = {
     TOKEN_REVIEW: '/apis/authentication.k8s.io/v1/tokenreviews'
 };
 
+// Core active-passive HA (Kubernetes Lease). Disabled when NOOBAA_CORE_LEASE_NAME is unset.
+// Time to wait between lease acquisition retries and between successful renew iterations.
+config.CORE_LEASE_ACQUIRE_RETRY_MS = 3000;
+// Short sleep between renew retries after a transient error (non-200, non-409 response).
+// Keeping this short (1s) lets us retry many times within the renew deadline.
+config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 1000;
+// Safety margin (ms) subtracted from the live leaseDurationSeconds when computing
+// how long the renew loop may fail before the leader steps down.
+// deadline = leaseDuration - CORE_LEASE_RENEW_ERROR_SLEEP_MS - CORE_LEASE_REQUEST_TIMEOUT_MS - LEASE_RENEW_DEADLINE_MARGIN_MS
+// e.g. 20000 - 1000 - 5000 - 4000 = 10000ms with a 20s lease.
+config.LEASE_RENEW_DEADLINE_MARGIN_MS = 4000;
+// Timeout for each individual Kubernetes API request in the lease client.
+// Keeps a hung API server from blocking the renew loop past the deadline.
+// note on go leader election module it is calculateed as max(renewDeadline / 2, time.Second). use a slightly shorter timeout to account for the extra delay.
+config.CORE_LEASE_REQUEST_TIMEOUT_MS = 5000;
+
 //////////////////////////////
 // ACCOUNT PREFERENCES      //
 //////////////////////////////

--- a/config.js
+++ b/config.js
@@ -673,19 +673,16 @@ config.KUBE_API_ENDPOINTS = {
 };
 
 // Core active-passive HA (Kubernetes Lease). Disabled when NOOBAA_CORE_LEASE_NAME is unset.
+// Desired lease duration..
+config.CORE_LEASE_DURATION_MS = 20000;
 // Time to wait between lease acquisition retries and between successful renew iterations.
 config.CORE_LEASE_ACQUIRE_RETRY_MS = 3000;
-// Short sleep between renew retries after a transient error (non-200, non-409 response).
-// Keeping this short (1s) lets us retry many times within the renew deadline.
+// Short sleep between renew retries after an error
 config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 1000;
-// Safety margin (ms) subtracted from the live leaseDurationSeconds when computing
-// how long the renew loop may fail before the leader steps down.
-// deadline = leaseDuration - CORE_LEASE_RENEW_ERROR_SLEEP_MS - CORE_LEASE_REQUEST_TIMEOUT_MS - LEASE_RENEW_DEADLINE_MARGIN_MS
-// e.g. 20000 - 1000 - 5000 - 4000 = 10000ms with a 20s lease.
-config.LEASE_RENEW_DEADLINE_MARGIN_MS = 4000;
+// The deadline for the lease renewal.
+config.LEASE_RENEW_DEADLINE_MS = 13000;
 // Timeout for each individual Kubernetes API request in the lease client.
-// Keeps a hung API server from blocking the renew loop past the deadline.
-// note on go leader election module it is calculateed as max(renewDeadline / 2, time.Second). use a slightly shorter timeout to account for the extra delay.
+// note on go leader election module it is calculated as max(renewDeadline / 2, time.Second). use a slightly shorter timeout to account for the extra delay.
 config.CORE_LEASE_REQUEST_TIMEOUT_MS = 5000;
 
 //////////////////////////////

--- a/src/test/unit_tests/util_functions_tests/test_leader_election.js
+++ b/src/test/unit_tests/util_functions_tests/test_leader_election.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
+/* eslint max-lines-per-function: ['warn', 500] */
 'use strict';
 
 const mocha = require('mocha');
@@ -25,6 +26,18 @@ function fresh_lease(holder = 'pod-a') {
             leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
         },
     };
+}
+
+/**
+ * Resolves when the given signal aborts, or immediately if already aborted.
+ * @param {AbortSignal} signal
+ * @returns {Promise<unknown>}
+ */
+function wait_for_abort(signal) {
+    if (signal.aborted) return Promise.resolve(signal.reason);
+    return new Promise(resolve => {
+        signal.addEventListener('abort', () => resolve(signal.reason), { once: true });
+    });
 }
 
 mocha.describe('leader_election', function() {
@@ -154,6 +167,64 @@ mocha.describe('leader_election', function() {
         assert.strictEqual(lease_utils.is_lease_takeable({ spec: { holderIdentity: '' } }, 'pod-b'), true);
     });
 
+    mocha.describe('combine_abort_signals', function() {
+
+        mocha.it('without abort_signal aborts on timeout', async function() {
+            const { signal, release_signal } = lease_utils.combine_abort_signals(30);
+            try {
+                const reason = await wait_for_abort(signal);
+                assert.strictEqual(reason.name, 'TimeoutError');
+            } finally {
+                release_signal();
+            }
+        });
+
+        mocha.it('with already-aborted parent aborts immediately', function() {
+            const parent = new AbortController();
+            parent.abort('renew_deadline');
+            const { signal, release_signal } = lease_utils.combine_abort_signals(5000, parent.signal);
+            try {
+                assert.strictEqual(signal.aborted, true);
+                assert.strictEqual(signal.reason, 'renew_deadline');
+            } finally {
+                release_signal();
+            }
+        });
+
+        mocha.it('aborts when parent fires', async function() {
+            const parent = new AbortController();
+            const { signal, release_signal } = lease_utils.combine_abort_signals(5000, parent.signal);
+            try {
+                setTimeout(() => parent.abort('deadline'), 10);
+                const reason = await wait_for_abort(signal);
+                assert.strictEqual(reason, 'deadline');
+            } finally {
+                release_signal();
+            }
+        });
+
+        mocha.it('aborts on per-request timeout when parent stays live', async function() {
+            const parent = new AbortController();
+            const { signal, release_signal } = lease_utils.combine_abort_signals(30, parent.signal);
+            try {
+                const reason = await wait_for_abort(signal);
+                assert.strictEqual(reason.name, 'TimeoutError');
+                assert.strictEqual(parent.signal.aborted, false);
+            } finally {
+                release_signal();
+            }
+        });
+
+        mocha.it('release_signal unwires parent listener', async function() {
+            const parent = new AbortController();
+            const { signal, release_signal } = lease_utils.combine_abort_signals(5000, parent.signal);
+            release_signal();
+            parent.abort('late');
+            await new Promise(resolve => setTimeout(resolve, 20));
+            assert.strictEqual(signal.aborted, false);
+        });
+    });
+
     mocha.describe('release_lease', function() {
         /** @type {sinon.SinonSandbox} */
         let sandbox;
@@ -220,13 +291,20 @@ mocha.describe('leader_election', function() {
 
         mocha.it('exits early when _stop_requested is set before retrying', async function() {
             const client = make_test_client();
-            const update_stub = sandbox.stub(client, 'update_lease');
-            sandbox.stub(client, 'read_lease_state').callsFake(async function() {
-                client._stop_requested = true;
-                return { lease: fresh_lease('pod-a'), can_take: false };
-            });
-            await client.acquire_lease();
-            assert.strictEqual(update_stub.called, false);
+            const orig_retry = config.CORE_LEASE_ACQUIRE_RETRY_MS;
+            config.CORE_LEASE_ACQUIRE_RETRY_MS = 10;
+            try {
+                // Return can_take: false for another holder — a case that would normally sleep and retry.
+                // Setting _stop_requested inside the stub proves the flag prevents the retry.
+                const read_stub = sandbox.stub(client, 'read_lease_state').callsFake(async function() {
+                    client._stop_requested = true;
+                    return { lease: fresh_lease('pod-b'), can_take: false };
+                });
+                await client.acquire_lease();
+                assert.strictEqual(read_stub.callCount, 1);
+            } finally {
+                config.CORE_LEASE_ACQUIRE_RETRY_MS = orig_retry;
+            }
         });
     });
 
@@ -290,7 +368,6 @@ mocha.describe('leader_election', function() {
 
         mocha.it('steps down when another holder is observed', async function() {
             const client = make_test_client();
-            client._lease_duration_ms = 60000;
             sandbox.stub(client, 'read_lease_state').resolves({
                 lease: fresh_lease('pod-b'),
                 can_take: false,
@@ -303,14 +380,11 @@ mocha.describe('leader_election', function() {
 
         mocha.it('steps down when renew deadline is exceeded without a successful PUT', async function() {
             const client = make_test_client();
-            // deadline = lease_duration - error_sleep - request_timeout - margin = 100 - 10 - 10 - 10 = 70ms
-            client._lease_duration_ms = 100;
+            // Deadline fires after 70ms; each failed renew sleeps for 10ms giving several retries before step-down.
+            const orig_deadline = config.LEASE_RENEW_DEADLINE_MS;
             const orig_error_sleep = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
-            const orig_request_timeout = config.CORE_LEASE_REQUEST_TIMEOUT_MS;
-            const orig_margin = config.LEASE_RENEW_DEADLINE_MARGIN_MS;
+            config.LEASE_RENEW_DEADLINE_MS = 70;
             config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 10;
-            config.CORE_LEASE_REQUEST_TIMEOUT_MS = 10;
-            config.LEASE_RENEW_DEADLINE_MARGIN_MS = 10;
             try {
                 sandbox.stub(client, 'read_lease_state').resolves({
                     lease: fresh_lease('pod-a'),
@@ -322,22 +396,18 @@ mocha.describe('leader_election', function() {
                 await client.renew_lease_loop();
                 assert.strictEqual(on_lost.calledOnce, true);
             } finally {
+                config.LEASE_RENEW_DEADLINE_MS = orig_deadline;
                 config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = orig_error_sleep;
-                config.CORE_LEASE_REQUEST_TIMEOUT_MS = orig_request_timeout;
-                config.LEASE_RENEW_DEADLINE_MARGIN_MS = orig_margin;
             }
         });
 
         mocha.it('treats thrown error (e.g. request timeout) as transient and steps down at deadline', async function() {
             const client = make_test_client();
-            // deadline = lease_duration - error_sleep - request_timeout - margin = 100 - 10 - 10 - 10 = 70ms
-            client._lease_duration_ms = 100;
+            // Deadline fires after 70ms; each thrown error sleeps for 10ms giving several retries before step-down.
+            const orig_deadline = config.LEASE_RENEW_DEADLINE_MS;
             const orig_error_sleep = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
-            const orig_request_timeout = config.CORE_LEASE_REQUEST_TIMEOUT_MS;
-            const orig_margin = config.LEASE_RENEW_DEADLINE_MARGIN_MS;
+            config.LEASE_RENEW_DEADLINE_MS = 70;
             config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 10;
-            config.CORE_LEASE_REQUEST_TIMEOUT_MS = 10;
-            config.LEASE_RENEW_DEADLINE_MARGIN_MS = 10;
             try {
                 const abort_err = new DOMException('The operation was aborted', 'AbortError');
                 sandbox.stub(client, 'read_lease_state').rejects(abort_err);
@@ -346,15 +416,13 @@ mocha.describe('leader_election', function() {
                 await client.renew_lease_loop();
                 assert.strictEqual(on_lost.calledOnce, true);
             } finally {
+                config.LEASE_RENEW_DEADLINE_MS = orig_deadline;
                 config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = orig_error_sleep;
-                config.CORE_LEASE_REQUEST_TIMEOUT_MS = orig_request_timeout;
-                config.LEASE_RENEW_DEADLINE_MARGIN_MS = orig_margin;
             }
         });
 
         mocha.it('stop_running exits without emitting EVENTS.LEADERSHIP_LOST', async function() {
             const client = make_test_client();
-            client._lease_duration_ms = 60000; // large duration so deadline is not immediately exceeded
             const orig_retry = config.CORE_LEASE_ACQUIRE_RETRY_MS;
             config.CORE_LEASE_ACQUIRE_RETRY_MS = 5000;
             try {
@@ -371,6 +439,87 @@ mocha.describe('leader_election', function() {
                 assert.strictEqual(on_lost.called, false);
             } finally {
                 config.CORE_LEASE_ACQUIRE_RETRY_MS = orig_retry;
+            }
+        });
+
+        mocha.it('steps down immediately when signal is already aborted before loop starts', async function() {
+            const client = make_test_client();
+            client._renew_deadline_abort.abort('renew_deadline');
+            const read_stub = sandbox.stub(client, 'read_lease_state');
+            const on_lost = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+            await client.renew_lease_loop();
+            assert.strictEqual(on_lost.calledOnce, true);
+            assert.strictEqual(read_stub.called, false);
+        });
+
+        mocha.it('steps down when signal fires during GET (AbortError thrown from _request)', async function() {
+            const client = make_test_client();
+            // Stub at _request level so read_lease_state → read_lease runs for real with the signal.
+            // First call (GET) aborts the controller and throws AbortError — caught as transient;
+            // signal is then aborted so loop skips sleep and steps down at top of next iteration.
+            let call_count = 0;
+            sandbox.stub(client, '_request').callsFake(async function() {
+                call_count += 1;
+                if (call_count === 1) {
+                    client._renew_deadline_abort.abort('renew_deadline');
+                    throw new DOMException('The operation was aborted', 'AbortError');
+                }
+                // should never reach a second call
+                throw new Error('unexpected _request call');
+            });
+            const on_lost = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+            await client.renew_lease_loop();
+            assert.strictEqual(on_lost.calledOnce, true);
+            assert.strictEqual(call_count, 1); // PUT was never attempted
+        });
+
+        mocha.it('steps down when signal fires during PUT (AbortError thrown from _request)', async function() {
+            const client = make_test_client();
+            // First call (GET) succeeds; second call (PUT) aborts the controller and throws AbortError —
+            // caught as transient; signal is then aborted so loop skips sleep and steps down.
+            let call_count = 0;
+            sandbox.stub(client, '_request').callsFake(async function(method) {
+                call_count += 1;
+                if (method === 'GET') {
+                    return { status_code: 200, body: fresh_lease('pod-a') };
+                }
+                // PUT
+                client._renew_deadline_abort.abort('renew_deadline');
+                throw new DOMException('The operation was aborted', 'AbortError');
+            });
+            const on_lost = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+            await client.renew_lease_loop();
+            assert.strictEqual(on_lost.calledOnce, true);
+            assert.strictEqual(call_count, 2); // GET + PUT both attempted
+        });
+
+        mocha.it('steps down when signal fires during sleep', async function() {
+            const client = make_test_client();
+            // Deadline fires after 30ms; error sleep is 50ms so the deadline timer fires mid-sleep.
+            const orig_deadline = config.LEASE_RENEW_DEADLINE_MS;
+            const orig_error_sleep = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
+            config.LEASE_RENEW_DEADLINE_MS = 30;
+            config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 50; // sleep longer than the deadline
+            try {
+                sandbox.stub(client, 'read_lease_state').resolves({
+                    lease: fresh_lease('pod-a'),
+                    can_take: true,
+                });
+                sandbox.stub(client, 'update_lease').resolves(500); // keep failing to trigger error sleep
+                const on_lost = sandbox.stub();
+                client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+                const start = Date.now();
+                await client.renew_lease_loop();
+                const elapsed = Date.now() - start;
+                assert.strictEqual(on_lost.calledOnce, true);
+                // should have exited well before the full error sleep duration
+                assert.ok(elapsed < 1000, `expected early exit but took ${elapsed}ms`);
+            } finally {
+                config.LEASE_RENEW_DEADLINE_MS = orig_deadline;
+                config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = orig_error_sleep;
             }
         });
     });

--- a/src/test/unit_tests/util_functions_tests/test_leader_election.js
+++ b/src/test/unit_tests/util_functions_tests/test_leader_election.js
@@ -1,0 +1,377 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const mocha = require('mocha');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const config = require('../../../../config');
+const LEASE_UTILS = require.resolve('../../../util/leader_election');
+
+const TEST_LEASE_DURATION_SECONDS = 60;
+
+/** @type {typeof import('../../../util/leader_election')} */
+let lease_utils;
+
+function make_test_client() {
+    return new lease_utils.LeaderElector({ lease_name: 'noobaa-core', holder: 'pod-a' });
+}
+
+function fresh_lease(holder = 'pod-a') {
+    return {
+        spec: {
+            holderIdentity: holder,
+            renewTime: new Date().toISOString(),
+            leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+        },
+    };
+}
+
+mocha.describe('leader_election', function() {
+
+    let _k8s_host;
+    let _k8s_port;
+
+    mocha.before(function() {
+        this.timeout(15000); // eslint-disable-line no-invalid-this
+        _k8s_host = process.env.KUBERNETES_SERVICE_HOST;
+        _k8s_port = process.env.KUBERNETES_SERVICE_PORT;
+        process.env.KUBERNETES_SERVICE_HOST ||= '127.0.0.1';
+        process.env.KUBERNETES_SERVICE_PORT ||= '443';
+        delete require.cache[LEASE_UTILS];
+        lease_utils = require(LEASE_UTILS);
+    });
+
+    mocha.after(function() {
+        if (_k8s_host === undefined) delete process.env.KUBERNETES_SERVICE_HOST;
+        else process.env.KUBERNETES_SERVICE_HOST = _k8s_host;
+        if (_k8s_port === undefined) delete process.env.KUBERNETES_SERVICE_PORT;
+        else process.env.KUBERNETES_SERVICE_PORT = _k8s_port;
+        delete require.cache[LEASE_UTILS];
+    });
+
+    mocha.it('parse_lease_time returns 0 for empty input', function() {
+        assert.strictEqual(lease_utils.parse_lease_time(undefined), 0);
+        assert.strictEqual(lease_utils.parse_lease_time(''), 0);
+    });
+
+    mocha.it('format_lease_time pads milliseconds to microseconds for K8s MicroTime', function() {
+        const d = new Date('2026-06-02T11:53:47.665Z');
+        assert.strictEqual(lease_utils.format_lease_time(d), '2026-06-02T11:53:47.665000Z');
+    });
+
+    mocha.it('format_lease_time pads zero milliseconds', function() {
+        const d = new Date('2026-06-02T11:53:47.000Z');
+        assert.strictEqual(lease_utils.format_lease_time(d), '2026-06-02T11:53:47.000000Z');
+    });
+
+    mocha.it('is_lease_expired when renewTime is missing', function() {
+        assert.strictEqual(lease_utils.is_lease_expired({ spec: { holderIdentity: 'pod-a' } }), true);
+    });
+
+    mocha.it('is_lease_expired when renew window elapsed', function() {
+        const old = new Date(Date.now() - (120 * 1000)).toISOString();
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: old,
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        assert.strictEqual(lease_utils.is_lease_expired(lease), true);
+    });
+
+    mocha.it('is_lease_expired false when renew is fresh', function() {
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: new Date().toISOString(),
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        assert.strictEqual(lease_utils.is_lease_expired(lease), false);
+    });
+
+    mocha.it('is_lease_takeable when empty holder', function() {
+        assert.strictEqual(lease_utils.is_lease_takeable({ spec: {} }, 'pod-a'), true);
+    });
+
+    mocha.it('is_lease_takeable when same holder', function() {
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: new Date().toISOString(),
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        assert.strictEqual(lease_utils.is_lease_takeable(lease, 'pod-a'), true);
+    });
+
+    mocha.it('cannot take lease held by another fresh holder', function() {
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: new Date().toISOString(),
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        assert.strictEqual(lease_utils.is_lease_takeable(lease, 'pod-b'), false);
+    });
+
+    mocha.it('can take lease when other holder expired', function() {
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: new Date(Date.now() - (120 * 1000)).toISOString(),
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        assert.strictEqual(lease_utils.is_lease_takeable(lease, 'pod-b'), true);
+    });
+
+    mocha.it('cannot take lease when renewTime is old but observed_change_ms is recent (clock skew protection)', function() {
+        // renewTime looks expired but we locally observed the lease change just now,
+        // so the other pod's clock is skewed behind ours — we must not steal the lease.
+        const lease = {
+            spec: {
+                holderIdentity: 'pod-a',
+                renewTime: new Date(Date.now() - (120 * 1000)).toISOString(),
+                leaseDurationSeconds: TEST_LEASE_DURATION_SECONDS,
+            },
+        };
+        const observed_change_ms = Date.now(); // just observed it locally
+        assert.strictEqual(lease_utils.is_lease_takeable(lease, 'pod-b', observed_change_ms), false);
+    });
+
+    mocha.it('is_lease_held_by matches holder identity', function() {
+        const lease = { spec: { holderIdentity: 'pod-a' } };
+        assert.strictEqual(lease_utils.is_lease_held_by(lease, 'pod-a'), true);
+        assert.strictEqual(lease_utils.is_lease_held_by(lease, 'pod-b'), false);
+    });
+
+    mocha.it('is_lease_held_by false when holder was cleared', function() {
+        assert.strictEqual(lease_utils.is_lease_held_by({ spec: { holderIdentity: '' } }, 'pod-a'), false);
+        assert.strictEqual(lease_utils.is_lease_takeable({ spec: { holderIdentity: '' } }, 'pod-b'), true);
+    });
+
+    mocha.describe('release_lease', function() {
+        /** @type {sinon.SinonSandbox} */
+        let sandbox;
+
+        mocha.beforeEach(function() {
+            sandbox = sinon.createSandbox();
+        });
+
+        mocha.afterEach(function() {
+            sandbox.restore();
+        });
+
+        mocha.it('skips release when held by another pod', async function() {
+            const client = make_test_client();
+            sandbox.stub(client, 'read_lease').resolves(fresh_lease('pod-b'));
+            const put_stub = sandbox.stub(client, '_put_release_lease');
+            await client.release_lease();
+            assert.strictEqual(put_stub.called, false);
+        });
+
+        mocha.it('logs warning on non-200 status without retrying', async function() {
+            const client = make_test_client();
+            sandbox.stub(client, 'read_lease').resolves(fresh_lease('pod-a'));
+            const put_stub = sandbox.stub(client, '_put_release_lease').resolves(409);
+            await client.release_lease();
+            assert.strictEqual(put_stub.callCount, 1);
+        });
+
+        mocha.it('handles transient errors gracefully without throwing', async function() {
+            const client = make_test_client();
+            sandbox.stub(client, 'read_lease').rejects(new Error('network error'));
+            await assert.doesNotReject(() => client.release_lease());
+        });
+    });
+
+    mocha.describe('acquire_lease', function() {
+        /** @type {sinon.SinonSandbox} */
+        let sandbox;
+
+        mocha.beforeEach(function() {
+            sandbox = sinon.createSandbox();
+        });
+
+        mocha.afterEach(function() {
+            sandbox.restore();
+        });
+
+        mocha.it('retries on transient network error and eventually acquires', async function() {
+            const client = make_test_client();
+            const orig_retry = config.CORE_LEASE_ACQUIRE_RETRY_MS;
+            config.CORE_LEASE_ACQUIRE_RETRY_MS = 10;
+            try {
+                const abort_err = new DOMException('The operation was aborted', 'AbortError');
+                const read_stub = sandbox.stub(client, 'read_lease_state');
+                read_stub.onFirstCall().rejects(abort_err);
+                read_stub.onSecondCall().resolves({ lease: fresh_lease('pod-a'), can_take: true });
+                sandbox.stub(client, 'update_lease').resolves(200);
+                await client.acquire_lease();
+                assert.strictEqual(read_stub.callCount, 2);
+            } finally {
+                config.CORE_LEASE_ACQUIRE_RETRY_MS = orig_retry;
+            }
+        });
+
+        mocha.it('exits early when _stop_requested is set before retrying', async function() {
+            const client = make_test_client();
+            const update_stub = sandbox.stub(client, 'update_lease');
+            sandbox.stub(client, 'read_lease_state').callsFake(async function() {
+                client._stop_requested = true;
+                return { lease: fresh_lease('pod-a'), can_take: false };
+            });
+            await client.acquire_lease();
+            assert.strictEqual(update_stub.called, false);
+        });
+    });
+
+    mocha.describe('start and stop', function() {
+        /** @type {sinon.SinonSandbox} */
+        let sandbox;
+
+        mocha.beforeEach(function() {
+            sandbox = sinon.createSandbox();
+        });
+
+        mocha.afterEach(function() {
+            sandbox.restore();
+        });
+
+        mocha.it('start emits EVENTS.LEADERSHIP_ACQUIRED after acquiring the lease', async function() {
+            const client = make_test_client();
+            sandbox.stub(client, 'acquire_lease').resolves();
+            sandbox.stub(client, 'renew_lease_loop').resolves();
+            const on_acquired = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_ACQUIRED, on_acquired);
+            await client.start();
+            assert.strictEqual(on_acquired.calledOnce, true);
+        });
+
+        mocha.it('stop calls stop_running then release_lease', async function() {
+            const client = make_test_client();
+            const stop_running_stub = sandbox.stub(client, 'stop_running').resolves();
+            const release_stub = sandbox.stub(client, 'release_lease').resolves();
+            await client.stop();
+            assert.strictEqual(stop_running_stub.calledOnce, true);
+            assert.strictEqual(release_stub.calledOnce, true);
+            assert.ok(stop_running_stub.calledBefore(release_stub));
+        });
+
+        mocha.it('stop() during acquire_lease prevents LEADERSHIP_ACQUIRED and renew loop', async function() {
+            const client = make_test_client();
+            sandbox.stub(client, 'acquire_lease').callsFake(async function() {
+                client._stop_requested = true;
+            });
+            const renew_stub = sandbox.stub(client, 'renew_lease_loop').resolves();
+            const on_acquired = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_ACQUIRED, on_acquired);
+            await client.start();
+            assert.strictEqual(on_acquired.called, false);
+            assert.strictEqual(renew_stub.called, false);
+        });
+    });
+
+    mocha.describe('renew_lease_loop', function() {
+        /** @type {sinon.SinonSandbox} */
+        let sandbox;
+
+        mocha.beforeEach(function() {
+            sandbox = sinon.createSandbox();
+        });
+
+        mocha.afterEach(function() {
+            sandbox.restore();
+        });
+
+        mocha.it('steps down when another holder is observed', async function() {
+            const client = make_test_client();
+            client._lease_duration_ms = 60000;
+            sandbox.stub(client, 'read_lease_state').resolves({
+                lease: fresh_lease('pod-b'),
+                can_take: false,
+            });
+            const on_lost = sandbox.stub();
+            client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+            await client.renew_lease_loop();
+            assert.strictEqual(on_lost.calledOnce, true);
+        });
+
+        mocha.it('steps down when renew deadline is exceeded without a successful PUT', async function() {
+            const client = make_test_client();
+            // deadline = lease_duration - error_sleep - request_timeout - margin = 100 - 10 - 10 - 10 = 70ms
+            client._lease_duration_ms = 100;
+            const orig_error_sleep = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
+            const orig_request_timeout = config.CORE_LEASE_REQUEST_TIMEOUT_MS;
+            const orig_margin = config.LEASE_RENEW_DEADLINE_MARGIN_MS;
+            config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 10;
+            config.CORE_LEASE_REQUEST_TIMEOUT_MS = 10;
+            config.LEASE_RENEW_DEADLINE_MARGIN_MS = 10;
+            try {
+                sandbox.stub(client, 'read_lease_state').resolves({
+                    lease: fresh_lease('pod-a'),
+                    can_take: true,
+                });
+                sandbox.stub(client, 'update_lease').resolves(500);
+                const on_lost = sandbox.stub();
+                client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+                await client.renew_lease_loop();
+                assert.strictEqual(on_lost.calledOnce, true);
+            } finally {
+                config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = orig_error_sleep;
+                config.CORE_LEASE_REQUEST_TIMEOUT_MS = orig_request_timeout;
+                config.LEASE_RENEW_DEADLINE_MARGIN_MS = orig_margin;
+            }
+        });
+
+        mocha.it('treats thrown error (e.g. request timeout) as transient and steps down at deadline', async function() {
+            const client = make_test_client();
+            // deadline = lease_duration - error_sleep - request_timeout - margin = 100 - 10 - 10 - 10 = 70ms
+            client._lease_duration_ms = 100;
+            const orig_error_sleep = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
+            const orig_request_timeout = config.CORE_LEASE_REQUEST_TIMEOUT_MS;
+            const orig_margin = config.LEASE_RENEW_DEADLINE_MARGIN_MS;
+            config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = 10;
+            config.CORE_LEASE_REQUEST_TIMEOUT_MS = 10;
+            config.LEASE_RENEW_DEADLINE_MARGIN_MS = 10;
+            try {
+                const abort_err = new DOMException('The operation was aborted', 'AbortError');
+                sandbox.stub(client, 'read_lease_state').rejects(abort_err);
+                const on_lost = sandbox.stub();
+                client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+                await client.renew_lease_loop();
+                assert.strictEqual(on_lost.calledOnce, true);
+            } finally {
+                config.CORE_LEASE_RENEW_ERROR_SLEEP_MS = orig_error_sleep;
+                config.CORE_LEASE_REQUEST_TIMEOUT_MS = orig_request_timeout;
+                config.LEASE_RENEW_DEADLINE_MARGIN_MS = orig_margin;
+            }
+        });
+
+        mocha.it('stop_running exits without emitting EVENTS.LEADERSHIP_LOST', async function() {
+            const client = make_test_client();
+            client._lease_duration_ms = 60000; // large duration so deadline is not immediately exceeded
+            const orig_retry = config.CORE_LEASE_ACQUIRE_RETRY_MS;
+            config.CORE_LEASE_ACQUIRE_RETRY_MS = 5000;
+            try {
+                sandbox.stub(client, 'read_lease_state').resolves({
+                    lease: fresh_lease('pod-a'),
+                    can_take: true,
+                });
+                sandbox.stub(client, 'update_lease').resolves(200);
+                const on_lost = sandbox.stub();
+                client.on(lease_utils.EVENTS.LEADERSHIP_LOST, on_lost);
+                const loop_promise = client.renew_lease_loop();
+                await client.stop_running();
+                await loop_promise;
+                assert.strictEqual(on_lost.called, false);
+            } finally {
+                config.CORE_LEASE_ACQUIRE_RETRY_MS = orig_retry;
+            }
+        });
+    });
+});

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -28,6 +28,7 @@ require('../../unit_tests/util_functions_tests/test_http_utils');
 require('../../unit_tests/util_functions_tests/test_v8_optimizations');
 require('../../unit_tests/util_functions_tests/test_ssl_utils');
 require('../../unit_tests/util_functions_tests/test_zip_utils');
+require('../../unit_tests/util_functions_tests/test_leader_election');
 require('../../unit_tests/util_functions_tests/test_wait_queue');
 require('../../unit_tests/util_functions_tests/test_kmeans');
 require('../../unit_tests/util_functions_tests/test_sensitive_wrapper');

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -38,6 +38,7 @@ const CONTENT_TYPE_APP_FORM_URLENCODED = 'application/x-www-form-urlencoded';
 
 const INTERNAL_CA_CERTS = process.env.INTERNAL_CA_CERTS || '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt';
 const EXTERNAL_CA_CERTS = process.env.EXTERNAL_CA_CERTS || '/etc/ocp-injected-ca-bundle/ca-bundle.crt';
+const KUBE_CA_CERTS = process.env.KUBE_CA_CERTS || '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
 
 const { HTTP_PROXY, HTTPS_PROXY, NO_PROXY } = process.env;
 const http_agent = new http.Agent({ keepAlive: true });
@@ -46,6 +47,7 @@ const https_agent = new https.Agent({
     ca: (ca => (ca.length ? ca : undefined))([
         fs_utils.try_read_file_sync(INTERNAL_CA_CERTS),
         fs_utils.try_read_file_sync(EXTERNAL_CA_CERTS),
+        fs_utils.try_read_file_sync(KUBE_CA_CERTS),
     ].filter(Boolean))
 });
 const unsecured_https_agent = new https.Agent({ rejectUnauthorized: false, keepAlive: true });

--- a/src/util/leader_election.js
+++ b/src/util/leader_election.js
@@ -1,0 +1,495 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+const fs = require('fs');
+const { EventEmitter } = require('events');
+const dbg = require('./debug_module')(__filename);
+const config = require('../../config');
+const { make_https_request } = require('./http_utils');
+const { read_stream_join } = require('./buffer_utils');
+const { randomUUID } = require('crypto');
+
+const LEASE_API = 'coordination.k8s.io/v1';
+
+const {
+    KUBERNETES_SERVICE_HOST,
+    KUBERNETES_SERVICE_PORT,
+} = process.env;
+
+/**
+ * Named events emitted by LeaderElector.
+ */
+const EVENTS = {
+    LEADERSHIP_ACQUIRED: 'leadership_acquired',
+    LEADERSHIP_LOST: 'leadership_lost',
+};
+
+/**
+ * @param {string|undefined} iso_string
+ * @returns {number}
+ */
+function parse_lease_time(iso_string) {
+    if (!iso_string) return 0;
+    const ms = Date.parse(iso_string);
+    return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Formats a Date for Kubernetes Lease spec acquireTime/renewTime (metav1.MicroTime).
+ * JavaScript toISOString() uses millisecond precision, the API expects microseconds.
+ * @param {Date} [date]
+ * @returns {string}
+ */
+function format_lease_time(date = new Date()) {
+    return date.toISOString().replace(/\.(\d{3})Z$/, (_, ms) => `.${ms}000Z`);
+}
+
+/**
+ * Returns true if the lease record has no valid holder (expired or empty renew time).
+ * @param {{ spec?: { holderIdentity?: string, renewTime?: string, leaseDurationSeconds?: number } }} lease
+ * @param {number} [observed_change_ms] local clock time when we last saw the lease record change.
+ *   Falls back to spec.renewTime when not provided.
+ * @returns {boolean}
+ */
+function is_lease_expired(lease, observed_change_ms = 0) {
+    const spec = lease?.spec || {};
+    if (!spec.leaseDurationSeconds) return true;
+    const reference_ms = observed_change_ms || parse_lease_time(spec.renewTime);
+    if (!reference_ms) return true;
+    return Date.now() >= reference_ms + (spec.leaseDurationSeconds * 1000);
+}
+
+/**
+ * Returns true if the given holder may acquire or renew this lease according to spec.
+ * @param {{ spec?: { holderIdentity?: string, renewTime?: string, leaseDurationSeconds?: number } }} lease
+ * @param {string} holder
+ * @param {number} [observed_change_ms] local clock time when we last saw the lease record change (clock-skew-safe)
+ * @returns {boolean}
+ */
+function is_lease_takeable(lease, holder, observed_change_ms = 0) {
+    const spec = lease?.spec || {};
+    const current_holder = spec.holderIdentity;
+    if (!current_holder) return true;
+    if (current_holder === holder) return true;
+    return is_lease_expired(lease, observed_change_ms);
+}
+
+/**
+ * Returns true if the lease is currently held by the given holder identity.
+ * @param {{ spec?: { holderIdentity?: string } }} lease
+ * @param {string} holder
+ * @returns {boolean}
+ */
+function is_lease_held_by(lease, holder) {
+    return lease?.spec?.holderIdentity === holder;
+}
+
+/**
+ * Leader elector backed by a Kubernetes coordination.k8s.io/v1 Lease.
+ * Emits EVENTS.LEADERSHIP_ACQUIRED when the lease is acquired and
+ * EVENTS.LEADERSHIP_LOST when the lease is lost or the renew deadline is exceeded.
+ * LeaderElector instances configured with the same lease name form a coordination group
+ * in which one, and only one, instance can be considered the leader at a time.
+ */
+class LeaderElector extends EventEmitter {
+    /**
+     * @param {{ lease_name: string, holder: string }} options
+     */
+    constructor({ lease_name, holder }) {
+        super();
+        if (!KUBERNETES_SERVICE_HOST || !KUBERNETES_SERVICE_PORT) {
+            throw new Error('LeaderElector requires in-cluster Kubernetes environment variables');
+        }
+        this._lease_name = lease_name;
+        this._holder = holder;
+        this._service_host = KUBERNETES_SERVICE_HOST;
+        this._service_port = KUBERNETES_SERVICE_PORT;
+        this._initialized = false;
+        this._stop_requested = false;
+        /** @type {number} lease duration in ms, set from the live lease spec at acquire time */
+        this._lease_duration_ms = 0;
+        /** @type {string|null} last resourceVersion we observed from the API */
+        this._observed_resource_version = null;
+        /** @type {number} local clock ms when we last saw the lease record change (clock-skew protection) */
+        this._observed_change_ms = 0;
+        /** @type {Promise<void>|null} */
+        this._running_promise = null;
+        /** @type {NodeJS.Timeout|null} */
+        this._sleep_timer = null;
+        /** @type {(() => void)|null} */
+        this._wake_sleep = null;
+    }
+
+    async _init() {
+        if (this._initialized) return;
+        const token_buf = await fs.promises.readFile(config.KUBE_SA_TOKEN_FILE);
+        this._sa_token = token_buf.toString('utf8').trim();
+        const ns_buf = await fs.promises.readFile(config.KUBE_NAMESPACE_FILE);
+        this._namespace = ns_buf.toString('utf8').trim();
+        this._initialized = true;
+    }
+
+    _lease_path() {
+        return `/apis/${LEASE_API}/namespaces/${this._namespace}/leases/${this._lease_name}`;
+    }
+
+    /**
+     * @param {string} method
+     * @param {object} [body]
+     * @returns {Promise<{ status_code: number, body: object }>}
+     */
+    async _request(method, body) {
+        await this._init();
+        const response = await make_https_request({
+            method,
+            hostname: this._service_host,
+            port: this._service_port,
+            path: this._lease_path(),
+            signal: AbortSignal.timeout(config.CORE_LEASE_REQUEST_TIMEOUT_MS),
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                Authorization: `Bearer ${this._sa_token}`,
+            },
+        }, body && JSON.stringify(body), 'utf8');
+        const buffer = await read_stream_join(response);
+        const res_body = buffer.length ? JSON.parse(buffer.toString('utf8')) : {};
+        return { status_code: response.statusCode, body: res_body };
+    }
+
+    /**
+     * GET the lease object from the API.
+     * @returns {Promise<object|null>}
+     */
+    async read_lease() {
+        const { status_code, body } = await this._request('GET');
+        if (status_code === 200) {
+            const resource_version = body.metadata?.resourceVersion;
+            if (resource_version !== this._observed_resource_version) {
+                // Pod clocks can differ, so takeover uses our local observation time as the expiry baseline.
+                // This may delay takeover slightly, but avoids taking the lease too early.
+                // Renew uses last_successful_renew_ms instead.
+                this._observed_resource_version = resource_version;
+                this._observed_change_ms = Date.now();
+            }
+            return body;
+        }
+        if (status_code === 404) return null;
+        throw new Error(`read lease failed status=${status_code} body=${JSON.stringify(body)}`);
+    }
+
+    /**
+     * GET the lease and evaluate whether this holder may take or renew it.
+     * @returns {Promise<{ lease: object|null, can_take: boolean }>}
+     */
+    async read_lease_state() {
+        const lease = await this.read_lease();
+        return {
+            lease,
+            can_take: Boolean(lease && is_lease_takeable(lease, this._holder, this._observed_change_ms)),
+        };
+    }
+
+    /**
+     * PUT Update the lease to take or renew it. Caller must pass the lease from read_lease_state.
+     * Uses metadata.resourceVersion for optimistic concurrency.
+     * @param {object} lease
+     * @param {boolean} is_acquire
+     * @returns {Promise<number>}
+     */
+    async update_lease(lease, is_acquire) {
+        const duration = lease.spec?.leaseDurationSeconds;
+        if (!duration) {
+            throw new Error(`lease ${this._lease_name} is missing spec.leaseDurationSeconds`);
+        }
+        const now = format_lease_time();
+        const updated = {
+            ...lease,
+            spec: {
+                ...lease.spec,
+                holderIdentity: this._holder,
+                leaseDurationSeconds: duration,
+                renewTime: now,
+                acquireTime: (is_acquire || !lease.spec?.acquireTime) ? now : lease.spec.acquireTime,
+            },
+        };
+        const { status_code, body } = await this._request('PUT', updated);
+        if (status_code !== 200) {
+            dbg.warn('lease PUT failed', this._lease_name, status_code, body);
+        }
+        return status_code;
+    }
+
+    /**
+     * Acquires the lease, emits EVENTS.LEADERSHIP_ACQUIRED, then starts the renew loop in the background.
+     * Emits EVENTS.LEADERSHIP_LOST if the lease is lost during the renew loop.
+     * Call stop() to release the lease and stop any active phase cleanly.
+     */
+    async start() {
+        this._stop_requested = false;
+        await this.acquire_lease();
+        if (this._stop_requested) return;
+        this.emit(EVENTS.LEADERSHIP_ACQUIRED);
+        this.renew_lease_loop().catch(err => {
+            dbg.error('renew_lease_loop unexpected error', this._lease_name, err.message);
+            this.emit(EVENTS.LEADERSHIP_LOST);
+        });
+    }
+
+    /**
+     * Stops any running acquire or renew phase and releases the lease.
+     */
+    async stop() {
+        await this.stop_running();
+        await this.release_lease();
+    }
+
+    /**
+     * Blocks until this holder owns the lease, or returns early if stop_running() is called.
+     */
+    async acquire_lease() {
+        /** @type {(value?: void) => void} */
+        let done;
+        this._running_promise = new Promise(resolve => { done = resolve; });
+        try {
+            dbg.log0('acquiring core lease', this._lease_name, 'holder', this._holder);
+            while (!this._stop_requested) {
+                try {
+                    const { lease, can_take } = await this.read_lease_state();
+                    if (!lease) {
+                        // Lease object not found — operator may not have created it yet, retry.
+                        dbg.warn('core lease not found, retrying', this._lease_name);
+                    } else if (can_take) {
+                        const status_code = await this.update_lease(lease, true);
+                        if (status_code === 200) {
+                            this._lease_duration_ms = (lease.spec?.leaseDurationSeconds ?? 0) * 1000;
+                            dbg.log0('acquired core lease', this._lease_name,
+                                'duration', this._lease_duration_ms, 'ms',
+                                'renew deadline', this._get_renew_deadline_ms(), 'ms');
+                            return;
+                        }
+                    }
+                } catch (err) {
+                    dbg.warn('acquire_lease transient error, retrying', this._lease_name, err.message);
+                }
+                if (this._stop_requested) return;
+                await this._interruptible_sleep(config.CORE_LEASE_ACQUIRE_RETRY_MS);
+            }
+        } finally {
+            done();
+            this._running_promise = null;
+        }
+    }
+
+    /**
+     * PUT the lease with an empty holderIdentity. Caller must pass the lease from read_lease.
+     * Uses metadata.resourceVersion for optimistic concurrency.
+     * @param {object} lease
+     * @returns {Promise<number>}
+     */
+    async _put_release_lease(lease) {
+        const updated = {
+            ...lease,
+            spec: {
+                ...lease.spec,
+                holderIdentity: '',
+            },
+        };
+        const { status_code, body } = await this._request('PUT', updated);
+        if (status_code !== 200) {
+            dbg.warn('lease release PUT failed', this._lease_name, status_code, body);
+        }
+        return status_code;
+    }
+
+    /**
+     * Clears this holder from the lease so another pod may acquire immediately.
+     * No-op when the lease is held by another identity or is already vacant.
+     */
+    async release_lease() {
+        dbg.log0('releasing core lease', this._lease_name, 'holder', this._holder);
+        try {
+            const lease = await this.read_lease();
+            if (!lease) {
+                dbg.warn('core lease not found during release', this._lease_name);
+                return;
+            }
+            if (!is_lease_held_by(lease, this._holder)) {
+                dbg.log0('core lease not held by us, skipping release',
+                    'holder', lease.spec?.holderIdentity, 'we are', this._holder);
+                return;
+            }
+            const status_code = await this._put_release_lease(lease);
+            if (status_code === 200) {
+                dbg.log0('released core lease', this._lease_name);
+            } else {
+                dbg.warn('core lease release failed, lease will expire naturally',
+                    this._lease_name, 'status', status_code);
+            }
+        } catch (err) {
+            dbg.warn('core lease release error, lease will expire naturally',
+                this._lease_name, err.message);
+        }
+    }
+
+    /**
+     * Signals any running acquire or renew phase to stop and waits for it to exit.
+     * Safe to call when nothing is running.
+     * @returns {Promise<void>}
+     */
+    async stop_running() {
+        this._stop_requested = true;
+        this._wake_interruptible_sleep();
+        if (!this._running_promise) return;
+        await this._running_promise;
+    }
+
+    /**
+     * @param {number} ms
+     * @returns {Promise<void>}
+     */
+    _interruptible_sleep(ms) {
+        return new Promise(resolve => {
+            this._wake_sleep = resolve;
+            this._sleep_timer = setTimeout(resolve, ms);
+        });
+    }
+
+    /**
+     * Ends an in-progress _interruptible_sleep.
+     */
+    _wake_interruptible_sleep() {
+        if (this._sleep_timer) {
+            clearTimeout(this._sleep_timer);
+            this._sleep_timer = null;
+        }
+        if (this._wake_sleep) {
+            this._wake_sleep();
+            this._wake_sleep = null;
+        }
+    }
+
+    /**
+     * Handles a 409 conflict after a PUT by re-reading the lease.
+     * Returns true (and emits EVENTS.LEADERSHIP_LOST) if we no longer hold the lease.
+     * @returns {Promise<boolean>}
+     */
+    async _handle_put_conflict() {
+        dbg.warn('lease PUT conflict, re-reading lease', this._lease_name);
+        const state = await this.read_lease_state();
+        if (!state.can_take) {
+            dbg.error('lost core lease after PUT conflict', this._lease_name, 'holder', state.lease?.spec?.holderIdentity, 'we are', this._holder);
+            this.emit(EVENTS.LEADERSHIP_LOST);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Renews until stop_running() is called or leadership is lost.
+     * Emits EVENTS.LEADERSHIP_LOST when the lease is taken by another pod or the renew deadline is exceeded.
+     */
+    async renew_lease_loop() {
+        this._stop_requested = false;
+        /** @type {(value?: void) => void} */
+        let loop_done;
+        this._running_promise = new Promise(resolve => {
+            loop_done = resolve;
+        });
+
+        try {
+            dbg.log0('starting core lease renew loop', this._lease_name);
+            let last_successful_renew_ms = Date.now();
+            while (!this._stop_requested) {
+                // lease is about to expire, step down
+                if (this._is_renew_deadline_exceeded(last_successful_renew_ms)) {
+                    dbg.error('renew deadline exceeded, leadership lost', this._lease_name);
+                    this.emit(EVENTS.LEADERSHIP_LOST);
+                    return;
+                }
+                let sleep_ms = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
+                try {
+                    const { lease, can_take } = await this.read_lease_state();
+                    if (!lease || !can_take) {
+                        // another pod acquired the lease or lease was deleted, step down
+                        dbg.error('lost core lease to another holder, leadership lost', this._lease_name, 'holder', lease?.spec?.holderIdentity, 'we are', this._holder);
+                        this.emit(EVENTS.LEADERSHIP_LOST);
+                        return;
+                    }
+                    const status_code = await this.update_lease(lease, false);
+                    if (status_code === 200) {
+                        last_successful_renew_ms = Date.now();
+                        sleep_ms = config.CORE_LEASE_ACQUIRE_RETRY_MS;
+                    } else if (status_code === 409) {
+                        if (await this._handle_put_conflict()) return;
+                    } else {
+                        dbg.warn('lease PUT failed, retrying', this._lease_name, status_code);
+                    }
+                } catch (err) {
+                    dbg.warn('renew_lease_loop transient error, retrying', this._lease_name, err.message);
+                }
+                if (this._stop_requested) break;
+                await this._interruptible_sleep(sleep_ms);
+            }
+        } finally {
+            this._wake_interruptible_sleep();
+            loop_done();
+            this._running_promise = null;
+        }
+    }
+
+    /**
+     * Computes the renew deadline from the live lease duration and timing constants.
+     * deadline = leaseDuration - CORE_LEASE_RENEW_ERROR_SLEEP_MS - CORE_LEASE_REQUEST_TIMEOUT_MS - LEASE_RENEW_DEADLINE_MARGIN_MS
+     * @returns {number} deadline in ms
+     */
+    _get_renew_deadline_ms() {
+        return this._lease_duration_ms -
+            config.CORE_LEASE_RENEW_ERROR_SLEEP_MS -
+            config.CORE_LEASE_REQUEST_TIMEOUT_MS -
+            config.LEASE_RENEW_DEADLINE_MARGIN_MS;
+    }
+
+    /**
+     * Returns true when too long has passed since the last successful renew.
+     * Step down in this case to avoid split brain if we can no longer refresh the lease.
+     * @param {number} last_successful_renew_ms
+     * @returns {boolean}
+     */
+    _is_renew_deadline_exceeded(last_successful_renew_ms) {
+        return Date.now() - last_successful_renew_ms > this._get_renew_deadline_ms();
+    }
+
+}
+
+/**
+ * @returns {boolean}
+ */
+function is_core_lease_enabled() {
+    return Boolean(process.env.NOOBAA_CORE_LEASE_NAME);
+}
+
+/**
+ * @returns {LeaderElector}
+ */
+function create_elector_from_env() {
+    const lease_name = process.env.NOOBAA_CORE_LEASE_NAME;
+    if (!lease_name) {
+        throw new Error('NOOBAA_CORE_LEASE_NAME is not set');
+    }
+    const holder = `${process.env.HOSTNAME}_${randomUUID()}`;
+    return new LeaderElector({ lease_name, holder });
+}
+
+// export classes and functions for use in other modules
+exports.EVENTS = EVENTS;
+exports.LeaderElector = LeaderElector;
+exports.create_elector_from_env = create_elector_from_env;
+exports.is_core_lease_enabled = is_core_lease_enabled;
+
+// export helper functions for testing only
+exports.parse_lease_time = parse_lease_time;
+exports.format_lease_time = format_lease_time;
+exports.is_lease_expired = is_lease_expired;
+exports.is_lease_takeable = is_lease_takeable;
+exports.is_lease_held_by = is_lease_held_by;

--- a/src/util/leader_election.js
+++ b/src/util/leader_election.js
@@ -24,6 +24,8 @@ const EVENTS = {
     LEADERSHIP_LOST: 'leadership_lost',
 };
 
+function noop() { /* noop */ }
+
 /**
  * @param {string|undefined} iso_string
  * @returns {number}
@@ -85,6 +87,48 @@ function is_lease_held_by(lease, holder) {
 }
 
 /**
+ * Combines a per-request timeout with an optional parent abort signal.
+ * there is a known memory-leak regression in Node 24.x for AbortSignal.any() (https://github.com/nodejs/node/issues/62363):
+ * this function is replaces AbortSignal.any() to avoid the memory leak.
+ * should be replaced with AbortSignal.any() when the memory leak is fixed. (post Node 24.16.0)
+ * @param {AbortSignal} [abort_signal] optional long-lived signal (e.g. renew deadline)
+ * @param {number} timeout_ms per-request timeout
+ * @returns {{ signal: AbortSignal, release_signal: () => void }}
+ */
+function combine_abort_signals(timeout_ms, abort_signal) {
+    if (!abort_signal) {
+        return { signal: AbortSignal.timeout(timeout_ms), release_signal: noop };
+    }
+
+    const controller = new AbortController();
+
+    let unwire_signal = noop;
+    if (abort_signal.aborted) {
+        dbg.log0('abort signal already aborted, aborting controller', abort_signal.reason);
+        controller.abort(abort_signal.reason);
+    } else {
+        // wire the abort signal to the controller
+        const forward_parent_abort = () => controller.abort(abort_signal.reason);
+        abort_signal.addEventListener('abort', forward_parent_abort, { once: true });
+        unwire_signal = () => abort_signal.removeEventListener('abort', forward_parent_abort);
+    }
+
+    // set a timeout to abort the controller if the request takes too longss
+    const timeout_id = setTimeout(
+        () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
+        timeout_ms
+    );
+
+    return {
+        signal: controller.signal,
+        release_signal() {
+            clearTimeout(timeout_id);
+            unwire_signal();
+        },
+    };
+}
+
+/**
  * Leader elector backed by a Kubernetes coordination.k8s.io/v1 Lease.
  * Emits EVENTS.LEADERSHIP_ACQUIRED when the lease is acquired and
  * EVENTS.LEADERSHIP_LOST when the lease is lost or the renew deadline is exceeded.
@@ -106,8 +150,6 @@ class LeaderElector extends EventEmitter {
         this._service_port = KUBERNETES_SERVICE_PORT;
         this._initialized = false;
         this._stop_requested = false;
-        /** @type {number} lease duration in ms, set from the live lease spec at acquire time */
-        this._lease_duration_ms = 0;
         /** @type {string|null} last resourceVersion we observed from the API */
         this._observed_resource_version = null;
         /** @type {number} local clock ms when we last saw the lease record change (clock-skew protection) */
@@ -118,6 +160,10 @@ class LeaderElector extends EventEmitter {
         this._sleep_timer = null;
         /** @type {(() => void)|null} */
         this._wake_sleep = null;
+        /** @type {AbortController} single controller reused across renew cycles; clearTimeout prevents abort from firing on success */
+        this._renew_deadline_abort = new AbortController();
+        /** @type {NodeJS.Timeout|null} */
+        this._renew_deadline = null;
     }
 
     async _init() {
@@ -136,33 +182,40 @@ class LeaderElector extends EventEmitter {
     /**
      * @param {string} method
      * @param {object} [body]
+     * @param {AbortSignal} [abort_signal] optional cycle-level deadline signal
      * @returns {Promise<{ status_code: number, body: object }>}
      */
-    async _request(method, body) {
+    async _request(method, body, abort_signal) {
         await this._init();
-        const response = await make_https_request({
-            method,
-            hostname: this._service_host,
-            port: this._service_port,
-            path: this._lease_path(),
-            signal: AbortSignal.timeout(config.CORE_LEASE_REQUEST_TIMEOUT_MS),
-            headers: {
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
-                Authorization: `Bearer ${this._sa_token}`,
-            },
-        }, body && JSON.stringify(body), 'utf8');
-        const buffer = await read_stream_join(response);
-        const res_body = buffer.length ? JSON.parse(buffer.toString('utf8')) : {};
-        return { status_code: response.statusCode, body: res_body };
+        const { signal, release_signal } = combine_abort_signals(config.CORE_LEASE_REQUEST_TIMEOUT_MS, abort_signal);
+        try {
+            const response = await make_https_request({
+                method,
+                hostname: this._service_host,
+                port: this._service_port,
+                path: this._lease_path(),
+                signal,
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: `Bearer ${this._sa_token}`,
+                },
+            }, body && JSON.stringify(body), 'utf8');
+            const buffer = await read_stream_join(response);
+            const res_body = buffer.length ? JSON.parse(buffer.toString('utf8')) : {};
+            return { status_code: response.statusCode, body: res_body };
+        } finally {
+            release_signal();
+        }
     }
 
     /**
      * GET the lease object from the API.
+     * @param {AbortSignal} [abort_signal]
      * @returns {Promise<object|null>}
      */
-    async read_lease() {
-        const { status_code, body } = await this._request('GET');
+    async read_lease(abort_signal) {
+        const { status_code, body } = await this._request('GET', undefined, abort_signal);
         if (status_code === 200) {
             const resource_version = body.metadata?.resourceVersion;
             if (resource_version !== this._observed_resource_version) {
@@ -180,10 +233,11 @@ class LeaderElector extends EventEmitter {
 
     /**
      * GET the lease and evaluate whether this holder may take or renew it.
+     * @param {AbortSignal} [abort_signal]
      * @returns {Promise<{ lease: object|null, can_take: boolean }>}
      */
-    async read_lease_state() {
-        const lease = await this.read_lease();
+    async read_lease_state(abort_signal) {
+        const lease = await this.read_lease(abort_signal);
         return {
             lease,
             can_take: Boolean(lease && is_lease_takeable(lease, this._holder, this._observed_change_ms)),
@@ -195,25 +249,22 @@ class LeaderElector extends EventEmitter {
      * Uses metadata.resourceVersion for optimistic concurrency.
      * @param {object} lease
      * @param {boolean} is_acquire
+     * @param {AbortSignal} [abort_signal]
      * @returns {Promise<number>}
      */
-    async update_lease(lease, is_acquire) {
-        const duration = lease.spec?.leaseDurationSeconds;
-        if (!duration) {
-            throw new Error(`lease ${this._lease_name} is missing spec.leaseDurationSeconds`);
-        }
+    async update_lease(lease, is_acquire, abort_signal) {
         const now = format_lease_time();
         const updated = {
             ...lease,
             spec: {
                 ...lease.spec,
                 holderIdentity: this._holder,
-                leaseDurationSeconds: duration,
+                leaseDurationSeconds: config.CORE_LEASE_DURATION_MS / 1000,
                 renewTime: now,
                 acquireTime: (is_acquire || !lease.spec?.acquireTime) ? now : lease.spec.acquireTime,
             },
         };
-        const { status_code, body } = await this._request('PUT', updated);
+        const { status_code, body } = await this._request('PUT', updated, abort_signal);
         if (status_code !== 200) {
             dbg.warn('lease PUT failed', this._lease_name, status_code, body);
         }
@@ -262,10 +313,9 @@ class LeaderElector extends EventEmitter {
                     } else if (can_take) {
                         const status_code = await this.update_lease(lease, true);
                         if (status_code === 200) {
-                            this._lease_duration_ms = (lease.spec?.leaseDurationSeconds ?? 0) * 1000;
                             dbg.log0('acquired core lease', this._lease_name,
-                                'duration', this._lease_duration_ms, 'ms',
-                                'renew deadline', this._get_renew_deadline_ms(), 'ms');
+                                'duration', config.CORE_LEASE_DURATION_MS, 'ms',
+                                'renew deadline', config.LEASE_RENEW_DEADLINE_MS, 'ms');
                             return;
                         }
                     }
@@ -346,12 +396,22 @@ class LeaderElector extends EventEmitter {
 
     /**
      * @param {number} ms
+     * @param {AbortSignal} [abort_signal] if provided, resolves early when the signal is aborted
      * @returns {Promise<void>}
      */
-    _interruptible_sleep(ms) {
+    _interruptible_sleep(ms, abort_signal) {
         return new Promise(resolve => {
             this._wake_sleep = resolve;
-            this._sleep_timer = setTimeout(resolve, ms);
+            const on_abort = () => {
+                clearTimeout(this._sleep_timer);
+                this._sleep_timer = null;
+                resolve();
+            };
+            this._sleep_timer = setTimeout(() => {
+                if (abort_signal) abort_signal.removeEventListener('abort', on_abort);
+                resolve();
+            }, ms);
+            if (abort_signal) abort_signal.addEventListener('abort', on_abort, { once: true });
         });
     }
 
@@ -370,13 +430,39 @@ class LeaderElector extends EventEmitter {
     }
 
     /**
+     * Arms or resets the per-cycle renew deadline timer.
+     * Cancels any previous timer so the abort does not fire on a successful renew.
+     * The same AbortController is reused across cycles since clearTimeout prevents
+     * the abort from firing — a new controller is only needed when the signal is
+     * actually aborted, which only happens on step-down (after which the loop exits).
+     */
+    _reset_renew_deadline() {
+        clearTimeout(this._renew_deadline);
+        this._renew_deadline = setTimeout(
+            () => this._renew_deadline_abort.abort('renew_deadline'),
+            config.LEASE_RENEW_DEADLINE_MS
+        );
+    }
+
+    /**
+     * Cancels the renew deadline timer and resets the cycle abort controller.
+     * Called in the renew loop finally block so the next start() cycle begins clean.
+     */
+    _clear_renew_deadline() {
+        clearTimeout(this._renew_deadline);
+        this._renew_deadline = null;
+        this._renew_deadline_abort = new AbortController();
+    }
+
+    /**
      * Handles a 409 conflict after a PUT by re-reading the lease.
      * Returns true (and emits EVENTS.LEADERSHIP_LOST) if we no longer hold the lease.
+     * @param {AbortSignal} [abort_signal]
      * @returns {Promise<boolean>}
      */
-    async _handle_put_conflict() {
+    async _handle_put_conflict(abort_signal) {
         dbg.warn('lease PUT conflict, re-reading lease', this._lease_name);
-        const state = await this.read_lease_state();
+        const state = await this.read_lease_state(abort_signal);
         if (!state.can_take) {
             dbg.error('lost core lease after PUT conflict', this._lease_name, 'holder', state.lease?.spec?.holderIdentity, 'we are', this._holder);
             this.emit(EVENTS.LEADERSHIP_LOST);
@@ -390,7 +476,6 @@ class LeaderElector extends EventEmitter {
      * Emits EVENTS.LEADERSHIP_LOST when the lease is taken by another pod or the renew deadline is exceeded.
      */
     async renew_lease_loop() {
-        this._stop_requested = false;
         /** @type {(value?: void) => void} */
         let loop_done;
         this._running_promise = new Promise(resolve => {
@@ -399,65 +484,47 @@ class LeaderElector extends EventEmitter {
 
         try {
             dbg.log0('starting core lease renew loop', this._lease_name);
-            let last_successful_renew_ms = Date.now();
+            this._reset_renew_deadline();
             while (!this._stop_requested) {
-                // lease is about to expire, step down
-                if (this._is_renew_deadline_exceeded(last_successful_renew_ms)) {
+                // renew deadline fired — step down to avoid split brain
+                if (this._renew_deadline_abort.signal.aborted) {
                     dbg.error('renew deadline exceeded, leadership lost', this._lease_name);
                     this.emit(EVENTS.LEADERSHIP_LOST);
                     return;
                 }
                 let sleep_ms = config.CORE_LEASE_RENEW_ERROR_SLEEP_MS;
                 try {
-                    const { lease, can_take } = await this.read_lease_state();
+                    const { lease, can_take } = await this.read_lease_state(this._renew_deadline_abort.signal);
                     if (!lease || !can_take) {
                         // another pod acquired the lease or lease was deleted, step down
                         dbg.error('lost core lease to another holder, leadership lost', this._lease_name, 'holder', lease?.spec?.holderIdentity, 'we are', this._holder);
                         this.emit(EVENTS.LEADERSHIP_LOST);
                         return;
                     }
-                    const status_code = await this.update_lease(lease, false);
+                    if (this._renew_deadline_abort.signal.aborted) continue;
+                    const status_code = await this.update_lease(lease, false, this._renew_deadline_abort.signal);
                     if (status_code === 200) {
-                        last_successful_renew_ms = Date.now();
+                        this._reset_renew_deadline();
                         sleep_ms = config.CORE_LEASE_ACQUIRE_RETRY_MS;
                     } else if (status_code === 409) {
-                        if (await this._handle_put_conflict()) return;
+                        if (await this._handle_put_conflict(this._renew_deadline_abort.signal)) return;
                     } else {
                         dbg.warn('lease PUT failed, retrying', this._lease_name, status_code);
                     }
                 } catch (err) {
-                    dbg.warn('renew_lease_loop transient error, retrying', this._lease_name, err.message);
+                    dbg.warn('renew_lease_loop transient error', this._lease_name, err.message);
                 }
+
                 if (this._stop_requested) break;
-                await this._interruptible_sleep(sleep_ms);
+                if (this._renew_deadline_abort.signal.aborted) continue;
+                await this._interruptible_sleep(sleep_ms, this._renew_deadline_abort.signal);
             }
         } finally {
             this._wake_interruptible_sleep();
+            this._clear_renew_deadline();
             loop_done();
             this._running_promise = null;
         }
-    }
-
-    /**
-     * Computes the renew deadline from the live lease duration and timing constants.
-     * deadline = leaseDuration - CORE_LEASE_RENEW_ERROR_SLEEP_MS - CORE_LEASE_REQUEST_TIMEOUT_MS - LEASE_RENEW_DEADLINE_MARGIN_MS
-     * @returns {number} deadline in ms
-     */
-    _get_renew_deadline_ms() {
-        return this._lease_duration_ms -
-            config.CORE_LEASE_RENEW_ERROR_SLEEP_MS -
-            config.CORE_LEASE_REQUEST_TIMEOUT_MS -
-            config.LEASE_RENEW_DEADLINE_MARGIN_MS;
-    }
-
-    /**
-     * Returns true when too long has passed since the last successful renew.
-     * Step down in this case to avoid split brain if we can no longer refresh the lease.
-     * @param {number} last_successful_renew_ms
-     * @returns {boolean}
-     */
-    _is_renew_deadline_exceeded(last_successful_renew_ms) {
-        return Date.now() - last_successful_renew_ms > this._get_renew_deadline_ms();
     }
 
 }
@@ -477,7 +544,8 @@ function create_elector_from_env() {
     if (!lease_name) {
         throw new Error('NOOBAA_CORE_LEASE_NAME is not set');
     }
-    const holder = `${process.env.HOSTNAME}_${randomUUID()}`;
+    const holder_name = process.env.HOSTNAME || "noobaa-core";
+    const holder = `${holder_name}_${randomUUID()}`;
     return new LeaderElector({ lease_name, holder });
 }
 
@@ -493,3 +561,4 @@ exports.format_lease_time = format_lease_time;
 exports.is_lease_expired = is_lease_expired;
 exports.is_lease_takeable = is_lease_takeable;
 exports.is_lease_held_by = is_lease_held_by;
+exports.combine_abort_signals = combine_abort_signals;


### PR DESCRIPTION
### Describe the Problem
Today the NooBaa core pod runs as a single active instance. If it fails or is rescheduled, there is no built-in way for a standby core pod to take over cleanly. We need active-passive high availability so only one core pod serves at a time, with automatic failover when the leader is lost.

### Explain the Changes
This PR adds a new Kubernetes Lease-based leader election module to the core library.

The new module is responsible for acquiring and renewing leadership, releasing it on shutdown, and notifying callers when leadership is gained or lost. It provides a simple event-driven interface that can later be used by core_init and other HA-related flows.

This PR only adds the reusable leader election module and its unit tests.
The actual wiring into core_init is done separately in a follow-up PR.

New pieces:
1. Added a new Lease client in `core_lease_utils.js`. this client is provides functions to acquire, renew, and release the lease
2. added config variables CORE_LEASE_ACQUIRE_RETRY_MS and CORE_LEASE_RENEW_DEADLINE_MS to configure lease timings
3. Unit tests for the lease client 


### Issues:
1. part of https://redhat.atlassian.net/browse/RHSTOR-7491

operator side change: https://github.com/noobaa/noobaa-operator/pull/1964

### Testing Instructions:
1. `node --allow-natives-syntax ./node_modules/.bin/_mocha \
  src/test/unit_tests/util_functions_tests/test_core_lease.js`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added Kubernetes Lease–based active/passive leader election with `leadership_acquired` and `leadership_lost` events.
  - Introduced core lease timing and Kubernetes API request timeout configuration for the leader-election behavior.
  - Expanded HTTPS trust roots by optionally loading the Kubernetes CA certificate via a new `KUBE_CA_CERTS` setting.

- **Tests**
  - Added a comprehensive leader-election unit test suite covering lease parsing/formatting, expiry/takeability logic, and acquire/renew/release edge cases.
  - Wired the new leader-election tests into the existing unit test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->