### PR TITLE
Add timeout to postgres client pool connection

### DIFF
--- a/config.js
+++ b/config.js
@@ -275,6 +275,7 @@ config.DB_TYPE = /** @type {nb.DBType} */ (process.env.DB_TYPE || 'postgres');
 
 config.POSTGRES_DEFAULT_MAX_CLIENTS = 10;
 config.POSTGRES_MD_MAX_CLIENTS = (process.env.LOCAL_MD_SERVER === 'true') ? 70 : 10;
+config.POSTGRES_CONNECTION_TIMEOUT_MS = 10 * 1000;
 
 //whether to use read-only postgres replica cluster
 //ro host is set by operator in process.env.POSTGRES_HOST_RO

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -1712,7 +1712,11 @@ class PostgresClient extends EventEmitter {
             new_pool_params.host = pool.host;
         }
         if (!pool.instance) {
-            pool.instance = new Pool({ ...new_pool_params, max: pool.size });
+            pool.instance = new Pool({
+                ...new_pool_params,
+                max: pool.size,
+                connectionTimeoutMillis: config.POSTGRES_CONNECTION_TIMEOUT_MS,
+            });
             if (!pool._error_listener) {
                 pool.error_listener = err => {
                     dbg.error(`got error on postgres pool ${name}`, err);


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Add psql pool connection timeout needed for failover cases so noobaa-core won't hang on system store load, that causes noobaa status to be stuck on connecting phase.

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://redhat.atlassian.net/browse/DFBUGS-8004

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection reliability by introducing a configurable connection timeout (10 seconds).
  * Database connection attempts will no longer hang indefinitely when the database is unreachable, and failures should appear more predictably and recoverable behavior is improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->