### PR TITLE
S3 API | Head Bucket | Add archive policy custom header and a check if target bucket has GLACIER storage class

### DIFF
--- a/config.js
+++ b/config.js
@@ -521,6 +521,11 @@ config.LIFECYCLE_BATCH_SIZE = 1000;
 config.LIFECYCLE_SCHEDULE_MIN = 5 * 1000 * 60; // run every 5 minutes
 config.LIFECYCLE_ENABLED = true;
 
+/////////////////////
+// ARCHIVE CHECK   //
+/////////////////////
+config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+
 //////////////////////////
 // STATISTICS_COLLECTOR //
 /////////////////////////

--- a/src/api/pool_api.js
+++ b/src/api/pool_api.js
@@ -121,6 +121,9 @@ module.exports = {
                             },
                         }
                     },
+                    archive: {
+                        type: 'boolean',
+                    },
                 }
             },
             auth: {
@@ -578,6 +581,9 @@ module.exports = {
                 access_mode: {
                     type: 'string',
                     enum: ['READ_ONLY', 'READ_WRITE']
+                },
+                archive: {
+                    type: 'boolean'
                 },
             }
         },

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -7,6 +7,7 @@ const nb_native = require('../util/nb_native');
 const dbg = require('../util/debug_module')(__filename);
 const path = require('path');
 const config = require('../../config.js');
+const s3_utils = require('../endpoint/s3/s3_utils');
 const NamespaceFS = require('./namespace_fs');
 
 /**
@@ -48,7 +49,9 @@ class BucketSpaceNB {
     }
 
     async read_bucket(params) {
-        return this.rpc_client.bucket.read_bucket(params);
+        const bucket_info = await this.rpc_client.bucket.read_bucket(params);
+        bucket_info.supported_storage_classes = this._supported_storage_class(bucket_info.archive_policy);
+        return bucket_info;
     }
 
     async create_bucket(params, object_sdk) {
@@ -323,6 +326,20 @@ class BucketSpaceNB {
             if (err.code === 'ENOENT' || err.code === 'EACCES' || (err.code === 'EPERM' && err.message === 'Operation not permitted')) return false;
             throw err;
         }
+    }
+
+    /**
+     * returns a list of storage classes supported by this bucket based on its archive policy
+     * @param {object} archive_policy
+     * @returns {Array<string>}
+     */
+    _supported_storage_class(archive_policy) {
+        const storage_classes = [s3_utils.STORAGE_CLASS_STANDARD];
+        if (archive_policy?.deep_archive_resource) {
+            storage_classes.push(s3_utils.STORAGE_CLASS_GLACIER);
+            storage_classes.push(s3_utils.STORAGE_CLASS_DEEP_ARCHIVE);
+        }
+        return storage_classes;
     }
 
     is_nsfs_containerized_user_anonymous(token) {

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -126,9 +126,32 @@ function fix_error_object(err) {
     }
 }
 
+/**
+ * Attaches a deserialize-step middleware to the S3 client that captures raw
+ * response headers.  Returns a zero-argument getter that returns the captured
+ * headers after the next request completes.  The client should not be reused
+ * after the capture since the middleware remains attached.
+ *
+ * @param {object} s3 - S3 client returned by get_s3_client_v3_params
+ * @returns {() => Record<string, string>}
+ */
+function add_response_header_capture(s3) {
+    let response_headers = {};
+    s3.middlewareStack.add(
+        next => async args => {
+            const result = await next(args);
+            response_headers = result?.response?.headers || {};
+            return result;
+        },
+        { step: 'deserialize', name: 'captureHeaders' }
+    );
+    return () => response_headers;
+}
+
 // EXPORTS
 exports.get_s3_client_v3_params = get_s3_client_v3_params;
 exports.change_s3_client_params_to_v2_structure = change_s3_client_params_to_v2_structure;
 exports.get_sdk_class_str = get_sdk_class_str;
 exports.fix_error_object = fix_error_object;
 exports.get_requestHandler_with_suitable_agent = get_requestHandler_with_suitable_agent;
+exports.add_response_header_capture = add_response_header_capture;

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1045,6 +1045,12 @@ function resolve_archive_policy(req) {
     if (!nsr) {
         throw new RpcError('INVALID_ARCHIVE_RESOURCE', `Namespace resource not found: ${resource_name}`);
     }
+    if (!nsr.archive) {
+        throw new RpcError(
+            'INVALID_ARCHIVE_RESOURCE',
+            `Namespace resource "${resource_name}" must have archive:true to be used as a deep archive resource`
+        );
+    }
     return { deep_archive_resource: { resource: nsr._id, path: resource_path } };
 }
 
@@ -1060,7 +1066,7 @@ async function _validate_no_archived_objects(bucket) {
         .has_any_completed_objects_in_bucket_with_storage_class(bucket._id, deep_archive_storage_classes);
     dbg.log0(`_validate_no_archived_objects: has_archived_objects ${has_archived_objects}`);
     if (has_archived_objects) {
-        throw new RpcError('FORBIDDEN',
+        throw new RpcError('BUCKET_HAS_ARCHIVED_OBJECTS',
             `Cannot update or remove archive policy on bucket ${bucket.name.unwrap()}: ` +
             `bucket contains objects in archive storage classes (${deep_archive_storage_classes.join(', ')})`);
     }
@@ -2735,3 +2741,6 @@ exports.get_vector_index = get_vector_index;
 exports.list_vector_indices = list_vector_indices;
 exports.delete_vector_index = delete_vector_index;
 exports.update_rows_since_index = update_rows_since_index;
+
+// Exported for unit testing only
+exports._resolve_archive_policy = resolve_archive_policy;

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -23,6 +23,7 @@ const HistoryDataStore = require('../analytic_services/history_data_store').Hist
 const IoStatsStore = require('../analytic_services/io_stats_store').IoStatsStore;
 const pool_ctrls = require('./pool_controllers');
 const { KubeStore } = require('../kube-store.js');
+const noobaa_s3_client = require('../../sdk/noobaa_s3_client/noobaa_s3_client');
 
 
 const POOL_STORAGE_DEFAULTS = Object.freeze({
@@ -119,16 +120,17 @@ function new_pool_defaults(name, system_id, resource_type, pool_node_type, owner
     };
 }
 
-function new_namespace_resource_defaults(name, system_id, account_id, connection, nsfs_config, access_mode) {
-    return {
+function new_namespace_resource_defaults(name, system_id, account_id, connection, nsfs_config, access_mode, archive) {
+    return _.omitBy({
         _id: system_store.new_system_store_id(),
         system: system_id,
         account: account_id,
         name,
         connection,
         nsfs_config,
-        access_mode
-    };
+        access_mode,
+        archive,
+    }, _.isUndefined);
 }
 
 async function create_hosts_pool(req) {
@@ -269,13 +271,63 @@ async function get_agent_install_conf(system, pool, account, routing_hint) {
     return Buffer.from(install_string).toString('base64');
 }
 
+/**
+ * Validates that the target bucket on a cloud connection supports returns x-noobaa-available-storage-classes
+ * header and has GLACIER storage class, which is required for a deep-archive namespace resource.
+ * @param {object} connection - unencrypted cloud connection from the account credentials cache
+ * @param {string} target_bucket - S3 bucket name to validate
+ */
+async function _check_archive_target_bucket(connection, target_bucket) {
+    const s3_params = {
+        endpoint: connection.endpoint,
+        credentials: {
+            accessKeyId: connection.access_key.unwrap(),
+            secretAccessKey: connection.secret_key.unwrap(),
+        },
+        signatureVersion: cloud_utils.get_s3_endpoint_signature_ver(connection.endpoint, connection.auth_method),
+        requestHandler: noobaa_s3_client.get_requestHandler_with_suitable_agent(connection.endpoint),
+        region: connection.region || config.DEFAULT_REGION,
+        forcePathStyle: true,
+    };
+    const s3 = noobaa_s3_client.get_s3_client_v3_params(s3_params);
+    const get_headers = noobaa_s3_client.add_response_header_capture(s3);
+    const timeout_err = Object.assign(new Error('Operation timeout'), { code: 'OperationTimeout' });
+    try {
+        await P.timeout(
+            15 * 1000,
+            s3.headBucket({ Bucket: target_bucket }),
+            () => timeout_err
+        );
+    } catch (err) {
+        dbg.warn('_check_archive_target_bucket: headBucket failed for', target_bucket,
+            ` error: ${err}, message: ${err.message}`
+        );
+        throw new RpcError('ARCHIVE_TARGET_ERROR',
+            `HeadBucket failed for archive target bucket ${target_bucket}: ${err.message}`
+        );
+    }
+    const storage_classes = get_headers()['x-noobaa-available-storage-classes'] || '';
+    if (!storage_classes.includes('GLACIER')) {
+        throw new RpcError(
+            'INVALID_ARCHIVE_TARGET',
+            `Target bucket ${target_bucket} does not support GLACIER storage class`
+        );
+    }
+}
+
 async function create_namespace_resource(req) {
     req.rpc_params.access_mode = req.rpc_params.access_mode || 'READ_WRITE';
     const name = req.rpc_params.name;
     let namespace_resource;
     if (req.rpc_params.nsfs_config) {
+        if (req.rpc_params.archive) {
+            throw new RpcError(
+                'INVALID_ARCHIVE_RESOURCE',
+                'An archive namespace resource must be a cloud resource, not an NSFS resource'
+            );
+        }
         namespace_resource = new_namespace_resource_defaults(name, req.system._id, req.account._id, undefined, req.rpc_params.nsfs_config,
-            req.rpc_params.access_mode);
+            req.rpc_params.access_mode, req.rpc_params.archive);
         const already_used_by = system_store.data.namespace_resources.find(cur_nsr => cur_nsr.nsfs_config &&
             (cur_nsr.nsfs_config.fs_root_path === namespace_resource.nsfs_config.fs_root_path));
         if (already_used_by) {
@@ -317,7 +369,7 @@ async function create_namespace_resource(req) {
             region: connection.region,
             azure_log_access_keys,
             azure_sts_credentials
-        }, _.isUndefined), undefined, req.rpc_params.access_mode);
+        }, _.isUndefined), undefined, req.rpc_params.access_mode, req.rpc_params.archive);
 
         const cloud_buckets = await server_rpc.client.bucket.get_cloud_buckets({
             connection: connection.name,
@@ -335,6 +387,9 @@ async function create_namespace_resource(req) {
         if (already_used_by) {
             dbg.error(`This endpoint is already being used by a ${already_used_by.usage_type}: ${already_used_by.source_name}`);
             throw new RpcError('IN_USE', 'Target already in use');
+        }
+        if (req.rpc_params.archive && config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED) {
+            await _check_archive_target_bucket(connection, req.rpc_params.target_bucket);
         }
     }
     if (req.rpc_params.namespace_store) {
@@ -1072,7 +1127,8 @@ function get_namespace_resource_info(namespace_resource) {
         name: namespace_resource.name,
         mode: calc_namespace_resource_mode(namespace_resource),
         undeletable: check_namespace_resource_deletion(namespace_resource),
-        access_mode: namespace_resource.access_mode
+        access_mode: namespace_resource.access_mode,
+        archive: namespace_resource.archive,
     }, _.isUndefined);
     return info;
 }

--- a/src/server/system_services/schemas/namespace_resource_schema.js
+++ b/src/server/system_services/schemas/namespace_resource_schema.js
@@ -98,6 +98,9 @@ module.exports = {
                     type: 'boolean'
                 }
             }
+        },
+        archive: {
+            type: 'boolean'
         }
     }
 };

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -1867,6 +1867,88 @@ mocha.describe('s3_ops', function() {
         };
         test_object_ops(BKT7, 'namespace', undefined, options, skip);
     });
+
+    mocha.describe('head-bucket-archive-policy', function() {
+        this.timeout(60000);
+        const ARCHIVE_CONNECTION = 'archive_test_connection';
+        const ARCHIVE_NSR = 'archive_test_nsr';
+        const ARCHIVE_TARGET_BUCKET = 'archive-target-bucket';
+        const ARCHIVE_BUCKET = 'archive-policy-bucket';
+        const NO_ARCHIVE_BUCKET = 'no-archive-policy-bucket';
+
+        mocha.before(async function() {
+            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+            await s3.createBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
+            await rpc_client.account.add_external_connection({
+                name: ARCHIVE_CONNECTION,
+                endpoint: coretest.get_http_address(),
+                endpoint_type: 'S3_COMPATIBLE',
+                auth_method: 'AWS_V4',
+                identity: s3_client_params.credentials.accessKeyId,
+                secret: s3_client_params.credentials.secretAccessKey,
+            });
+            await rpc_client.pool.create_namespace_resource({
+                name: ARCHIVE_NSR,
+                connection: ARCHIVE_CONNECTION,
+                target_bucket: ARCHIVE_TARGET_BUCKET,
+                archive: true,
+            });
+            await rpc_client.bucket.create_bucket({
+                name: ARCHIVE_BUCKET,
+                archive_policy: {
+                    deep_archive_resource: { resource: ARCHIVE_NSR },
+                },
+            });
+            await rpc_client.bucket.create_bucket({ name: NO_ARCHIVE_BUCKET });
+        });
+
+        mocha.after(async function() {
+            await rpc_client.bucket.delete_bucket({ name: ARCHIVE_BUCKET });
+            await rpc_client.bucket.delete_bucket({ name: NO_ARCHIVE_BUCKET });
+            await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+            await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+            await s3.deleteBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
+            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+        });
+
+        mocha.it('should return supported storage classes header with GLACIER and DEEP_ARCHIVE for bucket with archive policy', async function() {
+            let response_headers;
+            s3.middlewareStack.add(
+                next => async args => {
+                    const result = await next(args);
+                    response_headers = result.response.headers;
+                    return result;
+                },
+                { step: 'deserialize', name: 'captureArchiveHeaders' }
+            );
+            await s3.headBucket({ Bucket: ARCHIVE_BUCKET });
+            s3.middlewareStack.remove('captureArchiveHeaders');
+            const storage_classes = response_headers['x-noobaa-available-storage-classes'];
+            assert.ok(storage_classes, 'expected x-noobaa-available-storage-classes header to be set');
+            assert.ok(storage_classes.includes('STANDARD'), 'expected STANDARD in supported storage classes');
+            assert.ok(storage_classes.includes('GLACIER'), 'expected GLACIER in supported storage classes');
+            assert.ok(storage_classes.includes('DEEP_ARCHIVE'), 'expected DEEP_ARCHIVE in supported storage classes');
+        });
+
+        mocha.it('should not return archive storage classes for bucket without archive policy', async function() {
+            let response_headers;
+            s3.middlewareStack.add(
+                next => async args => {
+                    const result = await next(args);
+                    response_headers = result.response.headers;
+                    return result;
+                },
+                { step: 'deserialize', name: 'captureNoArchiveHeaders' }
+            );
+            await s3.headBucket({ Bucket: NO_ARCHIVE_BUCKET });
+            s3.middlewareStack.remove('captureNoArchiveHeaders');
+            const storage_classes = response_headers['x-noobaa-available-storage-classes'];
+            if (storage_classes) {
+                assert.ok(!storage_classes.includes('GLACIER'), 'expected no GLACIER in supported storage classes');
+                assert.ok(!storage_classes.includes('DEEP_ARCHIVE'), 'expected no DEEP_ARCHIVE in supported storage classes');
+            }
+        });
+    });
 });
 
 function is_namespace_blob_bucket(bucket_type, remote_endpoint_type) {

--- a/src/test/unit_tests/api/s3/test_bucketspace_nb.test.js
+++ b/src/test/unit_tests/api/s3/test_bucketspace_nb.test.js
@@ -1,0 +1,72 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+jest.mock('../../../../util/nb_native', () => () => ({
+    fs: {
+        set_debug_level: () => undefined,
+        set_log_config: () => undefined,
+        checkAccess: () => undefined,
+    },
+}));
+
+const BucketSpaceNB = require('../../../../sdk/bucketspace_nb');
+const s3_utils = require('../../../../endpoint/s3/s3_utils');
+
+function create_mock_rpc_client(bucket_response) {
+    return {
+        bucket: {
+            read_bucket: async () => bucket_response,
+        },
+    };
+}
+
+describe('BucketSpaceNB', () => {
+    describe('read_bucket', () => {
+        it('should return GLACIER and DEEP_ARCHIVE when archive_policy has deep_archive_resource', async () => {
+            const bucket_response = {
+                name: 'test-bucket',
+                archive_policy: {
+                    deep_archive_resource: {
+                        resource: 'my-archive-nsr'
+                    }
+                }
+            };
+            const bs = new BucketSpaceNB({
+                rpc_client: create_mock_rpc_client(bucket_response),
+            });
+            const result = await bs.read_bucket({ name: 'test-bucket' });
+            expect(result.supported_storage_classes).toEqual([
+                s3_utils.STORAGE_CLASS_STANDARD,
+                s3_utils.STORAGE_CLASS_GLACIER,
+                s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            ]);
+        });
+
+        it('should return only STANDARD when archive_policy has no deep_archive_resource', async () => {
+            const bucket_response = {
+                name: 'test-bucket',
+                archive_policy: {}
+            };
+            const bs = new BucketSpaceNB({
+                rpc_client: create_mock_rpc_client(bucket_response),
+            });
+            const result = await bs.read_bucket({ name: 'test-bucket' });
+            expect(result.supported_storage_classes).toEqual([
+                s3_utils.STORAGE_CLASS_STANDARD,
+            ]);
+        });
+
+        it('should return only STANDARD when bucket has no archive_policy', async () => {
+            const bucket_response = {
+                name: 'test-bucket',
+            };
+            const bs = new BucketSpaceNB({
+                rpc_client: create_mock_rpc_client(bucket_response),
+            });
+            const result = await bs.read_bucket({ name: 'test-bucket' });
+            expect(result.supported_storage_classes).toEqual([
+                s3_utils.STORAGE_CLASS_STANDARD,
+            ]);
+        });
+    });
+});

--- a/src/test/unit_tests/internal/test_deep_archive_s3.test.js
+++ b/src/test/unit_tests/internal/test_deep_archive_s3.test.js
@@ -1,0 +1,152 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const pool_server = require('../../../server/system_services/pool_server');
+const bucket_server = require('../../../server/system_services/bucket_server');
+const { RpcError } = require('../../../rpc');
+
+// _resolve_archive_policy is exported from bucket_server for unit testing.
+const resolve_archive_policy = bucket_server._resolve_archive_policy;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function get_thrown(fn) {
+    try {
+        fn();
+    } catch (err) {
+        return err;
+    }
+    throw new Error('Expected function to throw but it did not');
+}
+
+function make_nsr(id, archive_flag) {
+    return {
+        _id: id,
+        name: 'nsr-' + id,
+        archive: archive_flag,
+        access_mode: 'READ_WRITE',
+        nsfs_config: { fs_root_path: '/data' },
+        system: {
+            buckets_by_name: {},
+            vector_buckets_by_name: {},
+        },
+    };
+}
+
+function make_archive_req(resource_name, path_value, nsr_map = {}) {
+    return {
+        system: {
+            _id: 'sys-id',
+            namespace_resources_by_name: nsr_map,
+        },
+        rpc_params: {
+            archive_policy: {
+                deep_archive_resource: {
+                    resource: resource_name,
+                    path: path_value,
+                },
+            },
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// get_namespace_resource_info – archive field exposure
+// ---------------------------------------------------------------------------
+
+describe('get_namespace_resource_info – archive field', () => {
+    it('includes archive:true when the NSR has archive set to true', () => {
+        const info = pool_server.get_namespace_resource_info(make_nsr('id-1', true));
+        expect(info.archive).toBe(true);
+    });
+
+    it('includes archive:false when the NSR has archive set to false', () => {
+        // archive:false is falsy but not undefined, so _.omitBy(_.isUndefined) preserves it
+        const info = pool_server.get_namespace_resource_info(make_nsr('id-2', false));
+        expect(info.archive).toBe(false);
+    });
+
+    it('omits archive when the NSR does not have the archive field', () => {
+        const nsr = make_nsr('id-3', undefined);
+        delete nsr.archive;
+        const info = pool_server.get_namespace_resource_info(nsr);
+        expect(info.archive).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolve_archive_policy – validation
+// ---------------------------------------------------------------------------
+
+describe('resolve_archive_policy – missing deep_archive_resource', () => {
+    it('throws INVALID_ARCHIVE_POLICY when deep_archive_resource is absent', () => {
+        const req = {
+            system: { namespace_resources_by_name: {} },
+            rpc_params: { archive_policy: {} },
+        };
+        const err = get_thrown(() => resolve_archive_policy(req));
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('INVALID_ARCHIVE_POLICY');
+    });
+});
+
+describe('resolve_archive_policy – NSR not found', () => {
+    it('throws INVALID_ARCHIVE_RESOURCE when the NSR does not exist in the system', () => {
+        const err = get_thrown(() => resolve_archive_policy(make_archive_req('nonexistent-nsr', '/data', {})));
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('INVALID_ARCHIVE_RESOURCE');
+        expect(err.message).toContain('nonexistent-nsr');
+    });
+});
+
+describe('resolve_archive_policy – archive flag guard', () => {
+    it('throws INVALID_ARCHIVE_RESOURCE when NSR exists but archive is undefined', () => {
+        const nsr = make_nsr('id-1', undefined);
+        const err = get_thrown(() => resolve_archive_policy(make_archive_req('nsr-id-1', '/deep', { 'nsr-id-1': nsr })));
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('INVALID_ARCHIVE_RESOURCE');
+        expect(err.message).toContain('archive:true');
+    });
+
+    it('throws INVALID_ARCHIVE_RESOURCE when NSR exists but archive is false', () => {
+        const nsr = make_nsr('id-2', false);
+        const err = get_thrown(() => resolve_archive_policy(make_archive_req('nsr-id-2', '/deep', { 'nsr-id-2': nsr })));
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('INVALID_ARCHIVE_RESOURCE');
+        expect(err.message).toContain('archive:true');
+    });
+
+    it('throws INVALID_ARCHIVE_RESOURCE when NSR exists but archive is null', () => {
+        const nsr = make_nsr('id-3', null);
+        const err = get_thrown(() => resolve_archive_policy(make_archive_req('nsr-id-3', '/deep', { 'nsr-id-3': nsr })));
+        expect(err).toBeInstanceOf(RpcError);
+        expect(err.rpc_code).toBe('INVALID_ARCHIVE_RESOURCE');
+        expect(err.message).toContain('archive:true');
+    });
+});
+
+describe('resolve_archive_policy – happy path', () => {
+    it('returns resolved archive policy when NSR has archive:true', () => {
+        const nsr = make_nsr('id-4', true);
+        const result = resolve_archive_policy(make_archive_req('nsr-id-4', '/deep/path', { 'nsr-id-4': nsr }));
+        expect(result).toEqual({
+            deep_archive_resource: { resource: 'id-4', path: '/deep/path' },
+        });
+    });
+
+    it('returns resolved archive policy with undefined path when path is omitted', () => {
+        const nsr = make_nsr('id-5', true);
+        const result = resolve_archive_policy(make_archive_req('nsr-id-5', undefined, { 'nsr-id-5': nsr }));
+        expect(result).toEqual({
+            deep_archive_resource: { resource: 'id-5', path: undefined },
+        });
+    });
+
+    it('uses the NSR _id in the resolved policy, not the name', () => {
+        const nsr = make_nsr('object-id-123', true);
+        const result = resolve_archive_policy(make_archive_req('nsr-object-id-123', '/path', { 'nsr-object-id-123': nsr }));
+        expect(result.deep_archive_resource.resource).toBe('object-id-123');
+    });
+});

--- a/src/test/unit_tests/util_functions_tests/test_s3_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_s3_utils.test.js
@@ -116,6 +116,30 @@ describe('s3_utils', () => {
         });
     });
 
+    describe('set_response_supported_storage_classes', () => {
+        it('should set empty header when no storage classes provided', () => {
+            const res = create_dummy_nb_response();
+            s3_utils.set_response_supported_storage_classes(res);
+            expect(res.headers['x-noobaa-available-storage-classes']).toBe('');
+        });
+
+        it('should set header with single storage class', () => {
+            const res = create_dummy_nb_response();
+            s3_utils.set_response_supported_storage_classes(res, ['STANDARD']);
+            expect(res.headers['x-noobaa-available-storage-classes']).toBe('STANDARD');
+        });
+
+        it('should set header with archive storage classes', () => {
+            const res = create_dummy_nb_response();
+            s3_utils.set_response_supported_storage_classes(res, [
+                s3_utils.STORAGE_CLASS_STANDARD,
+                s3_utils.STORAGE_CLASS_GLACIER,
+                s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            ]);
+            expect(res.headers['x-noobaa-available-storage-classes']).toBe('STANDARD,GLACIER,DEEP_ARCHIVE');
+        });
+    });
+
     describe('parse_body_public_access_block', () => {
         it('should throw error if config has ACL', () => {
             const req = {


### PR DESCRIPTION
### Describe the Problem
Add supported storage classes to custom header of head bucket in bucketspace_nb as we have in bucketspace_fs.

### Explain the Changes
1. Added custom header called `'x-noobaa-available-storage-classes'` that represents the supported storage class.
2.  Added to namespace_resource schema an archive boolean field, also added this field to pool_api  and to create_namespace_resource() params.
3. Added a check in create_namespace_resource that is running headBucket on the archive target bucket and it returns `x-noobaa-supported-storage-class` header and has GLACIER in it.
4.
### Issues: Fixed #xxx / Gap #xxx
1. Gap - since starting from this PR, also regular noobaa will return `x-noobaa-supported-storage-class` and GLACIER if there is an archive_policy on the bucket, there is an edge case where the customer might use a non dbs3 noobaa bucket that also has an archive policy.

### Testing Instructions:
Manual - 
1. Install NooBaa
3. create an archive namespacestore - `nb namespacestore create s3-compatible nss1 --access-key=<access-key>--secret-key=<secret-key> --endpoint=https://<endpoint-pod-ip>:6443 --target-bucket=first.bucket --archive`
5. create a bucketclass with archive policy - `nb bucketclass create placement-bucketclass bc1 --backingstores=noobaa-default-backing-store --deep-archive-resource=nss1`
6. create an obc on top of the bucketclass from step 3 - `nb obc create obc1 --exact --bucketclass=bc1`
7. create an s3api alias for the obc - `alias s3api='AWS_ACCESS_KEY_ID=<obc-access-key> AWS_SECRET_ACCESS_KEY=<obc-secret-key> aws s3api --no-verify-ssl --endpoint-url https://127.0.0.1:10443'`
8. port forward s3 svc on a different tab - `kubectl port-forward svc/s3 10443:443`
9. call head-bucket - `s3api head-bucket --bucket obc1 --debug`
10. search in the output for - `'x-noobaa-available-storage-classes': 'STANDARD, GLACIER, DEEP_ARCHIVE'`

auto - 
1. `npx jest src/test/unit_tests/api/s3/test_bucketspace_nb.test.js`
2. `node  ./node_modules/.bin/_mocha src/test/utils/index/index.js --grep "s3_ops"`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional archive-enabled flag for namespace resources (API + schema).
  * S3 responses now expose available storage classes, and bucket reads include supported storage classes derived from the archive policy.
* **Bug Fixes**
  * Enforced that deep-archive policies only resolve against archive-enabled namespace resources.
  * Updated bucket update/remove error handling when archived objects already exist (more specific error code).
* **Tests**
  * Added unit and integration coverage for storage-class headers, bucket storage-class reporting, namespace resource info, and archive policy validation.
* **Chores**
  * Added a config flag to enable archive target bucket capability checking by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->