### PR TITLE
[Deep Archive] - Update object_md related API's and types

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1631,6 +1631,10 @@ module.exports = {
             // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-noncurrentversiontransition.html#cfn-s3-bucket-noncurrentversiontransition-storageclass
             enum: ['STANDARD', 'GLACIER', 'GLACIER_IR', 'Glacier', 'DEEP_ARCHIVE', 'INTELLIGENT_TIERING', 'ONEZONE_IA', 'STANDARD_IA']
         },
+        transition_status_enum: {
+            type: 'string',
+            enum: ['IN_PROGRESS', 'DONE']
+        },
         bucket_logging: {
             type: 'object',
             required: ['log_bucket', 'log_prefix'],

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1597,6 +1597,8 @@ module.exports = {
                     type: 'array',
                     items: { $ref: '#/definitions/chunk_info' }
                 },
+                transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
+                data_expired: { idate: true },
             }
         },
 

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -435,6 +435,8 @@ interface ObjectMD {
     encryption: { algorithm: string; kms_key_id: string; context_b64: string; key_md5_b64: string; key_b64: string; };
     tagging: Array<{ key: string; value: string; }>;
     lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
+    transition_status?: string;
+    data_expired?: Date;
 }
 
 interface ObjectOwner {
@@ -481,6 +483,8 @@ interface ObjectInfo {
     checksum?: Checksum;
     object_parts?: GetObjectAttributesParts;
     nc_noncurrent_time?: number;
+    transition_status?: string;
+    data_expired?: number;
 }
 
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1765,7 +1765,9 @@ function get_object_info(md, options = {}) {
         tagging: md.tagging,
         encryption: md.encryption,
         tag_count: (md.tagging && md.tagging.length) || 0,
-        object_owner: _get_object_owner()
+        object_owner: _get_object_owner(),
+        transition_status: md.transition_status || undefined,
+        data_expired: md.data_expired ? md.data_expired.getTime() : undefined,
     };
 }
 

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -137,5 +137,8 @@ module.exports = {
             }
         },
 
+        transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
+
+        data_expired: { date: true },
     }
 };


### PR DESCRIPTION
### Explain the Changes
1. Added fields `transition_status` and `data_expired` to object_md schema, nb types, `object_info` definition.
2. Added an enum `transition_status_enum` to support `transition_status`.
3. Updated the function `get_object_info` to return the newly added fields.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - `NamespaceFS` class method `_get_object_info` is not updated as its not in the scope of this feature, but would be needed during NSFS implementation.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Object details now include optional `transition_status` and `data_expired` metadata when available.
  * `transition_status` is constrained to `IN_PROGRESS` or `DONE`.
  * SDK typings were updated to expose these fields on relevant object info types.
* **Bug Fixes**
  * Object info responses now consistently include `transition_status` and `data_expired`, returning `undefined` when values aren’t provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->