### PR TITLE
Deep Archive | Update archive policy of a bucket

### DIFF
--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1615,6 +1615,8 @@ module.exports = {
                 // },
                 namespace: { $ref: '#/definitions/namespace_bucket_config' },
                 versioning: { $ref: 'common_api#/definitions/versioning' },
+                archive_policy: { $ref: '#/definitions/archive_policy' },
+                remove_archive_policy: { type: 'boolean' },
             }
         },
         policy_modes: {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1119,6 +1119,23 @@ class MDStore {
         return Boolean(obj);
     }
 
+    /**
+     * Checks whether a bucket contains any completed (non-deleted, non-uploading) objects
+     * whose storage_class matches one of the given values.
+     * @param {nb.ID} bucket_id - the bucket's _id
+     * @param {string[]} storage_classes - array of storage class values to match (e.g. ['DEEP_ARCHIVE', 'GLACIER'])
+     * @returns {Promise<boolean>} true if at least one matching object exists
+     */
+    async has_any_completed_objects_in_bucket_with_storage_class(bucket_id, storage_classes) {
+        const obj = await this._objects.findOne({
+            bucket: bucket_id,
+            storage_class: { $in: storage_classes },
+            deleted: null,
+            upload_started: null,
+        });
+        return Boolean(obj);
+    }
+
     async count_objects_of_bucket(bucket_id) {
         return this._objects.countDocuments({
             bucket: bucket_id,

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -867,7 +867,7 @@ async function update_bucket(req) {
 }
 
 
-function get_bucket_changes(req, update_request, bucket, tiering_policy) {
+async function get_bucket_changes(req, update_request, bucket, tiering_policy) {
     const changes = {
         updates: {},
         inserts: {},
@@ -905,6 +905,10 @@ function get_bucket_changes(req, update_request, bucket, tiering_policy) {
 
     if (!_.isUndefined(quota)) {
         get_bucket_changes_quota(req, bucket, quota, single_bucket_update, changes);
+    }
+
+    if (update_request.archive_policy || update_request.remove_archive_policy) {
+        await get_bucket_changes_archive_policy(req, bucket, update_request, single_bucket_update);
     }
 
     // if (spillover_sent) {
@@ -974,6 +978,27 @@ function get_bucket_changes_namespace(req, bucket, update_request, single_bucket
     }
 }
 
+/**
+ * Handles archive policy changes for a bucket update.
+ * When the bucket already has an archive policy, validates that no objects exist in
+ * archive storage classes (DEEP_ARCHIVE, GLACIER) before allowing the change.
+ * Supports both setting a new archive policy and removing an existing one via remove_archive_policy.
+ * @param {Object} req - the RPC request (carries system context for namespace resource lookup)
+ * @param {Object} bucket - the existing bucket document from system_store
+ * @param {Object} update_request - the update params from the API call
+ * @param {Object} single_bucket_update - the bucket update object to populate for system_store.make_changes
+ */
+async function get_bucket_changes_archive_policy(req, bucket, update_request, single_bucket_update) {
+    if (bucket.archive_policy) {
+        await _validate_no_archived_objects(bucket);
+    }
+    if (update_request.remove_archive_policy) {
+        single_bucket_update.$unset = { ...(single_bucket_update.$unset || {}), archive_policy: 1 };
+    } else {
+        single_bucket_update.archive_policy = resolve_archive_policy({ ...req, rpc_params: update_request });
+    }
+}
+
 function get_bucket_changes_quota(req, bucket, quota_config, single_bucket_update, changes) {
     const quota_event = {
         event: 'bucket.quota',
@@ -1024,6 +1049,24 @@ function resolve_archive_policy(req) {
 }
 
 /**
+ * Validates that a bucket has no completed objects stored in archive storage classes
+ * (DEEP_ARCHIVE or GLACIER). This check prevents archive policy changes or removal
+ * when objects have already been archived, as those objects would become inaccessible
+ * without the archive policy.
+ */
+async function _validate_no_archived_objects(bucket) {
+    const deep_archive_storage_classes = ['DEEP_ARCHIVE', 'GLACIER'];
+    const has_archived_objects = await MDStore.instance()
+        .has_any_completed_objects_in_bucket_with_storage_class(bucket._id, deep_archive_storage_classes);
+    dbg.log0(`_validate_no_archived_objects: has_archived_objects ${has_archived_objects}`);
+    if (has_archived_objects) {
+        throw new RpcError('FORBIDDEN',
+            `Cannot update or remove archive policy on bucket ${bucket.name.unwrap()}: ` +
+            `bucket contains objects in archive storage classes (${deep_archive_storage_classes.join(', ')})`);
+    }
+}
+
+/**
  *
  * GET_BUCKET_UPDATE
  *
@@ -1040,7 +1083,7 @@ async function update_buckets(req) {
         const bucket = find_bucket(req, update_request.name);
         const tiering_policy = update_request.tiering &&
             resolve_tiering_policy(req, update_request.tiering);
-        const { updates, inserts, events, alerts } = get_bucket_changes(
+        const { updates, inserts, events, alerts } = await get_bucket_changes(
             req, update_request, bucket, tiering_policy);
         _.mergeWith(insert_changes, inserts, (existing_inserts, new_inserts) => (existing_inserts || []).concat(new_inserts));
         _.mergeWith(update_changes, updates, (existing_inserts, new_inserts) => (existing_inserts || []).concat(new_inserts));

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -177,6 +177,98 @@ mocha.describe('md_store', function() {
             return md_store.has_any_completed_objects_in_bucket(bucket_id);
         });
 
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() returns false when no matching objects', async function() {
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, false);
+        });
+
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() returns true for DEEP_ARCHIVE object', async function() {
+            const archive_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: 'archived_obj_' + Date.now().toString(36),
+                storage_class: 'DEEP_ARCHIVE',
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(archive_obj);
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, true);
+            await md_store.update_object_by_id(archive_obj._id, { deleted: new Date() });
+        });
+
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() returns true for GLACIER object', async function() {
+            const glacier_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: 'glacier_obj_' + Date.now().toString(36),
+                storage_class: 'GLACIER',
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(glacier_obj);
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, true);
+            await md_store.update_object_by_id(glacier_obj._id, { deleted: new Date() });
+        });
+
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() ignores deleted objects', async function() {
+            const deleted_archive_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: 'deleted_archive_' + Date.now().toString(36),
+                storage_class: 'DEEP_ARCHIVE',
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(deleted_archive_obj);
+            await md_store.update_object_by_id(deleted_archive_obj._id, { deleted: new Date() });
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, false);
+        });
+
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() ignores uploading objects', async function() {
+            const uploading_archive_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: 'uploading_archive_' + Date.now().toString(36),
+                storage_class: 'DEEP_ARCHIVE',
+                upload_started: md_store.make_md_id(),
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(uploading_archive_obj);
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, false);
+            await md_store.update_object_by_id(uploading_archive_obj._id, { deleted: new Date() });
+        });
+
+        mocha.it('has_any_completed_objects_in_bucket_with_storage_class() ignores non-matching storage class', async function() {
+            const standard_obj = {
+                _id: md_store.make_md_id(),
+                system: system_id,
+                bucket: bucket_id,
+                key: 'standard_obj_' + Date.now().toString(36),
+                storage_class: 'STANDARD',
+                create_time: new Date(),
+                content_type: 'application/octet-stream',
+            };
+            await md_store.insert_object(standard_obj);
+            const result = await md_store.has_any_completed_objects_in_bucket_with_storage_class(
+                bucket_id, ['DEEP_ARCHIVE', 'GLACIER']);
+            assert.strictEqual(result, false);
+            await md_store.update_object_by_id(standard_obj._id, { deleted: new Date() });
+        });
+
         mocha.it('count_objects_of_bucket()', async function() {
             return md_store.count_objects_of_bucket(bucket_id);
         });


### PR DESCRIPTION
### Describe the Problem
Currently, update of archive policy on a bucket is not supported.

### Explain the Changes
1. Add archive_policy and remove_archive_policy to bucket_api and bucket_server.
2. Added validation for not allowing update/remove of archive_policy while objects exists on deep archive.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bucket updates now support setting an archive policy or removing the existing one.
* **Bug Fixes**
  * Archive-policy changes are now applied only after eligibility checks finish.
  * Bucket archive-policy updates are blocked when the bucket already contains completed objects in incompatible archive storage classes (e.g., DEEP_ARCHIVE/GLACIER).
* **Tests**
  * Added integration coverage for detecting whether a bucket has completed objects for specific storage classes (including cases with soft-deleted, uploading, and non-matching objects).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->