### PR TITLE
fix supervisord copy into itself

### DIFF
--- a/src/cmd/core_init.js
+++ b/src/cmd/core_init.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const os_utils = require('../util/os_utils');
 
-const SUPERVISORD = '/usr/bin/supervisord';
+const SUPERVISORD = '/usr/bin/supervisord_orig';
 const PIDFILE = '/var/log/supervisord.pid';
 const PACKAGE_JSON_PATH = '/root/node_modules/noobaa-core/package.json';
 const NOOBAA_ROOT = '/root/node_modules/noobaa-core';

--- a/src/deploy/NVA_build/setup_platform.sh
+++ b/src/deploy/NVA_build/setup_platform.sh
@@ -40,7 +40,9 @@ function install_supervisor {
     # Autostart supervisor
     deploy_log "setup_supervisors autostart"
     bin_supervisord=$(find / -name supervisord | grep bin)
-    mv ${bin_supervisord} /usr/bin/supervisord
+    if [ "${bin_supervisord}" != "/usr/bin/supervisord_orig" ]; then
+        mv "${bin_supervisord}" /usr/bin/supervisord_orig
+    fi
 
     # Add NooBaa services configuration to supervisor
     deploy_log "setup_supervisors adding noobaa config to supervisord"

--- a/src/test/unit_tests/internal/test_core_init.js
+++ b/src/test/unit_tests/internal/test_core_init.js
@@ -42,7 +42,7 @@ function stub_os_utils_spawn(sandbox, { upgrade_rc = 0, supervisord_rc = 0, upgr
             if (upgrade_rc !== 0) {
                 throw new Error(`spawn "${cmd} ${args.join(' ')}" exit with error code ${upgrade_rc}`);
             }
-        } else if (cmd === '/bin/sh' && args[0] === '-c' && args[1]?.includes('/usr/bin/supervisord')) {
+        } else if (cmd === '/bin/sh' && args[0] === '-c' && args[1]?.includes('/usr/bin/supervisord_orig')) {
             if (supervisord_rc !== 0) {
                 throw new Error(`spawn "${cmd} ${args.join(' ')}" exit with error code ${supervisord_rc}`);
             }
@@ -138,20 +138,21 @@ mocha.describe('core_init', function() {
             fs.accessSync(REPO_INIT_SCRIPT, fs.constants.R_OK);
         });
 
-        mocha.it('Dockerfile CMD runs core_init.js and does not reference supervisord.orig', function() {
+        mocha.it('Dockerfile CMD runs core_init.js', function() {
             const dockerfile = fs.readFileSync(
                 path.join(REPO_ROOT, 'src/deploy/NVA_build/NooBaa.Dockerfile'),
                 'utf8'
             );
             assert.match(dockerfile, /CMD \["\/usr\/local\/bin\/node", "\/root\/node_modules\/noobaa-core\/src\/cmd\/core_init\.js"\]/);
-            assert.doesNotMatch(dockerfile, /supervisord\.orig/);
         });
 
-        mocha.it('setup_platform.sh configures supervisord logs under /var/log/supervisor', function() {
+        mocha.it('setup_platform.sh installs supervisord at /usr/bin/supervisord_orig', function() {
             const setup_platform = fs.readFileSync(
                 path.join(REPO_ROOT, 'src/deploy/NVA_build/setup_platform.sh'),
                 'utf8'
             );
+            assert.match(setup_platform, /\/usr\/bin\/supervisord_orig/);
+            assert.doesNotMatch(setup_platform, /mv\s+"?\$\{bin_supervisord\}"?\s+\/usr\/bin\/supervisord(?!_orig)\b/);
             assert.match(setup_platform, /logfile=\/var\/log\/supervisor\/supervisord\.log/);
             assert.match(setup_platform, /childlogdir=\/var\/log\/supervisor\//);
             assert.doesNotMatch(setup_platform, /logfile=\/log\/supervisor/);
@@ -186,7 +187,7 @@ mocha.describe('core_init', function() {
                     'expected upgrade_manager to run'
                 );
                 assert.ok(
-                    calls.some(c => c.cmd === '/bin/sh' && c.args[1]?.includes('/usr/bin/supervisord')),
+                    calls.some(c => c.cmd === '/bin/sh' && c.args[1]?.includes('/usr/bin/supervisord_orig')),
                     'expected supervisord shell command'
                 );
             } finally {
@@ -208,7 +209,7 @@ mocha.describe('core_init', function() {
                     /exit with error code 42/
                 );
                 assert.strictEqual(
-                    calls.some(c => c.cmd === '/bin/sh' && c.args[1]?.includes('/usr/bin/supervisord')),
+                    calls.some(c => c.cmd === '/bin/sh' && c.args[1]?.includes('/usr/bin/supervisord_orig')),
                     false
                 );
             } finally {


### PR DESCRIPTION
### Describe the Problem
on downstream `${bin_supervisord}` is in `/usr/bin/supervisord` casing the mv in src/deploy/NVA_build/setup_platform.sh to fail due to it moving the file onto itself.

### Explain the Changes
1. change it to the target path to be the old `/usr/bin/supervisord_orig` and change the path in the relevant places

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supervisor startup to use the preserved original binary path (`supervisord_orig`) for more reliable initialization and deployment.
  * Adjusted platform setup to avoid overwriting the existing supervisor binary when it’s already present in the expected location.
* **Tests**
  * Updated automated tests to reflect the revised supervisor launch path and added coverage for Docker command behavior and renamed binary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->