### PR TITLE
Validate comma-separated CORS preflight headers

### DIFF
--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -692,6 +692,79 @@ mocha.describe('s3_ops', function() {
             assert.deepEqual(response && response.statusCode, 200);
         });
 
+        mocha.it('should match OPTIONS request with comma-separated allowed headers', async function() {
+            const request_method = 'PUT';
+            const requested_headers = ['authorization', 'content-type', 'x-amz-date', 'x-amz-user-agent'];
+            const params = {
+                Bucket: cors_bucket_name,
+                CORSConfiguration: {
+                    CORSRules: [{
+                        ID: 'rule1',
+                        AllowedOrigins: [example_origin],
+                        AllowedHeaders: requested_headers,
+                        AllowedMethods: [request_method],
+                        ExposeHeaders: [expose_header]
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            const res = await s3.getBucketCors({ Bucket: cors_bucket_name });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+
+            const url = new URL(coretest.get_https_address());
+            const response = await http_utils.make_https_request({
+                hostname: url.hostname,
+                port: url.port,
+                path: `/${cors_bucket_name}/`,
+                method: 'OPTIONS',
+                rejectUnauthorized: false,
+                headers: {
+                    'Access-Control-Request-Headers': requested_headers.join(', '),
+                    'Access-Control-Request-Method': request_method,
+                    'Origin': example_origin,
+                }
+            });
+            assert.deepEqual(response && response.statusCode, 200);
+        });
+
+        mocha.it('should reject OPTIONS request when comma-separated headers include invalid header', async function() {
+            const request_method = 'PUT';
+            const allowed_headers = ['authorization', 'content-type', 'x-amz-date', 'x-amz-user-agent'];
+            const request_headers = [...allowed_headers, 'x-invalid-header'];
+            const params = {
+                Bucket: cors_bucket_name,
+                CORSConfiguration: {
+                    CORSRules: [{
+                        ID: 'rule1',
+                        AllowedOrigins: [example_origin],
+                        AllowedHeaders: allowed_headers,
+                        AllowedMethods: [request_method],
+                        ExposeHeaders: [expose_header]
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            const res = await s3.getBucketCors({ Bucket: cors_bucket_name });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+
+            const url = new URL(coretest.get_https_address());
+            const response = await http_utils.make_https_request({
+                hostname: url.hostname,
+                port: url.port,
+                path: `/${cors_bucket_name}/`,
+                method: 'OPTIONS',
+                rejectUnauthorized: false,
+                headers: {
+                    'Access-Control-Request-Headers': request_headers.join(', '),
+                    'Access-Control-Request-Method': request_method,
+                    'Origin': example_origin,
+                }
+            });
+            assert.deepEqual(response && response.statusCode, 403);
+        });
+
         mocha.it('should put bucket cors with lower case header, HEAD origin with invalid header', async function() {
             // put bucket cors
             const params = {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -854,14 +854,22 @@ function set_cors_headers_s3(req, res, cors_rules) {
     const match_method = req.headers['access-control-request-method'] || req.method;
     const match_origin = req.headers.origin;
     const match_header = req.headers['access-control-request-headers']; // not a must
+    const requested_headers = match_header ?
+        match_header
+            .split(',')
+            .map(header => header.trim())
+            .filter(Boolean) :
+        [];
     const matched_rule = req.headers.origin && ( // find the first rule with origin and method match
         cors_rules.find(rule => {
             const allowed_origins_regex = rule.allowed_origins.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`));
             const allowed_headers_regex = rule.allowed_headers?.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`, 'i'));
+            const are_requested_headers_allowed = requested_headers.length === 0 ||
+                requested_headers.every(header => allowed_headers_regex?.some(r => r.test(header)));
             return allowed_origins_regex.some(r => r.test(match_origin)) &&
                 rule.allowed_methods.includes(match_method) &&
-                // we can match if no request headers or if reuqest headers match the rule allowed headers
-                (!match_header || allowed_headers_regex?.some(r => r.test(match_header)));
+                // we can match if no request headers or if requested headers match the rule allowed headers
+                are_requested_headers_allowed;
         }));
     if (matched_rule) {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html


### PR DESCRIPTION
## Summary

- Fixes bug: [DFBUGS-7973](https://redhat.atlassian.net/browse/DFBUGS-7973)
- Parse `Access-Control-Request-Headers` as a comma-separated list in S3 CORS preflight handling.
- Require every requested header in preflight to match an allowed CORS header rule.
- Add integration tests for allowed and invalid comma-separated preflight header sets.

## Test plan
- [x] Validate CORS preflight `OPTIONS` for comma-separated allowed headers returns 200.
- [x] Validate CORS preflight with one invalid header returns 403.
- [x] Verified backend behavior on live cluster with patched `noobaa-core` image and `curl` preflight checks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 CORS handling for `OPTIONS` requests with comma-separated `Access-Control-Request-Headers`.
  * Requests are now accepted only when every requested header is allowed, which prevents invalid header combinations from being incorrectly permitted.
  * Added coverage for both successful and rejected CORS preflight requests in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->