### PR TITLE
[Backport into 5.22] validate comma-separated CORS preflight headers

### DIFF
--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -692,6 +692,79 @@ mocha.describe('s3_ops', function() {
             assert.deepEqual(response && response.statusCode, 200);
         });
 
+        mocha.it('should match OPTIONS request with comma-separated allowed headers', async function() {
+            const request_method = 'PUT';
+            const requested_headers = ['authorization', 'content-type', 'x-amz-date', 'x-amz-user-agent'];
+            const params = {
+                Bucket: cors_bucket_name,
+                CORSConfiguration: {
+                    CORSRules: [{
+                        ID: 'rule1',
+                        AllowedOrigins: [example_origin],
+                        AllowedHeaders: requested_headers,
+                        AllowedMethods: [request_method],
+                        ExposeHeaders: [expose_header]
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            const res = await s3.getBucketCors({ Bucket: cors_bucket_name });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+
+            const url = new URL(coretest.get_https_address());
+            const response = await http_utils.make_https_request({
+                hostname: url.hostname,
+                port: url.port,
+                path: `/${cors_bucket_name}/`,
+                method: 'OPTIONS',
+                rejectUnauthorized: false,
+                headers: {
+                    'Access-Control-Request-Headers': requested_headers.join(', '),
+                    'Access-Control-Request-Method': request_method,
+                    'Origin': example_origin,
+                }
+            });
+            assert.deepEqual(response && response.statusCode, 200);
+        });
+
+        mocha.it('should reject OPTIONS request when comma-separated headers include invalid header', async function() {
+            const request_method = 'PUT';
+            const allowed_headers = ['authorization', 'content-type', 'x-amz-date', 'x-amz-user-agent'];
+            const request_headers = [...allowed_headers, 'x-invalid-header'];
+            const params = {
+                Bucket: cors_bucket_name,
+                CORSConfiguration: {
+                    CORSRules: [{
+                        ID: 'rule1',
+                        AllowedOrigins: [example_origin],
+                        AllowedHeaders: allowed_headers,
+                        AllowedMethods: [request_method],
+                        ExposeHeaders: [expose_header]
+                    }]
+                }
+            };
+            await s3.putBucketCors(params);
+
+            const res = await s3.getBucketCors({ Bucket: cors_bucket_name });
+            assert.deepEqual(res.CORSRules, params.CORSConfiguration.CORSRules);
+
+            const url = new URL(coretest.get_https_address());
+            const response = await http_utils.make_https_request({
+                hostname: url.hostname,
+                port: url.port,
+                path: `/${cors_bucket_name}/`,
+                method: 'OPTIONS',
+                rejectUnauthorized: false,
+                headers: {
+                    'Access-Control-Request-Headers': request_headers.join(', '),
+                    'Access-Control-Request-Method': request_method,
+                    'Origin': example_origin,
+                }
+            });
+            assert.deepEqual(response && response.statusCode, 403);
+        });
+
         mocha.it('should put bucket cors with lower case header, HEAD origin with invalid header', async function() {
             // put bucket cors
             const params = {

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -854,14 +854,22 @@ function set_cors_headers_s3(req, res, cors_rules) {
     const match_method = req.headers['access-control-request-method'] || req.method;
     const match_origin = req.headers.origin;
     const match_header = req.headers['access-control-request-headers']; // not a must
+    const requested_headers = match_header ?
+        match_header
+            .split(',')
+            .map(header => header.trim())
+            .filter(Boolean) :
+        [];
     const matched_rule = req.headers.origin && ( // find the first rule with origin and method match
         cors_rules.find(rule => {
             const allowed_origins_regex = rule.allowed_origins.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`));
             const allowed_headers_regex = rule.allowed_headers?.map(r => RegExp(`^${r.replace(/\*/g, '.*')}$`, 'i'));
+            const are_requested_headers_allowed = requested_headers.length === 0 ||
+                requested_headers.every(header => allowed_headers_regex?.some(r => r.test(header)));
             return allowed_origins_regex.some(r => r.test(match_origin)) &&
                 rule.allowed_methods.includes(match_method) &&
-                // we can match if no request headers or if reuqest headers match the rule allowed headers
-                (!match_header || allowed_headers_regex?.some(r => r.test(match_header)));
+                // we can match if no request headers or if requested headers match the rule allowed headers
+                are_requested_headers_allowed;
         }));
     if (matched_rule) {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html


### PR DESCRIPTION
## Summary
- Backport of [DFBUGS-7973](https://redhat.atlassian.net/browse/DFBUGS-7973) fix to the 5.22 release branch
- Cherry-picked commit `5c3a8d2ef` from `DFBUGS-7973`
- Fixes CORS preflight `Access-Control-Request-Headers` matching: previously, comma-separated headers were matched as a single string against the allowed headers regex, causing valid preflight requests to be rejected. Now each header is split, trimmed, and individually validated.

## Changes
- `src/util/http_utils.js`: Split and individually validate comma-separated `Access-Control-Request-Headers` in CORS preflight matching
- `src/test/integration_tests/api/s3/test_s3_ops.js`: Added two integration tests — one for valid comma-separated headers (expects 200) and one with an invalid header mixed in (expects 403)

## Test plan
- [ ] Verify CORS preflight with comma-separated allowed headers returns 200
- [ ] Verify CORS preflight with invalid header in the list returns 403
- [ ] Ensure no regression in existing CORS behavior

Fixes: [DFBUGS-7973](https://redhat.atlassian.net/browse/DFBUGS-7973)
