### PR TITLE
KeyCloak | Migrate roles from accounts to iam_role schema

### DIFF
--- a/src/test/integration_tests/internal/test_upgrade_scripts.js
+++ b/src/test/integration_tests/internal/test_upgrade_scripts.js
@@ -15,6 +15,8 @@ const upgrade_bucket_policy = require('../../../upgrade/upgrade_scripts/5.15.6/u
 const upgrade_bucket_policy_principal = require('../../../upgrade/upgrade_scripts/5.21.0/upgrade_bucket_policy_principal');
 const upgrade_bucket_cors = require('../../../upgrade/upgrade_scripts/5.19.0/upgrade_bucket_cors');
 const remove_mongo_pool = require('../../../upgrade/upgrade_scripts/5.20.0/remove_mongo_pool');
+const upgrade_iam_role = require('../../../upgrade/upgrade_scripts/5.23.0/upgrade_iam_roles');
+const { DEFAULT_MAX_SESSION_DURATION_SECS } = require('../../../endpoint/iam/iam_constants');
 const dbg = require('../../../util/debug_module')(__filename);
 const assert = require('assert');
 const mocha = require('mocha');
@@ -338,5 +340,409 @@ mocha.describe('test upgrade scripts', async function() {
                 email: iam_username,
         };
         await rpc_client.account.delete_account(iam_acc);
+    });
+});
+
+/*eslint max-lines-per-function: ["error", 500]*/
+mocha.describe('test upgrade_iam_role script 5.23.0', async function() {
+    // Account email addresses created specifically for this suite.
+    const role_account_no_role_config = 'role_acct_no_role_config@test.com';
+    const role_account_assume_role = 'role_acct_assume_role@test.com';
+    const role_account_deny = 'role_acct_deny@test.com';
+    const role_account_web_identity = 'role_acct_web_identity@test.com';
+    const role_account_multi_stmt = 'role_acct_multi_stmt@test.com';
+    const role_account_with_version = 'role_acct_with_version@test.com';
+    const role_account_no_version = 'role_acct_no_version@test.com';
+    const role_account_multi_actions = 'role_acct_multi_actions@test.com';
+    const role_account_unset_check = 'role_acct_unset_check@test.com';
+    const role_account_name_collision = 'role_acct_name_collision@test.com';
+
+    /**
+     * Create an account via rpc_client (which produces a schema-valid DB record),
+     * then inject the old-schema role_config directly via system_store.make_changes
+     * to simulate an account that existed before the 5.23.0 upgrade.
+     * Returns the stored account object.
+     */
+    async function _insert_account_with_role_config(email, role_config) {
+        const params = {
+            name: email,
+            email: email,
+            has_login: false,
+            s3_access: true,
+            default_resource: process.env.NC_CORETEST ? 's3_bucket_policy_nsr' : POOL_LIST[1].name,
+        };
+        await rpc_client.account.create_account(params);
+        const acc = system_store.data.accounts.find(a => a.email.unwrap() === email);
+        if (role_config) {
+            await system_store.make_changes({
+                update: { accounts: [{ _id: acc._id, role_config }] }
+            });
+        }
+        return system_store.data.accounts.find(a => a.email.unwrap() === email);
+    }
+
+    /** Remove an account by email and any iam_roles owned by it. */
+    async function _delete_account(email) {
+        try {
+            await rpc_client.account.delete_account({ email });
+        } catch (_err) {
+            // account may already be gone
+        }
+    }
+
+    mocha.before(async function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+        await system_store.load();
+    });
+
+    mocha.after(async function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+        for (const email of [
+            role_account_no_role_config,
+            role_account_assume_role,
+            role_account_deny,
+            role_account_web_identity,
+            role_account_multi_stmt,
+            role_account_with_version,
+            role_account_no_version,
+            role_account_multi_actions,
+            role_account_unset_check,
+            role_account_name_collision,
+        ]) {
+            await _delete_account(email);
+        }
+    });
+
+    mocha.it('accounts without role_config are skipped — no iam_role is created', async function() {
+        const acc = await _insert_account_with_role_config(role_account_no_role_config, undefined);
+        const roles_before = (system_store.data.iam_roles || []).filter(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const roles_after = (system_store.data.iam_roles || []).filter(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.strictEqual(roles_after.length, roles_before.length,
+            'No iam_role should be created for an account that has no role_config');
+    });
+
+    mocha.it('sts:AssumeRole allow — iam_role created with correct base fields and Effect Allow', async function() {
+        // The real-world action stored in assume_role_policy is always a STS action.
+        // The upgrade script passes actions through actions_map; sts:AssumeRole is not
+        // in the S3 actions_map so it maps to undefined — this is the existing script
+        // behaviour that we document here.
+        const acc = await _insert_account_with_role_config(role_account_assume_role, {
+            role_name: 'test-role-assume',
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRole'],
+                    principal: ['user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created for an account that has role_config');
+
+        // Verify role base fields
+        assert.strictEqual(role.name, 'test-role-assume');
+        assert.strictEqual(role.iam_path, '/');
+        assert.strictEqual(role.description, 'Migrated from account');
+        assert.strictEqual(role.max_session_duration, DEFAULT_MAX_SESSION_DURATION_SECS);
+        assert.deepStrictEqual(role.iam_role_policies, []);
+
+        // Verify statement mapping
+        const stmt = role.assume_role_policy_document.Statement[0];
+        assert.strictEqual(stmt.Effect, 'Allow');
+        assert.deepStrictEqual(stmt.Principal, { AWS: ['user@example.com'] });
+        assert.strictEqual(stmt.Sid, 'RoleMigration0');
+        assert.strictEqual(stmt.Action[0], "sts:AssumeRole",
+            'sts:AssumeRole is not in the S3 actions_map — Action entry is undefined');
+    });
+
+    mocha.it('sts:AssumeRole deny — Effect mapped to "Deny"', async function() {
+        const acc = await _insert_account_with_role_config(role_account_deny, {
+            role_name: 'test-role-deny',
+            assume_role_policy: {
+                statement: [{
+                    effect: 'deny',
+                    action: ['sts:AssumeRole'],
+                    principal: ['deny-user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+
+        const stmt = role.assume_role_policy_document.Statement[0];
+        assert.strictEqual(stmt.Effect, 'Deny',
+            '"deny" (lowercase) must be normalised to "Deny"');
+        assert.deepStrictEqual(stmt.Principal, { AWS: ['deny-user@example.com'] });
+    });
+
+    mocha.it('sts:AssumeRoleWithWebIdentity — migrated into iam_role with Effect Allow', async function() {
+        const acc = await _insert_account_with_role_config(role_account_web_identity, {
+            role_name: 'test-role-web-identity',
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRoleWithWebIdentity'],
+                    principal: ['webid-user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+
+        const stmt = role.assume_role_policy_document.Statement[0];
+        assert.strictEqual(stmt.Effect, 'Allow');
+        assert.deepStrictEqual(stmt.Principal, { AWS: ['webid-user@example.com'] });
+    });
+
+    mocha.it('multi-statement policy with mixed STS actions — all statements migrated, Effects preserved per-statement', async function() {
+        const acc = await _insert_account_with_role_config(role_account_multi_stmt, {
+            role_name: 'test-role-multi',
+            assume_role_policy: {
+                statement: [
+                    {
+                        effect: 'allow',
+                        action: ['sts:AssumeRole'],
+                        principal: ['user-a@example.com'],
+                    },
+                    {
+                        effect: 'deny',
+                        action: ['sts:AssumeRole'],
+                        principal: ['user-b@example.com'],
+                    },
+                    {
+                        effect: 'allow',
+                        action: ['sts:AssumeRoleWithWebIdentity'],
+                        principal: ['user-c@example.com'],
+                    },
+                ]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+
+        const stmts = role.assume_role_policy_document.Statement;
+        assert.strictEqual(stmts.length, 3, 'All three statements must be preserved');
+
+        assert.strictEqual(stmts[0].Effect, 'Allow');
+        assert.deepStrictEqual(stmts[0].Principal, { AWS: ['user-a@example.com'] });
+
+        assert.strictEqual(stmts[1].Effect, 'Deny');
+        assert.deepStrictEqual(stmts[1].Principal, { AWS: ['user-b@example.com'] });
+
+        assert.strictEqual(stmts[2].Effect, 'Allow');
+        assert.deepStrictEqual(stmts[2].Principal, { AWS: ['user-c@example.com'] });
+    });
+
+    mocha.it('policy with version field — Version propagated into the new policy document', async function() {
+        // The upgrade script reads role_config.version (truthy) and copies
+        // role_config.assume_role_policy.version into new_policy.Version.
+        const acc = await _insert_account_with_role_config(role_account_with_version, {
+            role_name: 'test-role-version',
+            version: '2012-10-17',
+            assume_role_policy: {
+                version: '2012-10-17',
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRole'],
+                    principal: ['version-user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+        assert.strictEqual(role.assume_role_policy_document.Version, '2012-10-17',
+            'Version must be copied from assume_role_policy.version when role_config.version is set');
+    });
+
+    mocha.it('policy without version field — Version is absent from the new policy document', async function() {
+        const acc = await _insert_account_with_role_config(role_account_no_version, {
+            role_name: 'test-role-no-version',
+            // No top-level role_config.version => the Version branch is not taken
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRole'],
+                    principal: ['no-version-user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+        assert.strictEqual(role.assume_role_policy_document.Version, undefined,
+            'Version must be absent when role_config.version is falsy');
+    });
+
+    mocha.it('multiple STS actions per statement — all actions passed through independently', async function() {
+        // A statement can list several STS actions; each is looked up in actions_map
+        // independently. Neither sts:AssumeRole nor sts:AssumeRoleWithWebIdentity is
+        // in the S3 actions_map, so both resolve to undefined — documented behaviour.
+        const acc = await _insert_account_with_role_config(role_account_multi_actions, {
+            role_name: 'test-role-multi-actions',
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: [
+                        'sts:AssumeRole',
+                        'sts:AssumeRoleWithWebIdentity',
+                        'sts:AssumeRoleWithSAML',
+                    ],
+                    principal: ['multi-action-user@example.com'],
+                }]
+            }
+        });
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const role = (system_store.data.iam_roles || []).find(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        );
+        assert.ok(role, 'iam_role must be created');
+
+        // Three actions in → three entries out (each undefined because STS actions
+        // are not present in the S3 actions_map used by the upgrade script)
+        const actions = role.assume_role_policy_document.Statement[0].Action;
+        assert.strictEqual(actions.length, 3,
+            'Action array length must match the number of actions in the old policy');
+        assert.strictEqual(actions[0], 'sts:AssumeRole');
+        assert.strictEqual(actions[1], 'sts:AssumeRoleWithWebIdentity');
+        assert.strictEqual(actions[2], 'sts:AssumeRoleWithSAML');
+    });
+
+    mocha.it('role_config is unset from account after migration', async function() {
+        const acc = await _insert_account_with_role_config(role_account_unset_check, {
+            role_name: 'test-role-unset-check',
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRole'],
+                    principal: ['unset-check@example.com'],
+                }]
+            }
+        });
+
+        // Confirm role_config is present before the migration
+        assert.ok(acc.role_config, 'role_config must exist on the account before migration');
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const acc_after = system_store.data.accounts.find(
+            a => a.email.unwrap() === role_account_unset_check
+        );
+        assert.ok(acc_after, 'account must still exist after migration');
+        assert.strictEqual(acc_after.role_config, undefined,
+            'role_config must be unset from the account after a successful migration');
+    });
+
+    mocha.it('re-running the script inserts exactly one more iam_role per qualifying account', async function() {
+        // The upgrade script does not guard against duplicate inserts.
+        // Running it twice produces exactly one additional role per qualifying account.
+        const acc = system_store.data.accounts.find(
+            a => a.email.unwrap() === role_account_assume_role
+        );
+        assert.ok(acc, 'account should still be present from earlier test');
+
+        const count_before = (system_store.data.iam_roles || []).filter(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        ).length;
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        const count_after = (system_store.data.iam_roles || []).filter(
+            r => r.owner && r.owner._id && r.owner._id.toString() === acc._id.toString()
+        ).length;
+        assert.strictEqual(count_after, count_before,
+            'Each run of the script inserts exactly one new iam_role per qualifying account');
+    });
+    mocha.it('existing iam_role with same name — migration is skipped, existing role is unchanged', async function() {
+        const collision_role_name = 'test-role-collision';
+
+        // Seed an account that has role_config pointing at collision_role_name.
+        const acc = await _insert_account_with_role_config(role_account_name_collision, {
+            role_name: collision_role_name,
+            assume_role_policy: {
+                statement: [{
+                    effect: 'allow',
+                    action: ['sts:AssumeRole'],
+                    principal: ['collision-user@example.com'],
+                }]
+            }
+        });
+
+        // Pre-create an iam_role in the store with the same name so the script
+        // finds a collision when it iterates over this account.
+        const pre_existing_role_id = system_store.new_system_store_id();
+        const sentinel_description = 'pre-existing-sentinel';
+        await system_store.make_changes({
+            insert: {
+                iam_roles: [{
+                    _id: pre_existing_role_id,
+                    owner: acc._id,
+                    name: collision_role_name,
+                    iam_path: '/',
+                    description: sentinel_description,
+                    max_session_duration: DEFAULT_MAX_SESSION_DURATION_SECS,
+                    assume_role_policy_document: { Statement: [] },
+                    iam_role_policies: [],
+                    creation_date: Date.now(),
+                }]
+            }
+        });
+
+        const roles_before = (system_store.data.iam_roles || []).filter(
+            r => r.name === collision_role_name
+        );
+        assert.strictEqual(roles_before.length, 1, 'exactly one role with that name must exist before migration');
+
+        await upgrade_iam_role.run({ dbg, system_store, system_server: null });
+
+        // The script must not insert a second role with the same name.
+        const roles_after = (system_store.data.iam_roles || []).filter(
+            r => r.name === collision_role_name
+        );
+        assert.strictEqual(roles_after.length, 1,
+            'migration must not create a duplicate role when a role with the same name already exists');
+
+        // The pre-existing role must remain exactly as it was — sentinel description
+        // is the proof that the script did not overwrite it.
+        const surviving_role = roles_after[0];
+        assert.strictEqual(surviving_role.description, sentinel_description,
+            'pre-existing role must be left unchanged by the migration');
     });
 });

--- a/src/upgrade/upgrade_scripts/5.23.0/upgrade_iam_roles.js
+++ b/src/upgrade/upgrade_scripts/5.23.0/upgrade_iam_roles.js
@@ -1,0 +1,100 @@
+/* Copyright (C) 2023 NooBaa */
+"use strict";
+
+const util = require('util');
+const _ = require('lodash');
+
+const SensitiveString = require('../../../util/sensitive_string');
+const { DEFAULT_MAX_SESSION_DURATION_SECS } = require('../../../endpoint/iam/iam_constants');
+
+// Note: If the role with same already exists in iam_role schema, 
+//      Script will skip the migration for that entry in account.role_config
+
+
+/**
+ * unwarp principle for Principal property
+ *
+ * @param {String[] | SensitiveString[]} principals 
+ * @returns {String[]}
+ */
+function unwrap_principal(principals) {
+    return principals.map(principal =>
+        (principal instanceof SensitiveString ? principal.unwrap() : principal)
+    );
+}
+
+async function run({ dbg, system_store, system_server }) {
+
+    try {
+        dbg.log0('Starting migration of roles from account schema to role schema...');
+        const new_roles = [];
+        const migrated_account_ids = [];
+
+        for (const account of system_store.data.accounts) {
+            //Do not update if there are no role_config.
+            if (!account.role_config) continue;
+
+            const role_config = account.role_config;
+            const new_policy = {};
+
+            const iam_role = system_store.data.iam_roles.find(
+                a => a.name === role_config.role_name
+            );
+            if (iam_role) {
+                dbg.log0(`IAM role with name ${role_config.role_name} already exists, Skipping the entry...`);
+                continue;
+            }
+
+            if (role_config.assume_role_policy.version) new_policy.Version = role_config.assume_role_policy.version;
+            new_policy.Statement = role_config.assume_role_policy.statement.map(statement => ({
+                Effect: statement.effect === 'allow' ? 'Allow' : 'Deny',
+                Action: statement.action,
+                Principal: { AWS: unwrap_principal(statement.principal) },
+                Sid: 'RoleMigration0'
+            }));
+
+            const max_session_duration = DEFAULT_MAX_SESSION_DURATION_SECS;
+            const new_role = _.omitBy({
+                _id: system_store.new_system_store_id(),
+                owner: account._id,
+                name: role_config.role_name,
+                iam_path: "/",
+                description: "Migrated from account",
+                max_session_duration: max_session_duration,
+                assume_role_policy_document: new_policy,
+                iam_role_policies: [],
+                creation_date: Date.now(),
+            }, _.isUndefined);
+
+            new_roles.push(new_role);
+            migrated_account_ids.push(account._id);
+        }
+
+        if (new_roles.length > 0) {
+            dbg.log0(`Migrate roles from account to role schema ${new_roles.map(r => util.inspect(r)).join(', ')}`);
+            await system_store.make_changes({
+                insert: {
+                    iam_roles: new_roles,
+                },
+                update: {
+                    accounts: migrated_account_ids.map(account_id => ({
+                        _id: account_id,
+                        $unset: { role_config: 1 }
+                    }))
+                }
+            });
+        } else {
+            dbg.log0('Migration of roles from account schema to role schema: no upgrade needed...');
+        }
+
+    } catch (err) {
+        dbg.error('Got error while migrating role policy:', err);
+        throw err;
+    }
+}
+
+
+module.exports = {
+    run,
+    description: 'Migrate roles from account to role schema'
+};


### PR DESCRIPTION
### Describe the Problem

Migrate roles from accounts to iam_role schema, 

### Explain the Changes
1. Migrate data from accounts.role_config to iam_roles schema, 
2. Remove object from accounts.role_config after the migration

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-9443

Note: If the role with same already exists in iam_role schema, Script will skip the migration for that entry in account.role_config

### Testing Instructions:
1. node ./node_modules/.bin/mocha ./src/test/integration_tests/internal/test_upgrade_scripts.js


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During upgrade, legacy IAM role settings are migrated into the centralized role management system, including assume-role policy details and default session duration.

* **Bug Fixes**
  * Assume-role policy `Effect` values are normalized for consistent IAM semantics.
  * Migration is idempotent: already-migrated accounts remain unchanged, and accounts with an existing role of the same name are skipped while preserving the pre-existing role.
  * Legacy role settings are cleared after successful migration.

* **Tests**
  * Added integration tests validating multiple assume-role scenarios, conditional propagation of policy `Version`, and safe re-running of the upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->