### PR TITLE
add support for federated principal in ldap

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -117,6 +117,14 @@ module.exports = {
             enum: ['DISABLED', 'SUSPENDED', 'ENABLED']
         },
 
+        federated_role_policy_principal: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                Federated: { $ref: '#/definitions/string_or_string_array' }
+            }
+        },
+
         assume_role_policy: {
             type: 'object',
             required: ['statement'],
@@ -139,10 +147,15 @@ module.exports = {
                                 }
                             },
                             principal: {
-                                type: 'array',
-                                items: {
-                                    $ref: '#/definitions/email',
-                                }
+                                oneOf: [
+                                    {
+                                        type: 'array',
+                                        items: { $ref: '#/definitions/email' }
+                                    },
+                                    {
+                                        $ref: '#/definitions/federated_role_policy_principal'
+                                    }
+                                ]
                             },
                             condition: {
                                 $ref: '#/definitions/trust_policy_condition'

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -259,11 +259,16 @@ function _is_statements_fit(statements, method, cur_account_email, web_identity_
             }
         }
         // who can do that action
-        for (const principal of statement.principal) {
-            dbg.log0('assume_role_policy: principal fit?', principal.unwrap().toString(), cur_account_email);
-            if ((principal.unwrap() === cur_account_email) || (principal.unwrap() === '*')) {
-                principal_fit = true;
+        if (Array.isArray(statement.principal)) {
+            for (const principal of statement.principal) {
+                const principal_str = typeof principal.unwrap === 'function' ? principal.unwrap() : String(principal);
+                dbg.log0('assume_role_policy: principal fit?', principal_str, cur_account_email);
+                if ((principal_str === cur_account_email) || (principal_str === '*')) {
+                    principal_fit = true;
+                }
             }
+        } else if (statement.principal?.Federated) {
+            principal_fit = _is_federated_principal_fit(statement.principal.Federated, web_identity_info);
         }
 
         // look for conditions
@@ -287,6 +292,28 @@ function _is_statements_fit(statements, method, cur_account_email, web_identity_
         if (action_fit && principal_fit && condition_fit) return true;
     }
     return false;
+}
+
+function _parse_federated_arn(arn) {
+    // arn:aws:iam:::<account>:<provider-type>/<provider-id>
+    const match = arn.match(/^arn:aws:iam::[^:]*:(ldap-provider|oidc-provider)\/(.+)$/);
+    if (!match) return null;
+    return { provider_type: match[1], provider_id: match[2] };
+}
+
+function _is_federated_principal_fit(federated_value, web_identity_info) {
+    if (!web_identity_info) return false;
+    const federated_arns = Array.isArray(federated_value) ? federated_value : [federated_value];
+    return federated_arns.some(arn => {
+        if (arn === '*') return true;
+        const parsed = _parse_federated_arn(arn);
+        if (!parsed) return false;
+        if (parsed.provider_type === 'ldap-provider') {
+            return web_identity_info.ldap_server === parsed.provider_id;
+        }
+        // TODO: 'oidc-provider' case for Keycloak
+        return false;
+    });
 }
 
 function _is_ldap_identity_fit(condition_key, policy_value, identity_info, predicate) {

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -545,6 +545,17 @@ function validate_account_identifier(action, input_options) {
     // in list there is no identifier
 }
 
+function _is_valid_principal(principal) {
+    // array of strings
+    if (Array.isArray(principal)) return principal.length > 0;
+    // { Federated: string | string[] }
+    if (principal && typeof principal === 'object' && !Array.isArray(principal)) {
+        return typeof principal.Federated === 'string' ||
+               (Array.isArray(principal.Federated) && principal.Federated.length > 0);
+    }
+    return false;
+}
+
 /**
  * validate_role_config validates user_input.role_config when provided.
  * Accepts a JSON string (--role_config CLI flag)
@@ -578,9 +589,8 @@ function validate_role_config(user_input) {
     }
     for (const statement of policy.statement) {
         if (statement === null || typeof statement !== 'object' || Array.isArray(statement) ||
-                !statement.effect || !Array.isArray(statement.action) || !Array.isArray(statement.principal)) {
-            throw_cli_error(ManageCLIError.InvalidRoleConfig,
-                'each statement in assume_role_policy must have "effect", "action" (array) and "principal" (array)');
+                !statement.effect || !Array.isArray(statement.action) || !_is_valid_principal(statement.principal)) {
+            throw_cli_error(ManageCLIError.InvalidRoleConfig, 'each statement in assume_role_policy must have "effect", "action" (array) and "principal" (array or Federated object)');
         }
         if (statement.effect !== 'allow' && statement.effect !== 'deny') {
             throw_cli_error(ManageCLIError.InvalidRoleConfig, 'effect must be "allow" or "deny"');

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -98,6 +98,13 @@ class StsSDK {
             role_config: account.role_config
         };
     }
+
+    extract_ldap_host(uri) {
+        // example uri: ldaps://ldap.example.com:636 then return ldap.example.com
+        const match = uri.match(/^ldaps?:\/\/([^:/]+)/);
+        return match ? match[1] : uri;
+    }
+
     async authenticate_web_identity(req) {
         dbg.log1('sts_sdk.get_assumed_ldap_user body', req.body);
         let web_token;
@@ -138,8 +145,13 @@ class StsSDK {
             dbg.error('get_assumed_ldap_user error:', err);
             throw new RpcError('ACCESS_DENIED', 'issue with LDAP authentication');
         }
+        const ldap_uri = ldap_client.instance().ldap_params?.uri || '';
 
-        return ldap_auth_result;
+        return {
+            ...ldap_auth_result,
+            provider_type: 'ldap-provider',
+            ldap_server: this.extract_ldap_host(ldap_uri),
+        };
     }
 
     /**

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -62,11 +62,13 @@ async function create_account(req) {
 function validate_assume_role_policy(policy) {
     const all_op_names = Object.values(OP_NAME_TO_ACTION);
     for (const statement of policy.statement) {
-        for (const principal of statement.principal) {
-            if (principal.unwrap() !== '*') {
-                const account = system_store.get_account_by_email(principal);
-                if (!account) {
-                    throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+        if (Array.isArray(statement.principal)) {
+            for (const principal of statement.principal) {
+                if (principal.unwrap() !== '*') {
+                    const account = system_store.get_account_by_email(principal);
+                    if (!account) {
+                        throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+                    }
                 }
             }
         }

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -2,6 +2,7 @@
 'use strict';
 
 // setup coretest first to prepare the env
+require('../../../../util/dotenv').load();
 const { require_coretest, is_nc_coretest } = require('../../../system_tests/test_utils');
 const coretest = require_coretest();
 coretest.setup();
@@ -77,7 +78,8 @@ const errors = {
         message_invalid_effect: 'effect must be "allow" or "deny"',
         message_role_name: 'role_config must have a non-empty string "role_name"',
         message_assume_role_policy: 'role_config.assume_role_policy must have a non-empty "statement" array',
-        message_invalid_action: 'Policy has invalid action'
+        message_invalid_action: 'Policy has invalid action',
+        message_invalid_principal: 'each statement in assume_role_policy must have "effect", "action" (array) and "principal" (array or Federated object)'
     }
 };
 
@@ -908,6 +910,55 @@ mocha.describe('Assume role policy tests', function() {
         }), errors.malformed_policy.rpc_code, errors.malformed_policy.message_principal);
     });
 
+    mocha.it('create account with role policy - Federated principal - should be accepted', async function() {
+        const email = 'assume_email_fed';
+        const assume_role_policy = {
+            statement: [{
+                effect: 'allow',
+                action: ['sts:AssumeRoleWithWebIdentity'],
+                principal: { Federated: 'arn:aws:iam:::ldap-provider/ldap.example.com' },
+            }]
+        };
+        const account_opts = {
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: { role_name: 'fed_role', assume_role_policy }
+        };
+        if (is_nc_coretest) {
+            account_opts.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: coretest.NC_CORETEST_STORAGE_PATH,
+            };
+        }
+        await rpc_client.account.create_account(account_opts);
+        await rpc_client.account.delete_account({ email }).catch(() => {
+            dbg.log1("Error deleting account", email);
+        });
+    });
+
+    mocha.it('create account with role policy - principal is plain string - should be rejected', async function() {
+        const email = 'assume_email_bad_principal';
+        const assume_role_policy = {
+            statement: [{
+                effect: 'allow',
+                action: ['sts:AssumeRoleWithWebIdentity'],
+                principal: 'invalid-string-principal',
+            }]
+        };
+        const expected_error = is_nc_coretest ? errors.invalid_role_config.rpc_code : errors.invalid_schema_params.code;
+        const expected_message = is_nc_coretest ?
+            errors.invalid_role_config.message_invalid_principal :
+            errors.invalid_schema_params.message;
+        await assert_throws_async(rpc_client.account.create_account({
+            ...account_defaults,
+            email,
+            name: email,
+            role_config: { role_name: 'bad_role', assume_role_policy }
+        }), expected_error, expected_message);
+    });
+
     mocha.it('create account with role policy- invalid effect', async function() {
         const invalid_action = { effect: 'non_existing_effect' };
         const email = 'assume_email3';
@@ -955,6 +1006,139 @@ mocha.describe('Assume role policy tests', function() {
             }
         }), expected_error, expected_message);
     });
+});
+
+mocha.describe('Federated principal - AssumeRoleWithWebIdentity tests', function() {
+    const { rpc_client } = coretest;
+    let JWT_SECRET = 'TEST_SECRET'; // may be replaced in before() if ldap_config already exists
+    const ROLE_NAME = 'ldap_fed_role';
+    const LDAP_USER = 'fry';
+    const LDAP_PASSWORD = 'fry';
+
+    let anon_sts;
+    let role_account_key;
+    let _ldap_config_created_by_test = false;
+
+    // Helper: build an allow assume_role_policy with a Federated principal
+    const federated_principal_allow_policy = federated => ({
+        statement: [{
+            effect: 'allow',
+            action: ['sts:AssumeRoleWithWebIdentity'],
+            principal: { Federated: federated },
+        }]
+    });
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        anon_sts = new AWS.STS({
+            endpoint: coretest.get_https_address_sts(),
+            region: 'us-east-1',
+            sslEnabled: true,
+            computeChecksums: true,
+            httpOptions: { agent: new https.Agent({ keepAlive: false, rejectUnauthorized: false }) },
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+        });
+
+        if (is_nc_coretest) {
+            await fs.promises.mkdir(path.dirname(config.LDAP_CONFIG_PATH), { recursive: true });
+            try {
+                // If ldap_config already exists, reuse its jwt_secret to avoid overwriting
+                const existing = JSON.parse(await fs.promises.readFile(config.LDAP_CONFIG_PATH, 'utf8'));
+                if (existing.jwt_secret) JWT_SECRET = existing.jwt_secret;
+            } catch (_) {
+                // File does not exist — write our test jwt_secret
+                await fs.promises.writeFile(config.LDAP_CONFIG_PATH, JSON.stringify({ jwt_secret: JWT_SECRET }));
+                _ldap_config_created_by_test = true;
+            }
+        }
+        // Set jwt_secret in test process so JWT signing/verification reference matches
+        ldap_client.instance().ldap_params = { jwt_secret: JWT_SECRET };
+
+        // Create the role account with a Federated principal policy
+        const account_opts = {
+            has_login: false,
+            s3_access: true,
+            name: LDAP_USER,
+            email: LDAP_USER,
+            role_config: {
+                role_name: ROLE_NAME,
+                assume_role_policy: federated_principal_allow_policy('arn:aws:iam:::ldap-provider/ldap.planetexpress.com')
+            }
+        };
+        if (is_nc_coretest) {
+            account_opts.nsfs_account_config = {
+                uid: process.getuid(),
+                gid: process.getgid(),
+                new_buckets_path: coretest.NC_CORETEST_STORAGE_PATH,
+            };
+        }
+        const create_res = await rpc_client.account.create_account(account_opts);
+        role_account_key = create_res.access_keys[0].access_key.unwrap();
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(30000);
+        await rpc_client.account.delete_account({ email: LDAP_USER }).catch(() => {
+            dbg.log1("Error deleting account", LDAP_USER);
+        });
+        if (is_nc_coretest && _ldap_config_created_by_test) {
+            // Only remove the file if we created it (i.e., pre-existing file was not reused)
+            await fs.promises.unlink(config.LDAP_CONFIG_PATH).catch(() => {
+                dbg.log1("Error unlinking LDAP config file", config.LDAP_CONFIG_PATH);
+            });
+        }
+    });
+
+    // JWT validation tests — fail before ldap_client.authenticate() is ever called.
+
+    mocha.it('federated - bad JWT token - should be rejected', async function() {
+        await assert_throws_async(
+            anon_sts.assumeRoleWithWebIdentity({
+                RoleArn: `arn:aws:sts::${role_account_key}:role/${ROLE_NAME}`,
+                RoleSessionName: 'fed-session',
+                WebIdentityToken: 'not-a-jwt',
+            }).promise(),
+            stsErr.InvalidIdentityToken.code, 'jwt malformed'
+        );
+    });
+
+    mocha.it('federated - JWT with wrong secret - should be rejected', async function() {
+        await assert_throws_async(
+            anon_sts.assumeRoleWithWebIdentity({
+                RoleArn: `arn:aws:sts::${role_account_key}:role/${ROLE_NAME}`,
+                RoleSessionName: 'fed-session',
+                WebIdentityToken: jwt.sign({ user: LDAP_USER, password: LDAP_PASSWORD }, 'wrong-secret'),
+            }).promise(),
+            stsErr.InvalidIdentityToken.code, 'invalid signature'
+        );
+    });
+
+    mocha.it('federated - JWT missing user claim - should be rejected', async function() {
+        await assert_throws_async(
+            anon_sts.assumeRoleWithWebIdentity({
+                RoleArn: `arn:aws:sts::${role_account_key}:role/${ROLE_NAME}`,
+                RoleSessionName: 'fed-session',
+                WebIdentityToken: jwt.sign({ password: LDAP_PASSWORD }, JWT_SECRET),
+            }).promise(),
+            stsErr.InvalidIdentityToken.code, 'Missing a required claim: user'
+        );
+    });
+
+    mocha.it('federated - JWT missing password claim - should be rejected', async function() {
+        await assert_throws_async(
+            anon_sts.assumeRoleWithWebIdentity({
+                RoleArn: `arn:aws:sts::${role_account_key}:role/${ROLE_NAME}`,
+                RoleSessionName: 'fed-session',
+                WebIdentityToken: jwt.sign({ user: LDAP_USER }, JWT_SECRET),
+            }).promise(),
+            stsErr.InvalidIdentityToken.code, 'Missing a required claim: password'
+        );
+    });
+
 });
 
 mocha.describe('Assume role with web indentity tests', function() {

--- a/src/util/account_util.js
+++ b/src/util/account_util.js
@@ -302,11 +302,13 @@ function create_access_key_auth(req, account, is_iam) {
 function validate_assume_role_policy(policy) {
     const all_op_names = Object.values(OP_NAME_TO_ACTION);
     for (const statement of policy.statement) {
-        for (const principal of statement.principal) {
-            if (principal.unwrap() !== '*') {
-                const account = system_store.get_account_by_email(principal);
-                if (!account) {
-                    throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+        if (Array.isArray(statement.principal)) {
+            for (const principal of statement.principal) {
+                if (principal.unwrap() !== '*') {
+                    const account = system_store.get_account_by_email(principal);
+                    if (!account) {
+                        throw new RpcError('MALFORMED_POLICY', 'Invalid principal in policy', { detail: principal });
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Describe the Problem
NSFS (NC mode) did not support Federated principals in assume_role_policy, making it impossible to configure roles that allow AssumeRoleWithWebIdentity via LDAP (or future OIDC providers like Keycloak).

### Explain the Changes
1. common_api.js: Extended principal schema to accept { Federated: string | string[] } in addition to an array of emails.
2. manage_nsfs_validations.js: Updated validate_role_config to allow Federated principal objects; validates ARN format (arn:aws:iam:::<ldap-provider|oidc-provider>/...).
3. sts_sdk.js: authenticate_web_identity now returns provider_type and ldap_server (extracted from LDAP URI) in the identity info.
4. sts_rest.js: Added _parse_federated_arn and _is_federated_principal_fit to evaluate Federated principals against the authenticated identity's provider type and server.
5. test_sts.js: Added tests for Federated principal validation (accepted/rejected) and JWT validation flows (bad token, wrong secret, missing claims).

### Issues: Fixed #xxx / Gap #xxx
1. Gap - Federated principal support for LDAP in NC mode

### Testing Instructions:
1. Create an account with role_config containing principal: { Federated: "arn:aws:iam:::ldap-provider/<ldap-host>" }
2. Call AssumeRoleWithWebIdentity with a JWT signed using the configured jwt_secret containing user and password claims
3. Run integration tests: sudo env NC_CORETEST=true node --allow-natives-syntax ./node_modules/.bin/_mocha src/test/integration_tests/api/sts/test_sts.js


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IAM role trust policies now support `Principal.Federated` objects alongside existing email-based principals.
  * `AssumeRoleWithWebIdentity` can evaluate federated principals, including LDAP provider matching.

* **Bug Fixes**
  * Improved assume-role policy validation and principal matching to gracefully handle supported principal shapes and reject invalid ones.
  * Web identity authentication responses now return clearer LDAP provider details (type and server).

* **Tests**
  * Updated and expanded STS integration tests to cover federated principal success paths and additional failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->