### PR TITLE
refactor: remove WORM_ENABLED object-lock feature gate

### DIFF
--- a/config.js
+++ b/config.js
@@ -726,12 +726,6 @@ config.NC_ENABLE_ACCOUNT_ID_CACHE_STAT_VALIDATION = true;
 
 config.OPERATOR_ACCOUNT_EMAIL = 'operator@noobaa.io';
 
-///////////////////////////////
-//        WORM RELATED       //
-///////////////////////////////
-
-config.WORM_ENABLED = false;
-
 ////////////////////////////////
 //      NAMESPACE MONITOR     //
 ////////////////////////////////

--- a/src/endpoint/s3/ops/s3_delete_object.js
+++ b/src/endpoint/s3/ops/s3_delete_object.js
@@ -3,7 +3,6 @@
 
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
-const config = require('../../../../config');
 
 /**
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html
@@ -15,8 +14,8 @@ async function delete_object(req, res) {
         key: req.params.key,
         version_id,
         md_conditions: http_utils.get_md_conditions(req),
-        bypass_governance: config.WORM_ENABLED ? req.headers['x-amz-bypass-governance-retention'] &&
-            req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE' : undefined,
+        bypass_governance: req.headers['x-amz-bypass-governance-retention'] &&
+            req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE',
     });
     if (version_id) {
         res.setHeader('x-amz-version-id', version_id);

--- a/src/endpoint/s3/ops/s3_get_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_object_lock.js
@@ -1,16 +1,11 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 const s3_utils = require('../s3_utils');
-const config = require('../../../../config');
-const S3Error = require('../s3_errors').S3Error;
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLockConfiguration.html
  */
 async function get_bucket_object_lock(req) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
     const object_lock_configuration = await req.object_sdk.get_object_lock_configuration({ name: req.params.bucket });
     const parsed = s3_utils.parse_to_camel_case(object_lock_configuration, 'ObjectLockConfiguration');
     return parsed;

--- a/src/endpoint/s3/ops/s3_get_object_legal_hold.js
+++ b/src/endpoint/s3/ops/s3_get_object_legal_hold.js
@@ -2,16 +2,11 @@
 'use strict';
 
 const s3_utils = require('../s3_utils');
-const S3Error = require('../s3_errors').S3Error;
-const config = require('../../../../config');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectLegalHold.html
  */
 async function get_object_legal_hold(req, res) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
     const object_legal_hold = await req.object_sdk.get_object_legal_hold({
         bucket: req.params.bucket,
         key: req.params.key,

--- a/src/endpoint/s3/ops/s3_get_object_retention.js
+++ b/src/endpoint/s3/ops/s3_get_object_retention.js
@@ -2,16 +2,11 @@
 'use strict';
 
 const s3_utils = require('../s3_utils');
-const S3Error = require('../s3_errors').S3Error;
-const config = require('../../../../config');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectRetention.html
  */
 async function get_object_retention(req) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
     const object_retention = await req.object_sdk.get_object_retention({
         bucket: req.params.bucket,
         key: req.params.key,

--- a/src/endpoint/s3/ops/s3_post_object_uploads.js
+++ b/src/endpoint/s3/ops/s3_post_object_uploads.js
@@ -14,7 +14,7 @@ async function post_object_uploads(req, res) {
     const tagging = s3_utils.parse_tagging_header(req);
     const encryption = s3_utils.parse_encryption(req);
     const storage_class = s3_utils.parse_storage_class_header(req);
-    const lock_settings = config.WORM_ENABLED ? s3_utils.parse_lock_header(req) : undefined;
+    const lock_settings = s3_utils.parse_lock_header(req);
     if (config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD && storage_class === s3_utils.STORAGE_CLASS_STANDARD) {
         throw new S3Error(S3Error.InvalidStorageClass);
     }

--- a/src/endpoint/s3/ops/s3_put_bucket.js
+++ b/src/endpoint/s3/ops/s3_put_bucket.js
@@ -7,8 +7,8 @@ const config = require('../../../../config');
  * http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html
  */
 async function put_bucket(req, res) {
-    const lock_enabled = config.WORM_ENABLED ? req.headers['x-amz-bucket-object-lock-enabled'] &&
-        req.headers['x-amz-bucket-object-lock-enabled'].toUpperCase() === 'TRUE' : undefined;
+    const lock_enabled = req.headers['x-amz-bucket-object-lock-enabled'] &&
+        req.headers['x-amz-bucket-object-lock-enabled'].toUpperCase() === 'TRUE';
     const custom_bucket_path = req.headers[config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER];
     await req.object_sdk.create_bucket({ name: req.params.bucket, lock_enabled, custom_bucket_path });
     if (config.allow_anonymous_access_in_test && req.headers['x-amz-acl'] === 'public-read') { // For now we will enable only for tests

--- a/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_object_lock.js
@@ -2,15 +2,12 @@
 'use strict';
 const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
-const config = require('../../../../config');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLockConfiguration.html
  */
 async function put_bucket_object_lock(req, res) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
+    // TODO: may require at the future Content-MD5 & bucket-object-lock-token support
     if (req.body.ObjectLockConfiguration.ObjectLockEnabled[0] !== 'Enabled') {
         throw new S3Error(S3Error.MalformedXML);
     }

--- a/src/endpoint/s3/ops/s3_put_object.js
+++ b/src/endpoint/s3/ops/s3_put_object.js
@@ -29,7 +29,7 @@ async function put_object(req, res) {
     if (config.DENY_UPLOAD_TO_STORAGE_CLASS_STANDARD && storage_class === s3_utils.STORAGE_CLASS_STANDARD) {
         throw new S3Error(S3Error.InvalidStorageClass);
     }
-    const lock_settings = config.WORM_ENABLED ? s3_utils.parse_lock_header(req) : undefined;
+    const lock_settings = s3_utils.parse_lock_header(req);
     // Copy request sends empty content and not relevant to the object data
     const { size, md5_b64, sha256_b64 } = copy_source ? {} : {
         size: http_utils.parse_content_length(req, s3_error_options),

--- a/src/endpoint/s3/ops/s3_put_object_legal_hold.js
+++ b/src/endpoint/s3/ops/s3_put_object_legal_hold.js
@@ -2,16 +2,13 @@
 'use strict';
 
 const S3Error = require('../s3_errors').S3Error;
-const config = require('../../../../config');
 const s3_utils = require('../s3_utils');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html
  */
 async function put_object_legal_hold(req) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
+    // TODO: may require at the future Content-MD5 support
     const legal_hold_status = req.body.LegalHold.Status[0];
     if (legal_hold_status !== 'ON' && legal_hold_status !== 'OFF') {
         throw new S3Error(S3Error.MalformedXML);

--- a/src/endpoint/s3/ops/s3_put_object_retention.js
+++ b/src/endpoint/s3/ops/s3_put_object_retention.js
@@ -3,15 +3,12 @@
 
 const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
-const config = require('../../../../config');
 
 /**
  * https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
  */
 async function put_object_retention(req) {
-    if (!config.WORM_ENABLED) {
-        throw new S3Error(S3Error.NotImplemented);
-    }
+    // TODO: may require at the future Content-MD5 support
     if (!req.body.Retention) throw new S3Error(S3Error.MalformedXML);
     const mode = req.body.Retention.Mode[0];
     let retain_until_date = req.body.Retention.RetainUntilDate[0];

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -310,7 +310,7 @@ function set_response_object_md(res, object_md) {
     if (object_md.content_encoding) res.setHeader('Content-Encoding', object_md.content_encoding);
     res.setHeader('Content-Length', object_md.content_length === undefined ? object_md.size : object_md.content_length);
     res.setHeader('Accept-Ranges', 'bytes');
-    if (config.WORM_ENABLED && object_md.lock_settings) {
+    if (object_md.lock_settings) {
         if (object_md.lock_settings.legal_hold) {
             res.setHeader('x-amz-object-lock-legal-hold', object_md.lock_settings.legal_hold.status);
         }

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -357,7 +357,7 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             owner_account: account.owner ? account.owner : account._id, // The account is the owner of the buckets that were created by it or by its users.
             creator: account._id,
             versioning: config.NSFS_VERSIONING_ENABLED && lock_enabled ? 'ENABLED' : 'DISABLED',
-            object_lock_configuration: (config.WORM_ENABLED && config.NSFS_VERSIONING_ENABLED && lock_enabled) ? {
+            object_lock_configuration: (config.NSFS_VERSIONING_ENABLED && lock_enabled) ? {
                 object_lock_enabled: 'Enabled',
             } : undefined,
             creation_date: new Date().toISOString(),

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -97,7 +97,7 @@ async function create_object_upload(req) {
         info.cache_last_valid_time = new Date();
     }
 
-    const lock_settings = config.WORM_ENABLED ? calc_retention(req) : undefined;
+    const lock_settings = calc_retention(req);
     if (lock_settings) info.lock_settings = lock_settings;
 
     if (req.rpc_params.size >= 0) info.size = req.rpc_params.size;
@@ -237,6 +237,9 @@ function calc_retention(req) {
 function get_default_lock_config(bucket) {
     dbg.log1('get_default_lock_config:', bucket.object_lock_configuration);
     const bucket_info = bucket.object_lock_configuration;
+    if (!bucket_info) {
+        return;
+    }
     if (bucket_info.object_lock_enabled !== 'Enabled') {
         return;
     }
@@ -281,7 +284,7 @@ async function put_object_legal_hold(req) {
     if (req.role !== 'admin') {
         throw new RpcError('UNAUTHORIZED');
     }
-    if (req.bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
+    if (!req.bucket.object_lock_configuration || req.bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
         throw new RpcError('INVALID_REQUEST');
     }
     if (info.lock_settings && info.lock_settings.retention) {
@@ -342,7 +345,7 @@ async function put_object_retention(req) {
     if (req.role !== 'admin') {
         throw new RpcError('UNAUTHORIZED');
     }
-    if (req.bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
+    if (!req.bucket.object_lock_configuration || req.bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
         throw new RpcError('INVALID_REQUEST');
     }
     if (info.lock_settings && info.lock_settings.retention &&
@@ -1751,7 +1754,7 @@ function get_object_info(md, options = {}) {
         upload_size: _.isNumber(md.upload_size) ? md.upload_size : undefined,
         num_parts: md.num_parts,
         version_id: bucket.versioning === 'DISABLED' ? undefined : MDStore.instance().get_object_version_id(md),
-        lock_settings: config.WORM_ENABLED && options.role === 'admin' ? md.lock_settings : undefined,
+        lock_settings: options.role === 'admin' ? md.lock_settings : undefined,
         is_latest: !md.version_past,
         delete_marker: md.delete_marker,
         xattr: md.xattr && _.mapKeys(md.xattr, (v, k) => k.replace(/@/g, '.')),
@@ -2161,7 +2164,7 @@ async function _delete_object_version(req) {
         http_utils.check_md_conditions(req.rpc_params.md_conditions, obj);
         if (!obj) return { reply: {} };
 
-        if (config.WORM_ENABLED && obj.lock_settings) {
+        if (obj.lock_settings) {
             if (obj.lock_settings.legal_hold && obj.lock_settings.legal_hold.status === 'ON') {
                 dbg.error('object is locked, can not delete object', obj);
                 throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -67,10 +67,10 @@ function new_bucket_defaults(name, system_id, tiering_policy_id, owner_account_i
             last_update: (Math.floor(now / config.MD_AGGREGATOR_INTERVAL) * config.MD_AGGREGATOR_INTERVAL) -
                 (2 * config.MD_GRACE_IN_MILLISECONDS),
         },
-        versioning: config.WORM_ENABLED && lock_enabled ? 'ENABLED' : 'DISABLED',
-        object_lock_configuration: config.WORM_ENABLED ? {
+        versioning: lock_enabled ? 'ENABLED' : 'DISABLED',
+        object_lock_configuration: {
             object_lock_enabled: lock_enabled ? 'Enabled' : 'Disabled',
-        } : undefined,
+        },
         cors_configuration_rules: config.S3_CORS_DEFAULTS_ENABLED ? [{
             allowed_origins: config.S3_CORS_ALLOW_ORIGIN,
             allowed_methods: config.S3_CORS_ALLOW_METHODS,
@@ -856,7 +856,7 @@ async function read_bucket_sdk_info(req) {
 async function update_bucket(req) {
     const bucket = find_bucket(req, req.name);
     const conf = bucket.object_lock_configuration;
-    if (config.WORM_ENABLED && conf && conf.object_lock_enabled === 'Enabled' &&
+    if (conf && conf.object_lock_enabled === 'Enabled' &&
         req.rpc_params.versioning && req.rpc_params.versioning !== 'ENABLED') {
         throw new RpcError('INVALID_BUCKET_STATE', 'An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.');
     }
@@ -1719,7 +1719,7 @@ function get_bucket_info({
         node_tolerance: undefined,
         bucket_type: bucket.namespace ? 'NAMESPACE' : 'REGULAR',
         versioning: bucket.versioning,
-        object_lock_configuration: config.WORM_ENABLED ? bucket.object_lock_configuration : undefined,
+        object_lock_configuration: bucket.object_lock_configuration,
         tagging: bucket.tagging,
         force_md5_etag: bucket.force_md5_etag,
         logging: bucket.logging,

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -12,14 +12,12 @@ const mocha = require('mocha');
 const assert = require('assert');
 const path = require('path');
 const fs_utils = require('../../../../util/fs_utils');
-const config = require('../../../../../config');
 const today = new Date();
 const tomorrow = new Date(today);
 tomorrow.setDate(tomorrow.getDate() + 1);
 const todayPlus15 = new Date(today);
 todayPlus15.setDate(todayPlus15.getDate() + 15);
 const malformedXML_message = "The XML you provided was not well-formed or did not validate against our published schema.";
-const original_worm_enabled = config.WORM_ENABLED;
 async function assert_throws_async(promise, expected_code = 'AccessDenied', expected_message = 'Access Denied') {
     try {
         await promise;
@@ -50,7 +48,6 @@ mocha.describe('s3 worm', function() {
     let s3_owner;
     //let s3_a;
     mocha.before(async function() {
-        config.WORM_ENABLED = true;
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
         const s3_creds = {
@@ -91,9 +88,6 @@ mocha.describe('s3 worm', function() {
             s3_creds.credentials.secretAccessKey = admin_keys[0].secret_key.unwrap();
             s3_owner = new S3(s3_creds);
         }
-    });
-    mocha.after(function() {
-        config.WORM_ENABLED = original_worm_enabled;
     });
     mocha.describe('buckets creation', function() {
         mocha.it('create bucket BKT & enable lock', async function() {

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -224,7 +224,6 @@ async function config_dir_setup() {
         // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
         // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
         VACCUM_ANALYZER_INTERVAL: 1,
-        WORM_ENABLED: true,
     }));
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 }


### PR DESCRIPTION
Object lock behavior is controlled by S3 bucket/object state, so remove the global `WORM_ENABLED` config toggle and related runtime/test gating checks.

### Describe the Problem

Object Lock APIs and enforcement were gated behind a global `config.WORM_ENABLED` flag. When the flag was off, S3 Object Lock operations returned `NotImplemented` even though bucket/object lock state already existed in metadata. This made Object Lock behavior depend on deployment config instead of per-bucket/per-object state, and required tests to toggle runtime config to exercise lock flows.

After #9686 (PutObjectLockConfiguration on existing buckets), the global gate also conflicted with the intended model: lock behavior should follow bucket `object_lock_configuration` and object `lock_settings`.

### Explain the Changes

1. Removed `config.WORM_ENABLED` from `config.js`.
2. Removed `NotImplemented` gating from S3 Object Lock endpoint handlers (`Get/Put ObjectLockConfiguration`, `Get/Put ObjectRetention`, `Get/Put ObjectLegalHold`).
3. Always parse/apply lock settings from requests and responses based on bucket/object state (e.g. `calc_retention`, lock response headers, delete enforcement).
4. Always include `object_lock_configuration` in bucket defaults and bucket info (`Enabled` / `Disabled` internal state).
5. Drive governance bypass from the `x-amz-bypass-governance-retention` request header without a feature-flag check.
6. Added null guards for legacy buckets missing `object_lock_configuration` in `object_server` lock paths.
7. Updated `test_s3_worm.js` to stop toggling removed runtime config; removed unused `config` import.
8. Removed `WORM_ENABLED` from NC coretest config.

Rebased on current `master` (includes merged #9686) and kept existing-bucket lock-enable + versioning validation behavior from that PR.

### Issues: Fixed #xxx / Gap #xxx

- Fixed #RHSTOR-841
- Gap #N/A

### Testing Instructions:

1. Run object lock integration tests:
   `node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/integration_tests/api/s3/test_s3_worm.js --timeout 120000`
2. Verify Object Lock APIs work without setting any global WORM config flag:
   - `PutObjectLockConfiguration` / `GetObjectLockConfiguration`
   - `PutObjectRetention` / `GetObjectRetention`
   - `PutObjectLegalHold` / `GetObjectLegalHold`
3. Verify delete enforcement still blocks locked versions and allows governance bypass with `x-amz-bypass-governance-retention: true`.
4. Verify non-lock buckets still work and return internal `object_lock_enabled: Disabled` metadata without schema failures.
5. Verify legacy buckets without `object_lock_configuration` do not crash on lock-related RPC paths.

- [ ] Doc added/updated
- [x] Tests added