### PR TITLE
Added support for iam role policy validation

### DIFF
--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -71,6 +71,40 @@ function create_arn_for_role(account_id, role_name, iam_path) {
 }
 
 /**
+ * parse_role_arn extracts account id and role name from a role ARN
+ * @param {string} role_arn
+ * @returns {{account_id?: string, role_name?: string, error?: string}}
+ */
+function parse_role_arn(role_arn) {
+    if (!role_arn) return { error: 'MISSING_ROLE_ARN' };
+    const account_id = role_arn.split(':')[4];
+    const role_name = role_arn.slice(role_arn.lastIndexOf('/') + 1);
+    if (!account_id || !role_name) return { error: 'INVALID_ROLE_ARN' };
+    return { account_id, role_name };
+}
+
+/**
+ * resolve_iam_role_by_arn resolves IAM role entity from a role ARN
+ * @param {string} role_arn
+ * @returns {Promise<{iam_role?: object, account_id?: string, role_name?: string, error?: string}>}
+ */
+async function resolve_iam_role_by_arn(role_arn) {
+    const parsed = parse_role_arn(role_arn);
+    if (parsed.error) return { error: parsed.error };
+
+    const { account_id, role_name } = parsed;
+    // TODO: switch this role lookup to the IAM role cache, once cache support is implemented
+    // Lazy-load system_store so NC CLI startup does not pull it in
+    const system_store = require('../../server/system_services/system_store').get_instance();
+    const iam_roles_by_owner = system_store.data?.iam_roles_by_owner || {};
+    const account_roles = iam_roles_by_owner[account_id] || [];
+    const iam_role = _.find(account_roles, role => !role.deleted && role.name === role_name);
+    if (!iam_role) return { error: 'NO_SUCH_ROLE', account_id, role_name };
+
+    return { iam_role, account_id, role_name };
+}
+
+/**
  * get_action_message_title returns the full action name
  * @param {string} action (The action name as it is in AccountSpace)
  */
@@ -93,10 +127,11 @@ function check_iam_path_was_set(iam_path) {
  * @param {object} user_account
  * @param {string|string[]} method
  * @param {string} resource_arn
+ * @param {string} [principal_arn]
  */
-function create_detailed_message_for_iam_user_access(user_account, method, resource_arn) {
+function create_detailed_message_for_iam_user_access(user_account, method, resource_arn, principal_arn) {
     const owner_account_id = get_owner_account_id(user_account);
-    const arn_for_requesting_account = create_arn_for_user(owner_account_id,
+    const arn_for_requesting_account = principal_arn || create_arn_for_user(owner_account_id,
         user_account.name.unwrap(), user_account.iam_path);
     const full_action_name = Array.isArray(method) && method.length > 1 ? method[1] : method; // special case for get_object_attributes
 
@@ -1239,11 +1274,46 @@ function _get_resource_arn_from_req(req, bucket_name, service) {
 }
 
 /**
+ * _get_assumed_role_session_info detects assumed-role session from the session token without resolving the role
+ * @param {object} req
+ * @returns {{is_assumed_role_session: boolean, assumed_role_arn?: string}}
+ */
+function _get_assumed_role_session_info(req) {
+    const session_token = req.session_token;
+    const is_assumed_role_session = Boolean(
+        session_token?.assumed_role_access_key && session_token?.assumed_role_arn
+    );
+    return {
+        is_assumed_role_session,
+        assumed_role_arn: is_assumed_role_session ? session_token.assumed_role_arn : undefined,
+    };
+}
+
+/**
+ * _get_identity_policies collects identity-based policies for an IAM user or assumed-role session
+ * resolves the IAM role only when authorizing an assumed-role session
+ * @param {object} account
+ * @param {boolean} is_iam_user
+ * @param {string} [assumed_role_arn]
+ * @returns {Promise<object[]|null>} policies, or null if assumed role could not be resolved
+ */
+async function _get_identity_policies(account, is_iam_user, assumed_role_arn) {
+    if (is_iam_user) {
+        return account.iam_user_policies || [];
+    }
+    const resolved_role = await resolve_iam_role_by_arn(assumed_role_arn);
+    if (!resolved_role.iam_role) return null;
+    return resolved_role.iam_role.iam_role_policies || [];
+}
+
+/**
+ * authorize_request_iam_policy_impl evaluates IAM inline policies for IAM users and assumed-role sessions on the requested action/resource
+ * returns true on allow, undefined when IAM policy auth is not applicable, or a deny context object
  * @param {object} req - http request
  * @param {Function} method - s3 method to authorize policy for
  * @param {String} bucket_name
  * @param {String} service - Either s3 or s3vectors, default is s3.
- * @returns true if request is authorized by policy, an object with account and resource_arn if not
+ * @returns {Promise<true|undefined|{account: object, resource_arn: string, principal_arn?: string}>}
  */
 async function authorize_request_iam_policy_impl(req, method, bucket_name, service = 's3') {
     const auth_token = req.object_sdk.get_auth_token();
@@ -1252,43 +1322,49 @@ async function authorize_request_iam_policy_impl(req, method, bucket_name, servi
 
     const account = req.object_sdk.requesting_account;
     const is_iam_user = account.owner !== undefined;
-    if (!is_iam_user) return; // IAM policy is only on IAM users (account root user is authorized here)
+    const { is_assumed_role_session, assumed_role_arn } = _get_assumed_role_session_info(req);
+    if (!is_iam_user && !is_assumed_role_session) return;
 
+    const iam_identity = is_iam_user ? 'user' : 'role';
     const resource_arn = _get_resource_arn_from_req(req, bucket_name, service);
     const deny_result = {
         account,
-        resource_arn
+        resource_arn,
+        // Assumed-role sessions: put the role ARN in AccessDenied via 'principal_arn' field
+        // without this, the message builds a user ARN from requesting_account
+        // (the role owner, loaded via assumed_role_access_key)
+        principal_arn: assumed_role_arn,
     };
-    const iam_policies = account.iam_user_policies || [];
 
+    const iam_policies = await _get_identity_policies(account, is_iam_user, assumed_role_arn);
+    if (iam_policies === null) {
+        dbg.error('authorize_request_iam_policy: failed to resolve IAM role for assumed session token');
+        return deny_result;
+    }
     if (iam_policies.length === 0) {
-        if (req.object_sdk.nsfs_config_root) return true; // We do not have IAM policies in NC yet
-        dbg.error('authorize_request_iam_policy: IAM user has no inline policies configured');
+        if (is_iam_user && req.object_sdk.nsfs_config_root) return true; // We do not have IAM policies in NC yet
+        dbg.error('authorize_request_iam_policy:', iam_identity, 'has no inline policies configured');
         return deny_result;
     }
 
-    // parallel policy check
-    const promises = [];
-    for (const iam_policy of iam_policies) {
-        const promise = access_policy_utils.has_access_policy_permission(
+    const permission_results = await Promise.all(iam_policies.map(iam_policy =>
+        access_policy_utils.has_access_policy_permission(
             iam_policy.policy_document, undefined, method, resource_arn, req,
             { should_pass_principal: false }
-        );
-        promises.push(promise);
-    }
-    const permission_result = await Promise.all(promises);
+        )
+    ));
     let has_allow_permission = false;
-    for (const permission of permission_result) {
-        if (permission === "DENY") {
-            dbg.error('authorize_request_iam_policy: user has explicit DENY inline policy');
+    for (const permission of permission_results) {
+        if (permission === 'DENY') {
+            dbg.error('authorize_request_iam_policy:', iam_identity, 'has explicit DENY inline policy');
             return deny_result;
         }
-        if (permission === "ALLOW") {
+        if (permission === 'ALLOW') {
             has_allow_permission = true;
         }
     }
     if (has_allow_permission) return true;
-    dbg.error('authorize_request_iam_policy: user has inline policies but none of them matched the method');
+    dbg.error('authorize_request_iam_policy:', iam_identity, 'has inline policies but none matched the method');
     return deny_result;
 }
 
@@ -1314,6 +1390,8 @@ exports.validate_tag_user_params = validate_tag_user_params;
 exports.validate_untag_user_params = validate_untag_user_params;
 exports.validate_list_user_tags_params = validate_list_user_tags_params;
 exports.get_owner_account_id = get_owner_account_id;
+exports.parse_role_arn = parse_role_arn;
+exports.resolve_iam_role_by_arn = resolve_iam_role_by_arn;
 exports.throw_malformed_policy_document_error = throw_malformed_policy_document_error;
 exports.create_detailed_message_for_iam_user_access = create_detailed_message_for_iam_user_access;
 exports.authorize_request_iam_policy_impl = authorize_request_iam_policy_impl;

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -353,11 +353,21 @@ async function authorize_request_iam_policy(req) {
     const authorize_result = await authorize_request_iam_policy_impl(req, method, bucket_name, 's3');
 
     if (authorize_result === true || authorize_result === undefined) return;
-    _throw_iam_access_denied_error_for_s3_operation(authorize_result.account, method, authorize_result.resource_arn);
+    _throw_iam_access_denied_error_for_s3_operation(
+        authorize_result.account,
+        method,
+        authorize_result.resource_arn,
+        authorize_result.principal_arn
+    );
 }
 
-function _throw_iam_access_denied_error_for_s3_operation(requesting_account, method, resource_arn) {
-    const message_with_details = create_detailed_message_for_iam_user_access(requesting_account, method, resource_arn);
+function _throw_iam_access_denied_error_for_s3_operation(requesting_account, method, resource_arn, principal_arn) {
+    const message_with_details = create_detailed_message_for_iam_user_access(
+        requesting_account,
+        method,
+        resource_arn,
+        principal_arn
+    );
     const { code, http_code } = S3Error.AccessDenied;
     throw new S3Error({ code, message: message_with_details, http_code});
 }

--- a/src/endpoint/sts/ops/sts_post_assume_role.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role.js
@@ -19,7 +19,7 @@ async function assume_role(req) {
     try {
         assumed_role = await req.sts_sdk.get_assumed_role(req);
     } catch (err) {
-        if (err.code === 'ACCESS_DENIED') {
+        if (err.rpc_code === 'ACCESS_DENIED' || err.rpc_code === 'NO_SUCH_ROLE') {
             throw new StsError(StsError.AccessDeniedException);
         }
         throw new StsError(StsError.InternalFailure);
@@ -44,7 +44,8 @@ async function assume_role(req) {
                     SessionToken: sts_utils.generate_session_token({
                         access_key: access_keys.access_key.unwrap(),
                         secret_key: access_keys.secret_key.unwrap(),
-                        assumed_role_access_key: assumed_role.access_key
+                        assumed_role_access_key: assumed_role.access_key,
+                        assumed_role_arn: req.body.role_arn,
                     }, duration_sec)
                 },
                 PackedPolicySize: 0

--- a/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
@@ -37,13 +37,13 @@ async function assume_role_with_web_identity(req) {
     // The generated session token will store in it the temporary credentials and expiry and the role's access key
     const access_keys = await req.sts_sdk.generate_temp_access_keys();
 
-    // CHANGED: Include session tags in session token if present (for OIDC/Keycloak)
+    // Session token payload for AssumeRoleWithWebIdentity (optional session_tags)
     const session_token_data = {
         access_key: access_keys.access_key.unwrap(),
         secret_key: access_keys.secret_key.unwrap(),
-        assumed_role_access_key: assumed_role.access_key
+        assumed_role_access_key: assumed_role.access_key,
+        assumed_role_arn: req.body.role_arn,
     };
-    // Add session tags if present (from Keycloak/OIDC tokens)
     if (assumed_role.session_tags && Object.keys(assumed_role.session_tags).length > 0) {
         session_token_data.session_tags = assumed_role.session_tags;
     }

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -12,6 +12,7 @@ const signature_utils = require('../../util/signature_utils');
 const system_store = require('../../server/system_services/system_store').get_instance();
 const { is_nc_environment } = require('../../nc/nc_utils');
 const access_policy_utils = require('../../util/access_policy_utils');
+const { resolve_iam_role_by_arn } = require('../iam/iam_utils');
 
 const STS_MAX_BODY_LEN = 4 * 1024 * 1024;
 
@@ -350,14 +351,9 @@ function fetch_web_identity_info(req) {
  * @returns {Promise<Object>} - Assume role policy document
  */
 async function get_assume_role_policy(req) {
-    const role_arn = req.body.role_arn;
-    const role_name = role_arn.slice(role_arn.lastIndexOf('/') + 1);
     // TODO: Get the iam_role from cache
-    const iam_role = _.find(system_store.data.iam_roles || [], role => {
-        if (role.deleted) return false;
-        return role.name === role_name;
-    });
-    return iam_role?.assume_role_policy_document;
+    const resolved_role = await resolve_iam_role_by_arn(req.body.role_arn);
+    return resolved_role.iam_role?.assume_role_policy_document;
 }
 
 

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -222,11 +222,21 @@ async function authorize_request_iam_policy(req) {
     const authorize_result = await authorize_request_iam_policy_impl(req, method, bucket_name, 's3vectors');
 
     if (authorize_result === true || authorize_result === undefined) return;
-    _throw_iam_access_denied_error_for_vector_operation(authorize_result.account, method, authorize_result.resource_arn);
+    _throw_iam_access_denied_error_for_vector_operation(
+        authorize_result.account,
+        method,
+        authorize_result.resource_arn,
+        authorize_result.principal_arn
+    );
 }
 
-function _throw_iam_access_denied_error_for_vector_operation(requesting_account, method, resource_arn) {
-    const message_with_details = create_detailed_message_for_iam_user_access(requesting_account, method, resource_arn);
+function _throw_iam_access_denied_error_for_vector_operation(requesting_account, method, resource_arn, principal_arn) {
+    const message_with_details = create_detailed_message_for_iam_user_access(
+        requesting_account,
+        method,
+        resource_arn,
+        principal_arn
+    );
     const { code, http_code } = VectorError.AccessDeniedException;
     throw new VectorError({ code, message: message_with_details, http_code});
 }

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -1,8 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const _ = require('lodash');
-
 const cloud_utils = require('../util/cloud_utils');
 const dbg = require('../util/debug_module')(__filename);
 const { RpcError } = require('../rpc');
@@ -10,7 +8,7 @@ const signature_utils = require('../util/signature_utils');
 const { account_cache, dn_cache } = require('./object_sdk');
 const BucketSpaceNB = require('./bucketspace_nb');
 const jwt = require('jsonwebtoken');
-const system_store = require('../server/system_services/system_store').get_instance();
+const { resolve_iam_role_by_arn } = require('../endpoint/iam/iam_utils');
 const ldap_client = require('../util/ldap_client');
 const keycloak_client = require('../util/keycloak_client');
 
@@ -70,16 +68,11 @@ class StsSDK {
     }
 
     async _assume_role(role_arn) {
-        const role_name_idx = role_arn.lastIndexOf('/') + 1;
-        const role_name = role_arn.slice(role_name_idx);
-        const account_id = role_arn.split(':')[4];
-        // TODO: Use cache instead of system_store
-        const iam_role = _.find(system_store.data?.iam_roles || [], role => {
-            if (role.deleted) return false;
-            return role.name === role_name && role.owner._id.toString() === account_id;
-        });
-        if (!iam_role) {
-            throw new RpcError('NO_SUCH_ROLE', `No such Role found with name: ${role_name} and account id : ${account_id}`);
+        const resolved_role = await resolve_iam_role_by_arn(role_arn);
+        const iam_role = resolved_role.iam_role;
+        if (!iam_role || resolved_role.error) {
+            throw new RpcError('NO_SUCH_ROLE',
+                `No such Role found with name: ${resolved_role.role_name || 'unknown'} and account id : ${resolved_role.account_id || 'unknown'}`);
         }
         const account = iam_role.owner;
         dbg.log1('sts_sdk.get_assumed_role res', 'iam_role: ', iam_role.name);
@@ -155,7 +148,7 @@ class StsSDK {
         const role_config = await this._assume_role(req.body.role_arn);
         dbg.log0('sts_sdk.get_assumed_role_with_web_identity res', 'account.role_config: ', role_config);
         return {
-            access_key: req.body.role_arn.split(':')[4],
+            access_key: role_config.access_key,
             role_config,
             dn: ldap_auth_result.dn,
         };

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -21,7 +21,7 @@ const jwt_utils = require('../../../../util/jwt_utils');
 const config = require('../../../../../config');
 const ldap_client = require('../../../../util/ldap_client');
 const { S3Error } = require('../../../../endpoint/s3/s3_errors');
-const { CreateRoleCommand, DeleteRoleCommand, UpdateAssumeRolePolicyCommand } = require('@aws-sdk/client-iam');
+const { CreateRoleCommand, DeleteRoleCommand, PutRolePolicyCommand, UpdateAssumeRolePolicyCommand } = require('@aws-sdk/client-iam');
 const defualt_expiry_seconds = Math.ceil(config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS / 1000);
 
 const errors = {
@@ -170,6 +170,18 @@ mocha.describe('STS tests', function() {
         await iam_client_b.send(new CreateRoleCommand({
             RoleName: role_b,
             AssumeRolePolicyDocument: JSON.stringify(policy),
+        }));
+        await iam_client_b.send(new PutRolePolicyCommand({
+            RoleName: role_b,
+            PolicyName: 'Role_B_S3Access',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: ['arn:aws:s3:::first.bucket/*', 'arn:aws:s3:::first.bucket'],
+                }],
+            }),
         }));
 
 
@@ -484,6 +496,7 @@ function verify_session_token(session_token, access_key, secret_key, assumed_rol
     assert.equal(access_key, session_token_json.access_key);
     assert.equal(secret_key, session_token_json.secret_key);
     assert.equal(assumed_role_access_key, session_token_json.assumed_role_access_key);
+    assert.ok(session_token_json.assumed_role_arn);
 }
 
 mocha.describe('Session token tests', function() {
@@ -569,6 +582,18 @@ mocha.describe('Session token tests', function() {
         await accounts[0].iam.send(new CreateRoleCommand({
             RoleName: role_alice,
             AssumeRolePolicyDocument: JSON.stringify(policy),
+        }));
+        await accounts[0].iam.send(new PutRolePolicyCommand({
+            RoleName: role_alice,
+            PolicyName: 'Role_A_S3Access',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: ['*'],
+                }],
+            }),
         }));
 
         account_info_alice = await rpc_client.account.read_account({ email: alice2 });

--- a/src/util/validation_utils.js
+++ b/src/util/validation_utils.js
@@ -234,3 +234,4 @@ exports.validate_iam_tag_keys = validate_iam_tag_keys;
 exports._type_check_input = _type_check_input;
 exports._length_check_input = _length_check_input;
 exports._length_min_check_input = _length_min_check_input;
+exports._length_max_check_input = _length_max_check_input;


### PR DESCRIPTION
### Describe the Problem
Support for role policy validation.

### Explain the Changes
1. Extended IAM authorization to evaluate inline role policies for assumed-role sessions by resolving the role from `assumed_role_arn`.
2. Added shared role-ARN resolution and reused it across IAM/STS paths, including path-aware and owner-scoped role lookup.
3. Updated STS session token payload to carry assumed-role context needed for downstream policy evaluation, and aligned S3/Vector deny handling and tests accordingly.

### Issues: Fixed #xxx / Gap #xxx
1. EPIC: https://redhat.atlassian.net/browse/MCGI-330
2. Sub-task (keycloak): https://redhat.atlassian.net/browse/RHSTOR-8931

### Testing Instructions:
1) Create role
`AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <iam-endpoint-url> iam create-role \
  --role-name test-role \
  --assume-role-policy-document file://trust-policy.json \
  --path / \
  --max-session-duration 3600`

2) Attach inline role policy (allow example; omit for empty-policy deny)
`AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <iam-endpoint-url> iam put-role-policy \
  --role-name test-role \
  --policy-name s3-access \
  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}'`

Deny example:
`--policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:*","Resource":"*"}]}'`

3) Assume role
`AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <sts-endpoint-url> sts assume-role \
  --role-arn arn:aws:iam::<account-id>:role/test-role \
  --role-session-name test-session`

4) S3 with temp creds from AssumeRole response
`AWS_ACCESS_KEY_ID=<temp-access-key> AWS_SECRET_ACCESS_KEY=<temp-secret-key> AWS_SESSION_TOKEN=<session-token> \
aws --no-verify-ssl --endpoint-url <s3-endpoint-url> s3 ls s3://<bucket>`

**Verify**

Allow policy → S3 succeeds
No / empty role policy → AccessDenied
Deny policy → AccessDenied
Cross-account assume + role policy still enforced on S3

`$ cat trust-policy.json`

> {
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": { "AWS": "*" },
      "Action": "sts:AssumeRole"
    }
  ]
}


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added assumed-role session authorization by evaluating the resolved role’s inline permissions.
  * STS session tokens now preserve assumed role identity for clearer, consistent authorization.
* **Bug Fixes**
  * Improved role resolution for STS assume-role flows using the role ARN as the source of truth.
  * Access-denied responses for S3 and Vector now include the requesting principal ARN for better diagnostics.
  * Refined error mapping for assume-role failures to use the RPC error code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->