### PR TITLE
KeyCloack | Use existing has_access_policy_permission method in access_policy_utils

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -614,12 +614,13 @@ module.exports = {
         iam_trust_policy_sts_action: {
             type: 'string',
             // we will support the following STS actions in the future:
-            // sts:TagSession, sts:SetSourceIdentity
+            // sts:SetSourceIdentity
             enum: [
                 'sts:*',
                 'sts:AssumeRole',
                 'sts:AssumeRoleWithSAML',
-                'sts:AssumeRoleWithWebIdentity'
+                'sts:AssumeRoleWithWebIdentity',
+                'sts:TagSession'
             ]
         },
         iam_trust_policy_action: {

--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -268,7 +268,7 @@ async function authorize_request_policy(req) {
     // Both NSFS NC and containerized will validate bucket policy against account id
     // but in containerized deployment not against IAM user ID.
     const account_identifier_id = access_policy_utils.get_account_identifier_id(is_nc_deployment, account);
-    const account_identifier_arn = access_policy_utils.get_bucket_policy_principal_arn(account);
+    const account_identifier_arn = access_policy_utils.get_policy_principal_arn(account);
     // deny delete_bucket permissions from bucket_claim_owner accounts (accounts that were created by OBC from openshift\k8s)
     // the OBC bucket can still be delete by normal accounts according to the access policy which is checked below
     if (req.op_name === 'delete_bucket' && account.bucket_claim_owner) {

--- a/src/endpoint/sts/ops/sts_post_assume_role.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role.js
@@ -33,9 +33,8 @@ async function assume_role(req) {
         AssumeRoleResponse: {
             AssumeRoleResult: {
                 AssumedRoleUser: {
-                    // TODO: change the role arn with account id
-                    Arn: `arn:aws:sts::${assumed_role.access_key}:assumed-role/${assumed_role.role_config.role_name}/${req.body.role_session_name}`,
-                    AssumedRoleId: `${assumed_role.access_key}:${req.body.role_session_name}`
+                    Arn: `arn:aws:sts::${assumed_role.account_id}:assumed-role/${assumed_role.role_config.role_name}/${req.body.role_session_name}`,
+                    AssumedRoleId: `${assumed_role.account_id}:${req.body.role_session_name}`
                 },
                 Credentials: {
                     AccessKeyId: access_keys.access_key.unwrap(),

--- a/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
@@ -23,13 +23,13 @@ async function assume_role_with_web_identity(req) {
     } catch (err) {
         dbg.error('get_assumed_web_identity_role error:', err);
         if (err.rpc_code === 'ACCESS_DENIED') {
-            throw new StsError({ ...StsError.AccessDeniedWebIdentityException, message: err.message });
+            throw new StsError({ ...StsError.AccessDeniedException, message: err.message });
         }
         if (err.rpc_code === 'EXPIRED_WEB_IDENTITY_TOKEN') {
-            throw new StsError({ ...StsError.ExpiredWebIdentityToken, message: err.message });
+            throw new StsError({ ...StsError.ExpiredToken, message: err.message });
         }
         if (err.rpc_code === 'INVALID_WEB_IDENTITY_TOKEN') {
-            throw new StsError({ ...StsError.InvalidWebIdentityToken, message: err.message });
+            throw new StsError({ ...StsError.InvalidIdentityToken, message: err.message });
         }
         throw new StsError(StsError.InternalFailure);
     }
@@ -54,8 +54,8 @@ async function assume_role_with_web_identity(req) {
                 SubjectFromWebIdentityToken: assumed_role.sub,
                 Audience: assumed_role.aud,
                 AssumedRoleUser: {
-                    Arn: `arn:aws:sts::${assumed_role.access_key}:assumed-role/${assumed_role.role_config.role_name}/${req.body.role_session_name}`,
-                    AssumedRoleId: `${assumed_role.access_key}:${req.body.role_session_name}`
+                    Arn: `arn:aws:sts::${assumed_role.account_id}:assumed-role/${assumed_role.role_config.role_name}/${req.body.role_session_name}`,
+                    AssumedRoleId: `${assumed_role.account_id}:${req.body.role_session_name}`
                 },
                 Credentials: {
                     AccessKeyId: access_keys.access_key.unwrap(),

--- a/src/endpoint/sts/sts_errors.js
+++ b/src/endpoint/sts/sts_errors.js
@@ -147,20 +147,4 @@ StsError.InvalidIdentityToken = Object.freeze({
     http_code: 400,
 });
 
-StsError.ExpiredWebIdentityToken = Object.freeze({
-    code: 'ExpiredWebIdentityToken',
-    message: 'An error occurred (ExpiredWebIdentityToken) when calling the AssumeRoleWithWebIdentity operation: ',
-    http_code: 400,
-});
-StsError.InvalidWebIdentityToken = Object.freeze({
-    code: 'InvalidWebIdentityToken',
-    message: 'An error occurred (InvalidWebIdentityToken) when calling the AssumeRoleWithWebIdentity operation: ',
-    http_code: 400,
-});
-StsError.AccessDeniedWebIdentityException = Object.freeze({
-    code: 'AccessDeniedWebIdentityException',
-    message: 'An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity operation: ',
-    http_code: 400,
-});
-
 exports.StsError = StsError;

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -1,8 +1,6 @@
 /* Copyright (C) 2016 NooBaa */
 'use strict';
 
-const _ = require('lodash');
-const jwt = require('jsonwebtoken');
 
 const dbg = require('../../util/debug_module')(__filename);
 const StsError = require('./sts_errors').StsError;
@@ -118,7 +116,7 @@ async function authenticate_request(req) {
     try {
         signature_utils.authenticate_request_by_service(req, req.sts_sdk);
         if (req.op_name === 'post_assume_role_with_web_identity') {
-            const web_identity_info = fetch_web_identity_info(req);
+            const web_identity_info = access_policy_utils.fetch_web_identity_info(req);
             const is_ldap_request = web_identity_info.username;
             if (is_ldap_request) {
                 // fetch LDAP identity info
@@ -156,8 +154,26 @@ async function authorize_request_policy(req) {
     // system owner by design can always assume role policy of any account
     // skip for NC environments since system owner is not applicable
     if (!is_nc_environment() && (cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) return;
-    const web_identity_info = fetch_web_identity_info(req);
-    const permission = has_assume_role_permission(assume_role_policy, method, req.sts_sdk.requesting_account, web_identity_info);
+
+    // Build the account identifier array (email + ARN + account id) for Principal.AWS matching.
+    const account = req.sts_sdk.requesting_account;
+    const account_arr = [];
+    if (account) {
+        account_arr.push(account.email.unwrap());
+        account_arr.push(access_policy_utils.get_policy_principal_arn(account));
+        account_arr.push(account._id.toString());
+    }
+
+    const permission = await access_policy_utils.has_access_policy_permission(
+        assume_role_policy,
+        account_arr,
+        method,
+        undefined,
+        req,
+        {
+            is_trust_policy: true,
+        }
+    );
     dbg.log0('sts_rest.authorize_request_policy permission is: ', permission);
     if (permission === 'DENY' || permission === 'IMPLICIT_DENY') {
         throw new StsError(StsError.AccessDeniedException);
@@ -214,135 +230,6 @@ function handle_error(req, res, err) {
         res.setHeader('Content-Length', Buffer.byteLength(reply));
     }
     res.end(reply);
-}
-
-function has_assume_role_permission(policy, method, account, web_identity_info) {
-    const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
-    // look for explicit denies
-    if (_is_statements_fit(deny_statements, method, account, web_identity_info)) return 'DENY';
-    // look for explicit allows
-    if (_is_statements_fit(allow_statements, method, account, web_identity_info)) return 'ALLOW';
-
-    // implicit deny
-    return 'IMPLICIT_DENY';
-}
-
-function _is_statements_fit(statements, method, account, web_identity_info) {
-    for (const statement of statements) {
-        let action_fit = false;
-        let principal_fit = false;
-        dbg.log0('assume_role_policy: statement', statement);
-
-        // what action can be done
-
-        action_fit = _is_action_fit(method, statement);
-        dbg.log0('assume_role_policy: action fit?', action_fit);
-
-        principal_fit = _is_principal_fit(statement, account, web_identity_info);
-        dbg.log0('assume_role_policy: principal fit?', principal_fit);
-
-        const condition_fit = _is_condition_fit(statement.Condition, web_identity_info);
-        dbg.log0('assume_role_policy: condition fit?', condition_fit);
-
-        dbg.log0('assume_role_policy: is_statements_fit', action_fit, principal_fit, condition_fit);
-        if (action_fit && principal_fit && condition_fit) return true;
-    }
-    return false;
-}
-
-/**
- * _is_principal_fit checks if the statement can be applied to the account
- * @param {Object | Array} statement - The condition(s) from the policy statement
- * @param {Object} account - The account to validate against
- * @param {Object} web_identity_info - The web identity information to validate against
- * @returns {boolean} - true if all principle are satisfied, false otherwise
- */
-function _is_principal_fit(statement, account, web_identity_info) {
-    const statement_principal = statement.Principal || statement.NotPrincipal;
-
-        let principal_fit = false;
-        if (statement_principal.Federated) {
-            for (const federated of _.flatten([statement_principal.Federated])) {
-                const federated_url = typeof federated === 'string' ? federated : federated.unwrap();
-                dbg.log0('assume_role_policy: principal federated fit?', federated_url, web_identity_info.iss);
-                if (federated_url.split("oidc-provider/")[1] === web_identity_info.iss?.split('//')[1]) {
-                    principal_fit = true;
-                }
-            }
-        }
-
-        if (statement_principal.AWS) {
-            for (const principal_aws of _.flatten([statement_principal.AWS])) {
-                const principal = typeof principal_aws === 'string' ? principal_aws : principal_aws.unwrap();
-                const cur_account_email = account?.email.unwrap();
-                // Added ARN to principle validation
-                const account_identifier_arn = account ? access_policy_utils.get_bucket_policy_principal_arn(account) : "";
-                dbg.log0('assume_role_policy: principal fit?', principal, cur_account_email, account_identifier_arn);
-                if ((principal === cur_account_email) || (principal === '*') || (principal === account_identifier_arn)) {
-                    principal_fit = true;
-                }
-            }
-        }
-
-    return statement.Principal ? principal_fit : !principal_fit;
-}
-
-
-/**
- * _is_action_fit checks if the method is allowed by the statement
- * @param {String} method - The account to validate against
- * @param {Object|Array} statement - The condition(s) from the policy statement
- * @returns {boolean} - true if all method are satisfied, false otherwise
- */
-function _is_action_fit(method, statement) {
-    const statement_action = statement.Action || statement.NotAction;
-    let action_fit = false;
-    for (const action of _.flatten([statement_action])) {
-        dbg.log1('access_policy: ', statement.Action ? 'Action' : 'NotAction', ' fit?', action, method);
-        if (action === method || access_policy_utils._is_wildcard_match(action, method)) {
-            action_fit = true;
-            break;
-        }
-    }
-    return statement.Action ? action_fit : !action_fit;
-}
-
-
-/**
- * _is_condition_fit checks if the statement conditions match the web identity info
- * @param {Object|Array} statement_condition - The condition(s) from the policy statement
- * @param {Object} web_identity_info - The web identity information to validate against
- * @returns {boolean} - true if all conditions are satisfied, false otherwise
- */
-function _is_condition_fit(statement_condition, web_identity_info) {
-    if (!statement_condition) return true;
-
-    let statement_conditions = statement_condition;
-    // if the condition is an object, wrap it in an array
-    if (!Array.isArray(statement_condition)) {
-        statement_conditions = [statement_condition];
-    }
-    const is_keycloak_request = web_identity_info.iss;
-    for (const condition of statement_conditions) {
-        const condition_fit = access_policy_utils._is_identity_condition_fit(is_keycloak_request, condition, web_identity_info);
-        if (!condition_fit) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
- * fetch web identity object from request web_identity_token param
- * @param {Object} req - Request object
- * @returns {Object} - web_identity_info
- */
-function fetch_web_identity_info(req) {
-    let web_identity_info;
-    if (req.body.web_identity_token) {
-        web_identity_info = jwt.decode(req.body.web_identity_token, { json: true });
-    }
-    return web_identity_info || {};
 }
 
 /**

--- a/src/endpoint/vector/vector_rest.js
+++ b/src/endpoint/vector/vector_rest.js
@@ -343,7 +343,7 @@ async function authorize_request_vector_policy(req) {
         account_identifiers.push(account.name.unwrap());
     }
     if (!is_nc_deployment) {
-        account_identifiers.push(access_policy_utils.get_bucket_policy_principal_arn(account));
+        account_identifiers.push(access_policy_utils.get_policy_principal_arn(account));
     }
 
     const permission = await access_policy_utils.has_access_policy_permission(

--- a/src/manage_nsfs/manage_nsfs_validations.js
+++ b/src/manage_nsfs/manage_nsfs_validations.js
@@ -585,7 +585,7 @@ function validate_role_config(user_input) {
         if (statement.effect !== 'allow' && statement.effect !== 'deny') {
             throw_cli_error(ManageCLIError.InvalidRoleConfig, 'effect must be "allow" or "deny"');
         }
-        const valid_actions = ['*', 'sts:AssumeRole', 'sts:AssumeRoleWithWebIdentity', 'sts:AssumeRoleWithSAML', 'sts:*'];
+        const valid_actions = ['*', 'sts:AssumeRole', 'sts:AssumeRoleWithWebIdentity', 'sts:AssumeRoleWithSAML', 'sts:TagSession', 'sts:*'];
         for (const action of statement.action) {
             if (!valid_actions.includes(action)) {
                 throw_cli_error(ManageCLIError.InvalidRoleConfig, 'Policy has invalid action');

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -103,6 +103,8 @@ mocha.describe('STS tests', function() {
     let sts_creds;
     let accounts = [];
 
+    let user_b_id = '';
+
     /** @type {import('@aws-sdk/client-iam').IAMClient} */
     let iam_client_b;
     const iam_role_name = 'IamCreatedRole1';
@@ -159,6 +161,7 @@ mocha.describe('STS tests', function() {
 
         user_b_key = user_b_keys[0].access_key.unwrap();
         account_info_b = await rpc_client.account.read_account({ email: user_b });
+        user_b_id = account_info_b._id.toString();
 
         // Build an IAM client authenticated as the role-owner account
         iam_client_b = generate_iam_client(
@@ -236,24 +239,24 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user a assume role of admin - should be rejected', async function() {
         await assert_throws_async(sts.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${'dummy_role'}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${'dummy_role'}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('admin assume role of user b - should be allowed', async function() {
         const params = {
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:assumed-role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:assumed-role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
         const json = await assume_role_and_parse_xml(sts_admin, params);
-        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
 
     mocha.it('admin assume non existing role of user b - should be rejected', async function() {
         await assert_throws_async(sts_admin.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${'dummy_role2'}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${'dummy_role2'}`,
             RoleSessionName: 'just_a_dummy_session_name1'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
@@ -267,22 +270,22 @@ mocha.describe('STS tests', function() {
 
     mocha.it('anonymous user a assume role of user b - should be rejected', async function() {
         await assert_throws_async(anon_sts.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be allowed', async function() {
         const params = {
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
         const json = await assume_role_and_parse_xml(sts_c, params);
-        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
 
-        const temp_creds = validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        const temp_creds = validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
         const s3 = new AWS.S3({
             ...sts_creds,
             accessKeyId: temp_creds.access_key,
@@ -296,7 +299,7 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user a assume role of user b - should be rejected', async function() {
         await assert_throws_async(sts.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
@@ -320,12 +323,12 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user a assume role of user b - should be allowed', async function() {
         const params = {
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
         const json = await assume_role_and_parse_xml(sts, params);
-        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
 
     mocha.it('update assume role policy of user b to allow user a', async function() {
@@ -351,19 +354,19 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user a assume role of user b - should be rejected', async function() {
         await assert_throws_async(sts.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be allowed', async function() {
         const params = {
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
         const json = await assume_role_and_parse_xml(sts_c, params);
-        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
 
     mocha.it('update assume role policy of user b to allow user a sts:*', async function() {
@@ -397,12 +400,12 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user c assume role of user b - should be allowed sts:*', async function() {
         const params = {
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
         const json = await assume_role_and_parse_xml(sts_c, params);
-        validate_assume_role_response(json, `arn:aws:sts::${user_b_key}:assumed-role/${role_b}/${params.RoleSessionName}`,
-            `${user_b_key}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
+        validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
+            `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
 
     mocha.it('update assume role policy of user b to allow user a *', async function() {
@@ -422,14 +425,14 @@ mocha.describe('STS tests', function() {
 
     mocha.it('user a assume role of user b - should be rejected *', async function() {
         await assert_throws_async(sts.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be rejected *', async function() {
         await assert_throws_async(sts_c.assumeRole({
-            RoleArn: `arn:aws:sts::${account_info_b._id.toString()}:role/${role_b}`,
+            RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         }).promise(), errors.access_denied.code, errors.access_denied.message);
     });
@@ -630,8 +633,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_s3_with_session_token = new AWS.S3({
             ...sts_creds,
@@ -656,8 +659,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, duration_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, duration_seconds);
 
         const temp_s3_with_session_token = new AWS.S3({
             ...sts_creds,
@@ -697,8 +700,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_s3 = new AWS.S3({
             ...sts_creds,
@@ -720,12 +723,12 @@ mocha.describe('Session token tests', function() {
         };
 
         const json1 = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj1 = validate_assume_role_response(json1, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj1 = validate_assume_role_response(json1, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const json2 = await assume_role_and_parse_xml(accounts[2].sts, params);
-        const result_obj2 = validate_assume_role_response(json2, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj2 = validate_assume_role_response(json2, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_s3 = new AWS.S3({
             ...sts_creds,
@@ -749,8 +752,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_s3_with_session_token = new AWS.S3({
             ...sts_creds,
@@ -773,8 +776,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_s3_with_session_token = new AWS.S3({
             ...sts_creds,
@@ -798,8 +801,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_sts_with_session_token = new AWS.STS({
             ...sts_creds,
@@ -822,8 +825,8 @@ mocha.describe('Session token tests', function() {
         };
 
         const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-            `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+        const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+            `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
         const temp_sts_with_session_token = new AWS.STS({
             ...sts_creds,
@@ -849,8 +852,8 @@ mocha.describe('Session token tests', function() {
             };
 
             const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-                `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+                `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
             const temp_s3_with_session_token = new AWS.S3({
                 ...sts_creds,
@@ -875,8 +878,8 @@ mocha.describe('Session token tests', function() {
             };
 
             const json = await assume_role_and_parse_xml(accounts[1].sts, params);
-            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_key}:assumed-role/${role_alice}/${params.RoleSessionName}`,
-                `${user_a_key}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
+            const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
+                `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
             const temp_sts_with_session_token = new AWS.STS({
                 ...sts_creds,

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const dbg = require('./debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
 const RpcError = require('../rpc/rpc_error');
+const jwt = require('jsonwebtoken');
 
 const OP_NAME_TO_ACTION = Object.freeze({
     delete_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
@@ -166,7 +167,7 @@ async function _is_object_version_fit(req, predicate, value) {
  * @param {object} req
  */
 async function has_access_policy_permission(policy, account, method, resource_arn, req,
-    { disallow_public_access = false, should_pass_principal = true } = {}) {
+    { disallow_public_access = false, should_pass_principal = true, is_trust_policy = false } = {}) {
     const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
 
     // the case where the permission is an array started in op get_object_attributes
@@ -177,7 +178,8 @@ async function has_access_policy_permission(policy, account, method, resource_ar
     const res_arr_deny = await is_statement_fit_of_method_array(
         deny_statements, account_arr, method_arr, resource_arn, req, {
             disallow_public_access: false, // No need to disallow in "DENY"
-            should_pass_principal
+            should_pass_principal,
+            is_trust_policy
         }
     );
     if (res_arr_deny.every(item => item)) return 'DENY';
@@ -186,7 +188,8 @@ async function has_access_policy_permission(policy, account, method, resource_ar
     const res_arr_allow = await is_statement_fit_of_method_array(
         allow_statements, account_arr, method_arr, resource_arn, req, {
             disallow_public_access,
-            should_pass_principal
+            should_pass_principal,
+            is_trust_policy
         });
     if (res_arr_allow.every(item => item)) return 'ALLOW';
 
@@ -201,6 +204,26 @@ function _is_wildcard_match(action, method) {
     return method.startsWith(service_prefix);
 }
 
+/**
+ * _has_session_tags returns true when the JWT payload contains a non-empty
+ * principal_tags claim, indicating the federated user is forwarding session tags.
+ *
+ * @param {Object} web_identity_info - Decoded JWT payload
+ * @returns {boolean}
+ */
+function _has_session_tags(web_identity_info) {
+    const tags = get_tags_claim(web_identity_info);
+    return Boolean(tags && Object.keys(tags).length > 0);
+}
+
+/**
+ * _is_action_fit checks whether a policy statement's Action (or NotAction) covers
+ * the requested method.
+ *
+ * @param {string} method - The action being requested (e.g. 'sts:AssumeRoleWithWebIdentity')
+ * @param {Object} statement - Policy statement containing Action or NotAction
+ * @returns {boolean}
+ */
 function _is_action_fit(method, statement) {
     const statement_action = statement.Action || statement.NotAction;
     let action_fit = false;
@@ -214,24 +237,81 @@ function _is_action_fit(method, statement) {
     return statement.Action ? action_fit : !action_fit;
 }
 
-function _is_principal_fit(account_arr, statement, ignore_public_principal = false) {
-    let statement_principal = statement.Principal || statement.NotPrincipal;
+/**
+ * _is_principal_fit checks if the statement principal matches the given account or web identity.
+ *
+ * Handles both bucket policies (Principal.AWS) and assume-role trust policies (Principal.AWS +
+ * Principal.Federated).  The `account_arr` should contain all identifiers for the requesting
+ * account (email, ARN, account-id, etc.) so that any of them can match a policy principal.
+ *
+ * @param {string[]} account_arr - Array of account identifiers for the requester (email, ARN,
+ *   account-id, etc.).  A match against any element satisfies the principal check.
+ * @param {Object} statement - Policy statement object containing either `Principal` or
+ *   `NotPrincipal`.  Supports AWS (string / array) and Federated (OIDC) principal types.
+ * @param {Object} options - Optional flags that control evaluation behaviour.
+ * @param {boolean} [options.disallow_public_access=false] - When `true`, a wildcard principal
+ *   (`"*"`) in an `Allow` statement is ignored, effectively blocking public access.
+ * @param {boolean} [options.is_trust_policy=false] - When `true`, the statement is evaluated as
+ *   an assume-role trust policy.
+ * @param {Object} [options.web_identity_info={}] - Claims extracted from a web-identity token
+ *   (AssumeRoleWithWebIdentity).
+ * @returns {boolean} `true` if the principal in the statement matches the requester, `false`
+ *   otherwise.
+ */
+function _is_principal_fit(account_arr, statement,
+        { disallow_public_access = false, is_trust_policy = false, web_identity_info = {} } = {}) {
 
+    // Trust policies must not invert NotPrincipal like bucket policies
+    if (is_trust_policy && statement.NotPrincipal) return false;
+
+    const statement_principal = statement.Principal || statement.NotPrincipal;
     let principal_fit = false;
-    statement_principal = statement_principal.AWS ? statement_principal.AWS : statement_principal;
-    for (const principal of _.flatten([statement_principal])) {
+
+    // --- AWS principal ---
+    // When the principal value is a plain string / array (no sub-keys), treat as AWS principal.
+    // This preserves the original behaviour for root-level wildcard ('*') entries.
+    const principals = _get_principals(statement_principal);
+    for (const principal of _.flatten([principals])) {
         const principal_val = typeof principal === 'string' ? principal : principal.unwrap();
-        dbg.log1('access_policy: ', statement.Principal ? 'Principal' : 'NotPrincipal', ' fit?', principal_val, account_arr);
         if ((principal_val === '*') || account_arr.includes(principal_val)) {
-            if (ignore_public_principal && principal_val === '*' && statement.Principal) {
+            if (disallow_public_access && principal_val === '*' && statement.Principal) {
                 continue;
             }
-
             principal_fit = true;
             break;
         }
     }
+    // --- Federated (OIDC) principal ---
+    if (!principal_fit && statement_principal.Federated && web_identity_info.iss) {
+        for (const federated of _.flatten([statement_principal.Federated])) {
+            const federated_url = typeof federated === 'string' ? federated : federated.unwrap();
+            dbg.log1('access_policy: federated url details: ', federated_url, web_identity_info.iss);
+            // Match the OIDC provider URL after the 'oidc-provider/' prefix against the issuer
+            // hostname (strips the scheme, e.g. 'https://').
+            if (federated_url.split('oidc-provider/')[1] === web_identity_info.iss.split('//')[1]) {
+                principal_fit = true;
+                break;
+            }
+        }
+    }
+
     return statement.Principal ? principal_fit : !principal_fit;
+}
+
+/**
+ * _get_principals resolves the AWS principals from a statement principal object.
+ * When the principal value is a plain string / array (no sub-keys), treat as AWS principal.
+ * This preserves the original behaviour for root-level wildcard ('*') entries.
+ * @param {Object} statement_principal - The Principal or NotPrincipal value from the statement
+ * @returns {string|string[]} - The AWS principal(s)
+ */
+function _get_principals(statement_principal) {
+    if (statement_principal.AWS) {
+        return statement_principal.AWS;
+    } else if (statement_principal.Federated) {
+        return statement_principal.Federated;
+    }
+    return statement_principal;
 }
 
 function _is_malformed_resource(resource) {
@@ -261,40 +341,98 @@ function _is_resource_fit(arn_path, statement) {
 }
 
 async function is_statement_fit_of_method_array(statements, account_arr, method_arr, arn_path, req,
-    { disallow_public_access = false, should_pass_principal = true } = {}) {
+    { disallow_public_access = false, should_pass_principal = true, is_trust_policy = false } = {}) {
     return Promise.all(method_arr.map(method_permission =>
-        _is_statements_fit(statements, account_arr, method_permission, arn_path, req, { disallow_public_access, should_pass_principal })));
+        _is_statements_fit(statements, account_arr, method_permission, arn_path, req, {
+            disallow_public_access,
+            should_pass_principal,
+            is_trust_policy,
+        })));
 }
 
 async function _is_statements_fit(statements, account_arr, method, arn_path, req,
-    { disallow_public_access = false, should_pass_principal = true} = {}) {
+    { disallow_public_access = false, should_pass_principal = true, is_trust_policy = false } = {}) {
+    const web_identity_info = is_trust_policy ? fetch_web_identity_info(req) : undefined;
+    // AWS requires sts:TagSession to be allowed somewhere in the policy when the JWT carries session
+    // tags and the requested action is AssumeRoleWithWebIdentity. The sts:TagSession allow may live
+    // in a separate statement from the one that grants sts:AssumeRoleWithWebIdentity.
+    const needs_tag_session_check = method === 'sts:AssumeRoleWithWebIdentity' && _has_session_tags(web_identity_info);
+    const tag_session_allowed = needs_tag_session_check && statements.some(s => _is_action_fit('sts:TagSession', s));
     for (const statement of statements) {
         const action_fit = _is_action_fit(method, statement);
         // When evaluating IAM user inline policies, should_pass_principal is false since these policies
         // don't have a Principal field (the principal is implicitly the user)
-        const principal_fit = should_pass_principal ? _is_principal_fit(account_arr, statement, disallow_public_access) : true;
-        const resource_fit = _is_resource_fit(arn_path, statement);
-        const condition_fit = await _is_condition_fit(statement, req, method);
+        const principal_fit = should_pass_principal ?
+                        _is_principal_fit(account_arr, statement, {disallow_public_access, is_trust_policy, web_identity_info}) : true;
+        const resource_fit = is_trust_policy ? true : _is_resource_fit(arn_path, statement);
+        const condition_fit = await _is_condition_fit(statement, req, method, {web_identity_info, is_trust_policy});
+        const tag_session_fit = _is_tag_session_fit(needs_tag_session_check, tag_session_allowed);
 
-        dbg.log1('access_policy - is_statements_fit: action_fit, principal_fit, resource_fit, condition_fit', action_fit, principal_fit, resource_fit, condition_fit);
-        if (action_fit && principal_fit && resource_fit && condition_fit) return true;
+        dbg.log0('access_policy - is_statements_fit:', 'action_fit: ', action_fit, 'principal_fit: ', principal_fit, 'resource_fit: ', resource_fit, 'condition_fit: ', condition_fit,
+                "tag_session_fit: ", tag_session_fit
+        );
+        if (action_fit && principal_fit && resource_fit && condition_fit && tag_session_fit) {
+            return true;
+        }
     }
     return false;
 }
 
-async function _is_condition_fit(policy_statement, req, method) {
+/**
+ * _is_tag_session_fit check tag session have Action "sts:TagSession" and 
+ * _has_session_tags returns true when the JWT payload contains a non-empty
+ * @param {boolean} needs_tag_session_check - needs tag session check
+ * @param {boolean} tag_session_allowed 
+ * @returns {boolean}
+ */
+function _is_tag_session_fit(needs_tag_session_check, tag_session_allowed) {
+    if (needs_tag_session_check && !tag_session_allowed) return false;
+    return true;
+}
+
+/**
+ * _is_condition_fit checks whether the Condition block of a single policy statement
+ * is satisfied for the current request.
+ *
+ * Two distinct evaluation paths exist:
+ *
+ *   1. Trust-policy (is_trust_policy === true):
+ *      Delegates to _is_identity_condition_fit, which evaluates OIDC / LDAP identity
+ *      conditions (e.g. StringEquals on Keycloak claims or ldap: attributes) using
+ *      the decoded JWT / identity payload supplied in web_identity_info.
+ *
+ *   2. Bucket / resource policy (is_trust_policy === false):
+ *      Iterates over every operator (e.g. StringEquals, StringLike) and condition key
+ *      (e.g. s3:ExistingObjectTag, s3:x-amz-server-side-encryption, s3:VersionId) in
+ *      the Condition block.
+ *
+ * @param {Object} policy_statement    - A single Statement object from the policy document.
+ * @param {Object} req                 - The incoming HTTP request object.
+ * @param {string} method              - The normalised S3 action being evaluated (e.g. 's3:GetObject').
+ * * @param {Object} options - Optional flags that control evaluation behaviour.
+ * @param {boolean} [options.web_identity_info={}] - Claims extracted from a web-identity token
+ *   (AssumeRoleWithWebIdentity).
+ * @param {boolean} [options.is_trust_policy=false] - When `true`, the statement is evaluated as
+ *   an assume-role trust policy.
+ * @returns {Promise<boolean>} - Resolves to true if all conditions are satisfied, false otherwise.
+ */
+async function _is_condition_fit(policy_statement, req, method, { web_identity_info = {}, is_trust_policy = false } = {}) {
     if (!policy_statement.Condition || !req) {
         return true;
     }
-    _parse_condition_keys(policy_statement.Condition);
-    for (const [condition, condition_statements] of Object.entries(policy_statement.Condition)) {
-        const predicate = predicate_map[condition];
-        for (const [condition_key, value] of Object.entries(condition_statements)) {
-            if (!supported_actions[condition_key].includes(method)) {
-                continue;
-            }
-            if (await condition_fit_functions[condition_key](req, predicate, value) === false) {
-                return false;
+    if (is_trust_policy) {
+        return _is_identity_condition_fit(Boolean(web_identity_info.iss), policy_statement.Condition, web_identity_info);
+    } else {
+        _parse_condition_keys(policy_statement.Condition);
+        for (const [condition, condition_statements] of Object.entries(policy_statement.Condition)) {
+            const predicate = predicate_map[condition];
+            for (const [condition_key, value] of Object.entries(condition_statements)) {
+                if (!supported_actions[condition_key].includes(method)) {
+                    continue;
+                }
+                if (await condition_fit_functions[condition_key](req, predicate, value) === false) {
+                    return false;
+                }
             }
         }
     }
@@ -429,7 +567,7 @@ function allows_public_access(policy) {
  * @param {Object} account 
  * @returns {string}
  */
-function get_bucket_policy_principal_arn(account) {
+function get_policy_principal_arn(account) {
     const bucket_policy_arn = account.owner ? create_arn_for_user(account.owner, account.name.unwrap().split(':')[0], account.iam_path) :
                                         create_arn_for_root(account._id);
     return bucket_policy_arn;
@@ -778,16 +916,30 @@ function compare_for_any_value_string_equals(actual, expected) {
     );
 }
 
+/**
+ * fetch web identity object from request web_identity_token param
+ * @param {Object} req - Request object
+ * @returns {Object} - web_identity_info
+ */
+function fetch_web_identity_info(req) {
+    let web_identity_info;
+    if (req?.body?.web_identity_token) {
+        web_identity_info = jwt.decode(req.body.web_identity_token, { json: true });
+    }
+    return web_identity_info || {};
+}
+
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.VECTOR_OP_NAME_TO_ACTION = VECTOR_OP_NAME_TO_ACTION;
 exports.has_access_policy_permission = has_access_policy_permission;
 exports.validate_bucket_policy = validate_bucket_policy;
 exports.validate_vector_bucket_policy = validate_vector_bucket_policy;
 exports.allows_public_access = allows_public_access;
-exports.get_bucket_policy_principal_arn = get_bucket_policy_principal_arn;
+exports.get_policy_principal_arn = get_policy_principal_arn;
 exports.create_arn_for_root = create_arn_for_root;
 exports.get_account_identifier_id = get_account_identifier_id;
 exports._is_wildcard_match = _is_wildcard_match;
 exports._is_identity_condition_fit = _is_identity_condition_fit;
 exports.keycloak_predicate_map = keycloak_predicate_map;
 exports.extract_tag_key_from_condition = extract_tag_key_from_condition;
+exports.fetch_web_identity_info = fetch_web_identity_info;

--- a/src/util/keycloak_client.js
+++ b/src/util/keycloak_client.js
@@ -5,6 +5,7 @@ const { KeyCloakProvider } = require('./keycloak_utils');
 const config = require('../../config');
 const dbg = require('./debug_module')(__filename);
 const fs = require('fs');
+const jwt = require('jsonwebtoken');
 
 /**
  * Singleton KeyCloak client manager
@@ -72,19 +73,13 @@ class KeyCloakClientManager {
     }
 
     /**
-     * Verify token and return provider + verified token
      * This method decode the token, introspects will do actual verification
      * @param {String} token - token
      */
     async verify_token(token) {
-        const decoded = require('jsonwebtoken').decode(token);
+        const decoded = jwt.decode(token);
         if (!decoded || !decoded.iss) {
             throw new Error('Invalid token: missing issuer');
-        }
-
-        const provider = this.get_provider(decoded.iss);
-        if (!provider) {
-            throw new Error(`No KeyCloak provider configured for issuer: ${decoded.iss}`);
         }
     }
 
@@ -95,11 +90,7 @@ class KeyCloakClientManager {
      * @returns {Promise<Object>} - introspection result
      */
     async introspect_token(token) {
-        const decoded = require('jsonwebtoken').decode(token);
-        if (!decoded || !decoded.iss) {
-            throw new Error('Invalid token: missing issuer');
-        }
-
+        const decoded = jwt.decode(token);
         const provider = this.get_provider(decoded.iss);
         if (!provider) {
             throw new Error(`No KeyCloak provider configured for issuer: ${decoded.iss}`);


### PR DESCRIPTION

### Describe the Problem

This code use existing has_access_policy_permission method in access_policy_utils and remove duplicate code sts_rest

### Explain the Changes
1. Make changes in `sts_rest.authorize_request_policy()` method to use access_policy_utils.has_access_policy_permission()
2. Update role ARN with account id

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 

manual testing
1. Create role for assume role
`iam create-role --role-name test-role-iam3 --assume-role-policy-document file://../../iam_trust_policy_01.json --max-session-duration 3600`
with trust policy
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam:::oidc-provider/keycloak.noobaa.svc.cluster.local:8080/realms/noobaa"
      },
      "Action": ["sts:AssumeRoleWithWebIdentity", "sts:TagSession"],
      "Condition": {
        "ForAnyValue:StringEquals": {
          "keycloak.noobaa.svc.cluster.local:8080/realms/noobaa:aud": "noobaa-client",
          "aws:RequestTag/Department":"Engineering"
        }
      }
    }
  ]
}
```
2. Call assume-role-with-web-identity API with web-identity-toke that satify the `Principal`, `Action` and `Condition`.
```
 aws sts assume-role-with-web-identity --endpoint https://127.0.0.1:62561 --role-arn arn:aws:iam::6a5f08ac3b67a2001e4ba029:role/test-role-iam3 --role-session-name arn_root --no-verify-ssl --web-identity-toke eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ3Wjl3UmV0MWpia2h6TlVqRGhpdW9
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket, vector, and permission authorization by using consistent account principal ARN resolution across policy checks.
  * Strengthened assume-role web-identity authorization by decoding web-identity info, enabling Federated/OIDC principal matching, and applying identity-based condition evaluation when applicable.
  * Updated STS web-identity error handling to return the correct general STS error types, and streamlined JWT decoding in token verification/introspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->