### PR TITLE
NC | dynamic supplemental groups - dont throw when user not found

### DIFF
--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -310,11 +310,16 @@ class ObjectSDK {
             const cfg = this.requesting_account?.nsfs_account_config;
             const enable_dynamic = cfg && config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
             if (enable_dynamic && !cfg.supplemental_groups) {
-                const groups = await supplemental_groups_cache.get_with_cache({
-                    uid: this.requesting_account.nsfs_account_config.uid,
-                    name: distinguished_name,
-                    gid: this.requesting_account.nsfs_account_config.gid
-                });
+                let groups = [];
+                try {
+                    groups = await supplemental_groups_cache.get_with_cache({
+                        uid: this.requesting_account.nsfs_account_config.uid,
+                        name: distinguished_name,
+                        gid: this.requesting_account.nsfs_account_config.gid
+                    });
+                } catch (err) {
+                    dbg.error('load_requesting_account: supplemental groups lookup failed, proceeding without', err, err.code);
+                }
                 // Copy instead of mutating: this.requesting_account points at the shared account_cache
                 // entry (from get_with_cache above). Mutating it would persist supplemental_groups
                 // onto the cache, causing future requests to skip supplemental_groups_cache and

--- a/src/test/unit_tests/nsfs/test_nsfs_access.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_access.js
@@ -10,6 +10,7 @@ const fs_utils = require('../../../util/fs_utils');
 const native_fs_utils = require('../../../util/native_fs_utils');
 const nb_native = require('../../../util/nb_native');
 const ObjectSDK = require('../../../sdk/object_sdk');
+const { supplemental_groups_cache } = ObjectSDK;
 const test_utils = require('../../system_tests/test_utils');
 const fs = require('fs');
 const { TMP_PATH } = require('../../system_tests/test_utils');
@@ -18,6 +19,7 @@ const buffer_utils = require('../../../util/buffer_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const SensitiveString = require('../../../util/sensitive_string');
 const { RpcError } = require('../../../rpc');
+const sinon = require('sinon');
 
 const new_umask = process.env.NOOBAA_ENDPOINT_UMASK || 0o000;
 const old_umask = process.umask(new_umask);
@@ -242,6 +244,128 @@ mocha.describe('dynamic supplemental groups - get_fs_context flow', function() {
             assert.fail('readdir should fail with EACCES');
         } catch (err) {
             assert.equal(err.code, 'EACCES');
+        }
+    });
+});
+
+mocha.describe('supplemental groups lookup failures', function() {
+    const NON_EXISTING_UID = 98765;
+
+    mocha.it('get_supplemental_groups_by_uid returns empty array for a uid with no passwd entry', async function() {
+        const groups = await native_fs_utils.get_supplemental_groups_by_uid({ uid: NON_EXISTING_UID });
+        assert.deepStrictEqual(groups, []);
+    });
+
+    mocha.it('get_supplemental_groups_by_uid throws on native syscall failure', async function() {
+        const stub = sinon.stub(nb_native().fs, 'getSupplementalGroupsByUid').rejects(Object.assign(new Error('EIO'), { code: 'EIO' }));
+        try {
+            await assert.rejects(
+                native_fs_utils.get_supplemental_groups_by_uid({ uid: 1234 }),
+                err => err.code === 'EIO'
+            );
+        } finally {
+            stub.restore();
+        }
+    });
+
+    mocha.it('get_supplemental_groups_by_user throws on native syscall failure', async function() {
+        const stub = sinon.stub(nb_native().fs, 'getSupplementalGroupsByUserName').rejects(Object.assign(new Error('EIO'), { code: 'EIO' }));
+        try {
+            await assert.rejects(
+                native_fs_utils.get_supplemental_groups_by_user({ name: 'someuser', gid: 1000 }),
+                err => err.code === 'EIO'
+            );
+        } finally {
+            stub.restore();
+        }
+    });
+
+    mocha.it('supplemental_groups_cache caches empty result for unknown uid', async function() {
+        supplemental_groups_cache.invalidate({ uid: NON_EXISTING_UID });
+        const first = await supplemental_groups_cache.get_with_cache({ uid: NON_EXISTING_UID });
+        assert.deepStrictEqual(first, []);
+        const second = await supplemental_groups_cache.get_with_cache({ uid: NON_EXISTING_UID });
+        assert.deepStrictEqual(second, []);
+        supplemental_groups_cache.invalidate({ uid: NON_EXISTING_UID });
+    });
+
+    mocha.it('supplemental_groups_cache does not cache transient syscall failures', async function() {
+        const cache_key_uid = NON_EXISTING_UID + 2;
+        const stub = sinon.stub(nb_native().fs, 'getSupplementalGroupsByUid').rejects(Object.assign(new Error('EIO'), { code: 'EIO' }));
+        try {
+            supplemental_groups_cache.invalidate({ uid: cache_key_uid });
+            await assert.rejects(
+                supplemental_groups_cache.get_with_cache({ uid: cache_key_uid }),
+                err => err.code === 'EIO'
+            );
+            await assert.rejects(
+                supplemental_groups_cache.get_with_cache({ uid: cache_key_uid }),
+                err => err.code === 'EIO'
+            );
+            assert.strictEqual(stub.callCount, 2);
+        } finally {
+            stub.restore();
+            supplemental_groups_cache.invalidate({ uid: cache_key_uid });
+        }
+    });
+
+    mocha.it('load_requesting_account succeeds with empty supplemental_groups for unknown uid', async function() {
+        const dynamic_backup = config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+        try {
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
+            const test_access_key = 'test-unknown-uid-sg-key';
+            const account = {
+                nsfs_account_config: { uid: NON_EXISTING_UID, gid: 1000 },
+                access_keys: [{ access_key: test_access_key }],
+            };
+            const mock_bucketspace = {
+                read_account_by_access_key: async ({ access_key }) => {
+                    if (access_key === test_access_key) return account;
+                    throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+                },
+                is_nsfs_containerized_user_anonymous: () => false,
+            };
+            const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+            object_sdk.bucketspace = mock_bucketspace;
+            object_sdk.set_auth_token({ access_key: test_access_key });
+            await object_sdk.load_requesting_account({});
+            assert.deepStrictEqual(
+                object_sdk.requesting_account.nsfs_account_config.supplemental_groups,
+                []
+            );
+        } finally {
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_backup;
+        }
+    });
+
+    mocha.it('load_requesting_account succeeds with empty supplemental_groups on transient lookup failure', async function() {
+        const dynamic_backup = config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS;
+        const stub = sinon.stub(nb_native().fs, 'getSupplementalGroupsByUid').rejects(Object.assign(new Error('EIO'), { code: 'EIO' }));
+        try {
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = true;
+            const test_access_key = 'test-eio-sg-key';
+            const account = {
+                nsfs_account_config: { uid: NON_EXISTING_UID + 3, gid: 1000 },
+                access_keys: [{ access_key: test_access_key }],
+            };
+            const mock_bucketspace = {
+                read_account_by_access_key: async ({ access_key }) => {
+                    if (access_key === test_access_key) return account;
+                    throw new RpcError('NO_SUCH_ACCOUNT', 'Account not found');
+                },
+                is_nsfs_containerized_user_anonymous: () => false,
+            };
+            const object_sdk = new ObjectSDK({ rpc_client: { options: {} }, internal_rpc_client: {} });
+            object_sdk.bucketspace = mock_bucketspace;
+            object_sdk.set_auth_token({ access_key: test_access_key });
+            await object_sdk.load_requesting_account({});
+            assert.deepStrictEqual(
+                object_sdk.requesting_account.nsfs_account_config.supplemental_groups,
+                []
+            );
+        } finally {
+            stub.restore();
+            config.NSFS_ENABLE_DYNAMIC_SUPPLEMENTAL_GROUPS = dynamic_backup;
         }
     });
 });

--- a/src/util/native_fs_utils.js
+++ b/src/util/native_fs_utils.js
@@ -568,6 +568,7 @@ async function get_user_by_distinguished_name({ distinguished_name }) {
 /**
  * get_supplemental_groups_by_uid - gets supplemental groups by uid via getpwuid_r + getgrouplist.
  * Used by supplemental_groups_cache load when user data is not already available.
+ * Returns [] for NO_SUCH_USER so the cache can store a permanent empty result.
  */
 async function get_supplemental_groups_by_uid({ uid }) {
     try {
@@ -575,6 +576,10 @@ async function get_supplemental_groups_by_uid({ uid }) {
         const groups = await nb_native().fs.getSupplementalGroupsByUid(context, uid);
         return groups;
     } catch (err) {
+        if (err.message === 'NO_SUCH_USER') {
+            dbg.log0('native_fs_utils.get_supplemental_groups_by_uid: uid not found in passwd, uid', uid);
+            return [];
+        }
         dbg.error('native_fs_utils.get_supplemental_groups_by_uid: failed with error', err, err.code, uid);
         throw err;
     }
@@ -584,6 +589,7 @@ async function get_supplemental_groups_by_uid({ uid }) {
  * get_supplemental_groups_by_user - gets supplemental groups by username and primary gid.
  * Optimization: when user data is already available (e.g. from getpwnam for distinguished_name),
  * avoids redundant getpwuid_r lookup.
+ * Returns [] for NO_SUCH_USER so the cache can store a permanent empty result.
  */
 async function get_supplemental_groups_by_user({ name, gid }) {
     try {
@@ -591,7 +597,11 @@ async function get_supplemental_groups_by_user({ name, gid }) {
         const groups = await nb_native().fs.getSupplementalGroupsByUserName(context, name, gid);
         return groups;
     } catch (err) {
-        dbg.error('native_fs_utils.get_supplemental_groups_by_user: failed with error', err, err.code, name);
+        if (err.message === 'NO_SUCH_USER') {
+            dbg.log0('native_fs_utils.get_supplemental_groups_by_user: user not found, name', name, gid);
+            return [];
+        }
+        dbg.error('native_fs_utils.get_supplemental_groups_by_user: failed with error', err, err.code, name, gid);
         throw err;
     }
 }
@@ -645,7 +655,7 @@ async function _get_supplemental_groups_for_account(nsfs_account_config, fs_cont
         }
         return await get_supplemental_groups_by_uid({ uid: fs_context.uid });
     } catch (err) {
-        dbg.warn('get_supplemental_groups_for_account: failed to get supplemental groups', fs_context.uid, err);
+        dbg.error('get_supplemental_groups_for_account: failed to get supplemental groups', fs_context.uid, err, err.code);
         return undefined;
     }
 }


### PR DESCRIPTION
### Describe the Problem
When dynamic supplemental groups are enabled, get_supplemental_groups_by_uid throws on a UID with no passwd entry (NO_SUCH_USER). supplemental_groups_cache does not cache failures, so every request for that account retries the native lookup and fails again. causing repeated errors and unnecessary syscall load.

Additionally, the S3 path had no graceful handling for supplemental-group lookup failures, so any error could fail the whole request.


### Explain the Changes
1. Treat NO_SUCH_USER as a normal outcome: return [] instead of throwing, so the cache stores the result and stops retrying on every request.
2. Transient/syscall errors are not cached. other errors are logged and rethrown from the helpers, so supplemental_groups_cache does not store a misleading empty result.
3.  unit tests in test_nsfs_access.js covering the empty-array return and that the cache serves the cached [] on subsequent lookups.

### Issues: Fixed #xxx / Gap #xxx

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Treats “no such user” supplemental-group lookups as non-errors and returns an empty list.
  * When dynamic supplemental groups are enabled, request loading continues if supplemental-group retrieval fails, falling back to an empty set.
  * Supplemental-group caching now avoids caching transient lookup failures.
* **Tests**
  * Added unit tests covering missing-user, lookup failure vs unknown UID, cache hit/invalidation behavior, and dynamic supplemental-group loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->