### PR TITLE
Keycloak |  Error messages in STS web identity exceptions

### DIFF
--- a/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
@@ -21,16 +21,16 @@ async function assume_role_with_web_identity(req) {
         // CHANGED: Use unified method that supports both LDAP and OIDC/Keycloak
         assumed_role = await req.sts_sdk.get_assumed_web_identity_role(req);
     } catch (err) {
+        dbg.error('get_assumed_web_identity_role error:', err);
         if (err.rpc_code === 'ACCESS_DENIED') {
-            throw new StsError(StsError.AccessDeniedException);
+            throw new StsError({ ...StsError.AccessDeniedWebIdentityException, message: err.message });
         }
         if (err.rpc_code === 'EXPIRED_WEB_IDENTITY_TOKEN') {
-            throw new StsError(StsError.ExpiredToken);
+            throw new StsError({ ...StsError.ExpiredWebIdentityToken, message: err.message });
         }
         if (err.rpc_code === 'INVALID_WEB_IDENTITY_TOKEN') {
-            throw new StsError({ ...StsError.InvalidIdentityToken, message: err.message });
+            throw new StsError({ ...StsError.InvalidWebIdentityToken, message: err.message });
         }
-        dbg.error('get_assumed_web_identity_role error:', err);
         throw new StsError(StsError.InternalFailure);
     }
     // Temporary credentials are NOT stored in noobaa

--- a/src/endpoint/sts/sts_errors.js
+++ b/src/endpoint/sts/sts_errors.js
@@ -146,4 +146,21 @@ StsError.InvalidIdentityToken = Object.freeze({
     message: 'Missing a required claim',
     http_code: 400,
 });
+
+StsError.ExpiredWebIdentityToken = Object.freeze({
+    code: 'ExpiredWebIdentityToken',
+    message: 'An error occurred (ExpiredWebIdentityToken) when calling the AssumeRoleWithWebIdentity operation: ',
+    http_code: 400,
+});
+StsError.InvalidWebIdentityToken = Object.freeze({
+    code: 'InvalidWebIdentityToken',
+    message: 'An error occurred (InvalidWebIdentityToken) when calling the AssumeRoleWithWebIdentity operation: ',
+    http_code: 400,
+});
+StsError.AccessDeniedWebIdentityException = Object.freeze({
+    code: 'AccessDeniedWebIdentityException',
+    message: 'An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity operation: ',
+    http_code: 400,
+});
+
 exports.StsError = StsError;

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -201,21 +201,11 @@ class StsSDK {
                 name: introspection_resp.name,
             };
         } catch (err) {
-            // TODO: Create error map mapKeycloakError
-            dbg.error('get_assumed_oidc_user error:', err);
-            if (err.name === 'TokenExpiredError') {
-                throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN', err.message);
+            dbg.error('get_assumed_oidc_user error :', err, err.rpc_code);
+            if (err.rpc_code === 'EXPIRED_WEB_IDENTITY_TOKEN' || err.rpc_code === 'INVALID_WEB_IDENTITY_TOKEN') {
+                throw err;
             }
-            if (err.name === 'JsonWebTokenError') {
-                throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', err.message);
-            }
-            if (err.message && err.message.includes('No KeyCloak provider')) {
-                throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', err.message);
-            }
-            if (err.message && err.message.includes('Token is not active')) {
-                throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN', 'Token has been revoked or is inactive');
-            }
-            throw new RpcError('ACCESS_DENIED', 'Issue with KeyCloak authentication');
+            throw new RpcError('ACCESS_DENIED', 'Not authorized to perform sts:AssumeRoleWithWebIdentity');
         }
     }
 

--- a/src/test/unit_tests/util_functions_tests/test_assume_iam_role_trust_policy.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_assume_iam_role_trust_policy.test.js
@@ -21,7 +21,7 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should validate single StringEquals condition - match', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
+                "https://aws.amazon.com/tags": {
                     principal_tags: {
                         Department: "Engineering",
                     }
@@ -40,9 +40,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Sales'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Sales'
+                            }
+                        }
                     }
                 },
             };
@@ -59,11 +63,15 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        Team: 'DevOps',
-                        Environment: 'Production'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                Team: 'DevOps',
+                                Environment: 'Production'
+                            }
+                        }
                     }
                 },
             };
@@ -83,10 +91,14 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        Team: 'QA'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                Team: 'QA'
+                            }
+                        }
                     }
                 },
             };
@@ -104,9 +116,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -123,9 +139,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: ['Engineering', 'Research']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: ['Engineering', 'Research']
+                            }
+                        }
                     }
                 },
             };
@@ -145,9 +165,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Team: ['Engineering', 'QA']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Team: ['Engineering', 'QA']
+                            }
+                        }
                     }
                 },
             };
@@ -164,9 +188,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Team: ['QA', 'Support']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Team: ['QA', 'Support']
+                            }
+                        }
                     }
                 },
             };
@@ -184,9 +212,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Team: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Team: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -204,10 +236,14 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Team: ['Engineering', 'QA'],
-                        Project: ['ProjectA', 'ProjectB']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Team: ['Engineering', 'QA'],
+                                Project: ['ProjectA', 'ProjectB']
+                            }
+                        }
                     }
                 },
             };
@@ -226,9 +262,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Roles: ['Admin', 'Developer', 'Tester']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Roles: ['Admin', 'Developer', 'Tester']
+                            }
+                        }
                     }
                 },
             };
@@ -250,10 +290,14 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        Team: ['DevOps', 'QA']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                Team: ['DevOps', 'QA']
+                            }
+                        }
                     }
                 },
             };
@@ -273,10 +317,14 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        Team: ['QA', 'Support']
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                Team: ['QA', 'Support']
+                            }
+                        }
                     }
                 },
             };
@@ -296,12 +344,16 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        Team: ['DevOps', 'Security'],
-                        Email: 'user@noobaa.io',
-                        CostCenter: 'CC-123'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                Team: ['DevOps', 'Security'],
+                                Email: 'user@noobaa.io',
+                                CostCenter: 'CC-123'
+                            }
+                        }
                     }
                 },
             };
@@ -324,9 +376,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should return true when no conditions provided', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -338,9 +394,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should return true when conditions is undefined', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -374,9 +434,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should handle custom condition key formats', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -392,9 +456,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should handle missing tag in claim', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                       Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                               Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -411,9 +479,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                       Department: ''
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                               Department: ''
+                            }
+                        }
                     }
                 },
             };
@@ -429,9 +501,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should handle numeric values as strings', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                       CostCenter: 123
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                               CostCenter: 123
+                            }
+                        }
                     }
                 },
             };
@@ -448,9 +524,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                       Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                               Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -491,11 +571,15 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         it('should validate complete trust policy with conditions', () => {
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        CostCenter: 'CC-123',
-                        Project: 'NooBaa'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                CostCenter: 'CC-123',
+                                Project: 'NooBaa'
+                            }
+                        }
                     }
                 },
             };
@@ -525,12 +609,16 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
 
             const web_identity_info = {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
-                token_claims: {
-                    principal_tags: {
-                        Environment: 'Development',
-                        Team: ['QA'],
-                        Email: 'dev@company.com',
-                        Clearance: 'Low'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Environment: 'Development',
+                                Team: ['QA'],
+                                Email: 'dev@company.com',
+                                Clearance: 'Low'
+                            }
+                        }
                     }
                 },
             };
@@ -555,10 +643,14 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
                 iss: "http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa",
                 aud: ['CLIENT_ID', 'account'],
                 typ: 'Bearer',
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering',
-                        CostCenter: 'CC-123'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering',
+                                CostCenter: 'CC-123'
+                            }
+                        }
                     }
                 },
             };
@@ -581,9 +673,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
                 sub: '1e59d996-2aa9-4a91-9740-d9cf61ccfd3e',
                 azp: 'noobaa-client',
                 iss: 'http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa',
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -605,9 +701,13 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
             const web_identity_info = {
                 aud: ['other-client', 'account'],
                 iss: 'http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa',
-                token_claims: {
-                    principal_tags: {
-                        Department: 'Engineering'
+                "https://aws": {
+                    amazon: {
+                        "com/tags": {
+                            principal_tags: {
+                                Department: 'Engineering'
+                            }
+                        }
                     }
                 },
             };
@@ -625,4 +725,3 @@ describe('IAM Policy Utils - Trust Policy Condition Validation', () => {
         });
     });
 });
-

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -535,8 +535,6 @@ const VECTOR_OP_NAME_TO_ACTION = Object.freeze({
 });
 
 
-const TOKEN_CLAIMS_NAME = 'token_claims';
-
 const ldap_predicate_map = {
     'StringEquals': string_equals_predicate,
     'ForAnyValue:StringEquals': for_any_value_string_equals_predicate,
@@ -553,14 +551,15 @@ function _is_ldap_identity_fit(condition_key, expected_value, identity_info, pre
  * Will have different set of predicate_maps for keycloak and ldap
  * @param {Boolean} is_keycloak_request - The account to validate against
  * @param {Object} condition - The condition(s) from the policy statement
- * @param {Object} web_identity_info - The condition(s) from the policy statement
+ * @param {Object} web_identity_info - The web identity info decoded from the JWT token.
+ *   principal_tags are nested under the AWS OIDC claim key:
+ *   web_identity_info["https://aws"]["amazon"]["com/tags"]["principal_tags"]
  * @returns {boolean} - true if all method are satisfied, false otherwise
  */
 function _is_identity_condition_fit(is_keycloak_request, condition, web_identity_info) {
     const conditon_predicate_map = is_keycloak_request ? keycloak_predicate_map : ldap_predicate_map;
     const evaluation_context = {
-        // TODO: TOKEN_CLAIMS_NAME missing error response in console
-        tags_claim: web_identity_info ? web_identity_info[TOKEN_CLAIMS_NAME]?.principal_tags : {},
+        tags_claim: get_tags_claim(web_identity_info),
         token_claims: web_identity_info || {},
     };
 
@@ -573,8 +572,8 @@ function _is_identity_condition_fit(is_keycloak_request, condition, web_identity
         for (const [expected_key, expected_value] of Object.entries(value)) {
             if (is_keycloak_request) {
                 if (!predicate({ [expected_key]: expected_value }, evaluation_context)) {
-                    dbg.log0('_is_identity_condition_fit: Condition validation failed for operator:', expected_key,
-                        'condition_key:', expected_key);
+                    dbg.log0('_is_identity_condition_fit: Condition validation failed for operator: condition_key', condition_key,
+                        'expected_key:', expected_key, "expected_value ", evaluation_context);
                     return false;
                 }
             } else if (expected_key.startsWith('ldap:')) { // LDAP identity condition
@@ -583,6 +582,33 @@ function _is_identity_condition_fit(is_keycloak_request, condition, web_identity
         }
     }
     return true;
+}
+
+/**
+ * get_tags_claim extracts the principal_tags object from a decoded JWT web identity token.
+ *
+ * AWS OIDC providers (e.g. Keycloak) may embed the principal tags under one of two
+ * claim key formats depending on how the OIDC mapper is configured:
+ *
+ *  1. Flat URL key (standard AWS format):
+ *       web_identity_info["https://aws.amazon.com/tags"]["principal_tags"]
+ *
+ *  2. Split URL key (produced when the JWT parser splits on "."):
+ *       web_identity_info["https://aws"]["amazon"]["com/tags"]["principal_tags"]
+ *
+ * The function checks for the flat key first, then falls back to the split-key
+ * path. Returns undefined when neither format is present.
+ *
+ * @param {Object} web_identity_info - Decoded JWT payload from the web identity token.
+ * @returns {Object|undefined} - The principal_tags map, or undefined if not present.
+ */
+function get_tags_claim(web_identity_info) {
+    if (web_identity_info?.["https://aws.amazon.com/tags"]) {
+        return web_identity_info["https://aws.amazon.com/tags"]?.principal_tags;
+    } else if (web_identity_info?.["https://aws"]) {
+        return web_identity_info?.["https://aws"]?.amazon?.["com/tags"]?.principal_tags;
+    }
+    return {};
 }
 
 

--- a/src/util/keycloak_client.js
+++ b/src/util/keycloak_client.js
@@ -48,10 +48,9 @@ class KeyCloakClientManager {
     async add_provider(provider_config) {
         try {
             // Auto-discover endpoints if only issuer is provided
-            if (!provider_config.jwks_uri && provider_config.issuer) {
+            if (provider_config.issuer) {
                 dbg.log0('Discovering KeyCloak configuration for:', provider_config.issuer);
                 const discovery = await KeyCloakProvider.discover(provider_config.issuer);
-                provider_config.jwks_uri = discovery.jwks_uri;
                 provider_config.token_introspection_endpoint = discovery.introspection_endpoint;
             }
             const provider = new KeyCloakProvider(provider_config);

--- a/src/util/keycloak_utils.js
+++ b/src/util/keycloak_utils.js
@@ -4,6 +4,7 @@
 const querystring = require('querystring');
 const { make_http_request, make_https_request } = require('./http_utils');
 const { read_stream_join } = require('./buffer_utils');
+const { RpcError } = require('../rpc');
 const dbg = require('./debug_module')(__filename);
 
 
@@ -16,7 +17,6 @@ class KeyCloakProvider {
         this.issuer = config.issuer;
         this.client_id = config.client_id;
         this.client_secret = config.client_secret;
-        this.jwks_uri = config.jwks_uri;
         this.token_introspection_endpoint = config.token_introspection_endpoint;
     }
 
@@ -55,13 +55,13 @@ class KeyCloakProvider {
 
         if (response.statusCode !== 200) {
             dbg.error('KeyCloak token introspection failed with status:', response.statusCode, 'body:', body_str);
-            throw new Error(`KeyCloak token introspection failed with status: ${response.statusCode}, body: ${body_str}`);
+            throw new RpcError('INVALID_WEB_IDENTITY_TOKEN', `Couldn't retrieve verification key from your identity provider, please reference AssumeRoleWithWebIdentity documentation for requirements`);
         }
 
         const result = JSON.parse(body_str);
 
         if (!result.active) {
-            throw new Error('Token is not active');
+            throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN', 'Token expired: current date/time must be before the expiration date/time');
         }
 
         return result;
@@ -73,7 +73,8 @@ class KeyCloakProvider {
      * @returns {Promise<Object>} - .well-known OIDC provider configuration object
      */
     static async discover(issuer_url) {
-        const well_known_url = new URL('.well-known/openid-configuration', issuer_url);
+        const base_url = issuer_url.endsWith('/') ? issuer_url : issuer_url + '/';
+        const well_known_url = new URL('.well-known/openid-configuration', base_url);
         try {
             const make_request = well_known_url.protocol === 'https:' ? make_https_request : make_http_request;
             const response = await make_request(


### PR DESCRIPTION
### Describe the Problem

Return error messages similer to AWS and update custom claim name

### Explain the Changes
1. Return error messages similer
2. update custom claim name similer to ceph[ceph](https://docs.ceph.com/en/latest/radosgw/session-tags/)
3. Remove `jwks_uri` from keycloak configuation

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. npx jest /src/test/unit_tests/util_functions_tests/test_assume_iam_role_trust_policy.test.js


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web identity sign-in failure reporting by distinguishing expired, invalid, and access-denied cases with dedicated STS error variants and consistent error details.
  * Updated trust-policy condition evaluation to correctly read AWS tag claims from newer web identity token claim layouts, improving identity matching.
  * Refined Keycloak token introspection and discovery behavior, ensuring more consistent provider setup and clearer errors when tokens are inactive or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->