### PR TITLE
use the shorter querry name

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -34,6 +34,7 @@ const sql_and_conditions = (...conditions) => conditions.filter(Boolean).join(' 
 class MDStore {
 
     constructor(test_suffix = '') {
+        this._test_suffix = test_suffix;
         this._postgres_pool = 'md';
 
         this._objects = db_client.instance().define_collection({
@@ -2090,9 +2091,7 @@ class MDStore {
         const values = [String(obj_id), start_gte, start_lt, end_gt];
         const res = await db_client.instance().executeSQL(query, values, {
             preferred_pool: this._postgres_pool,
-            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
-                `find_parts_chunks_blocks_by_range:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
-                undefined,
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ? `fpcbb${this._test_suffix}` : undefined,
         });
         return _parse_mapping(res.rows[0]?.mapping, sorter);
     }
@@ -2156,9 +2155,7 @@ class MDStore {
         const values = [`${bucket_id}`, key, max_parts];
         const res = await db_client.instance().executeSQL(query, values, {
             preferred_pool: this._postgres_pool,
-            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
-                `find_object_with_mapping_by_key:${this._objects.name}:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
-                undefined,
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ? `fowmbk${this._test_suffix}` : undefined,
         });
         if (!res.rows.length) return null;
         const row = res.rows[0];

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -72,6 +72,7 @@ function build_lifecycle_filter_conditions(filters, start_idx) {
 class MDStore {
 
     constructor(test_suffix = '') {
+        this._test_suffix = test_suffix;
         this._postgres_pool = 'md';
 
         this._objects = db_client.instance().define_collection({
@@ -2284,9 +2285,8 @@ class MDStore {
         const values = [String(obj_id), start_gte, start_lt, end_gt];
         const res = await db_client.instance().executeSQL(query, values, {
             preferred_pool: this._postgres_pool,
-            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
-                `find_parts_chunks_blocks_by_range:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
-                undefined,
+            // fpcbb - find_parts_chunks_blocks_by_range
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ? `fpcbb${this._test_suffix}` : undefined,
         });
         return _parse_mapping(res.rows[0]?.mapping, sorter);
     }
@@ -2350,9 +2350,8 @@ class MDStore {
         const values = [`${bucket_id}`, key, max_parts];
         const res = await db_client.instance().executeSQL(query, values, {
             preferred_pool: this._postgres_pool,
-            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ?
-                `find_object_with_mapping_by_key:${this._objects.name}:${this._parts.name}:${this._chunks.name}:${this._blocks.name}` :
-                undefined,
+            // fowmbk - find_object_with_mapping_by_key
+            query_name: config.DB_PREPARED_STATEMENTS_ENABLED ? `fowmbk${this._test_suffix}` : undefined,
         });
         if (!res.rows.length) return null;
         const row = res.rows[0];


### PR DESCRIPTION
### Describe the Problem
because of code rabbit comment in #9590 I added a suffix to the query names to include the table names. the reason for that was that if for some reason the tables used  by this function would change the cached query would be wrong. since the table names are always the same this should never happen. I added it mainly as a defensive measure, just in case.
However postgress does not support queries above 63 characters, so it truncates the querry name and logs a warning.

### Explain the Changes
1. remove the suffix as it is purely defensive and causes the log warning
2. in case of tests add the test suffix to the query name to avoid collitions

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency for data lookups in certain database configurations.
  * Preserved existing query results and application behavior.
  * No new user-facing features or changes to the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->