### PR TITLE
Keycloak | IAM Roles caching

### DIFF
--- a/config.js
+++ b/config.js
@@ -712,6 +712,8 @@ config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS = 60000;
 config.OBJECT_SDK_ACCOUNT_CACHE_EXPIRY_MS = Number(process.env.ACCOUNTS_CACHE_EXPIRY) || 10 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
 // Accountspace_fs account id cache expiration time
 config.ACCOUNTS_ID_CACHE_EXPIRY = 3 * 60 * 1000; // TODO: Decide on a time that we want to invalidate
+// IAM ListRoles cache expiration time (containerized endpoint)
+config.IAM_ROLES_CACHE_EXPIRY_MS = Number(process.env.IAM_ROLES_CACHE_EXPIRY) || 10 * 60 * 1000;
 
 // Nodes identity cache (list_nodes_by_identity per-node entries)
 config.NODES_IDENTITY_CACHE_MAX = 100;

--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -183,6 +183,25 @@ module.exports = {
             }
         },
 
+        read_role_by_name: {
+            doc: 'Read role info by name for endpoint cache loading',
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['role_name', 'owner_account_id'],
+                properties: {
+                    role_name: { type: 'string' },
+                    owner_account_id: { type: 'string' },
+                }
+            },
+            reply: {
+                $ref: '#/definitions/role_info',
+            },
+            auth: {
+                system: 'admin',
+            }
+        },
+
         update_account: {
             doc: 'Update the info of the authorized account',
             method: 'PUT',

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -3,6 +3,7 @@
 
 const account_util = require('../util/account_util');
 const { IAM_DEFAULT_PATH} = require('../endpoint/iam/iam_constants');
+const { iam_roles_cache } = require('./object_sdk');
 
 /**
  * @implements {nb.AccountSpace}
@@ -146,11 +147,21 @@ class AccountSpaceNB {
     }
 
     async update_role(params, account_sdk) {
-        return account_sdk.rpc_client.account.update_role(params);
+        const result = await account_sdk.rpc_client.account.update_role(params);
+        iam_roles_cache.invalidate({
+            role_name: params.role_name,
+            owner_account_id: String(account_sdk.requesting_account._id),
+        });
+        return result;
     }
 
     async delete_role(params, account_sdk) {
-        return account_sdk.rpc_client.account.delete_role(params);
+        const result = await account_sdk.rpc_client.account.delete_role(params);
+        iam_roles_cache.invalidate({
+            role_name: params.role_name,
+            owner_account_id: String(account_sdk.requesting_account._id),
+        });
+        return result;
     }
 
     async list_roles(params, account_sdk) {
@@ -174,7 +185,13 @@ class AccountSpaceNB {
     }
 
     async update_assume_role_policy(params, account_sdk) {
-        return account_sdk.rpc_client.account.update_assume_role_policy(params);
+        const result = await account_sdk.rpc_client.account.update_assume_role_policy(params);
+        // Trust policy is part of cached role_info — invalidate so STS does not use a stale policy
+        iam_roles_cache.invalidate({
+            role_name: params.role_name,
+            owner_account_id: String(account_sdk.requesting_account._id),
+        });
+        return result;
     }
 }
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -108,6 +108,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         }
     }
 
+    async read_role_by_name({ role_name, owner_account_id }) {
+        return {};
+    }
+
     async read_bucket_sdk_info({ name }) {
         try {
             dbg.log0('BucketSpaceFS.read_bucket_sdk_info: bucket name', name);

--- a/src/sdk/bucketspace_nb.js
+++ b/src/sdk/bucketspace_nb.js
@@ -24,6 +24,10 @@ class BucketSpaceNB {
         return this.internal_rpc_client.account.read_account_by_access_key({ access_key });
     }
 
+    async read_role_by_name({ role_name, owner_account_id }) {
+        return this.internal_rpc_client.account.read_role_by_name({ role_name, owner_account_id });
+    }
+
     async read_bucket_sdk_info({ name }) {
         return this.internal_rpc_client.bucket.read_bucket_sdk_info({ name });
     }

--- a/src/sdk/bucketspace_simple_fs.js
+++ b/src/sdk/bucketspace_simple_fs.js
@@ -28,6 +28,10 @@ class BucketSpaceSimpleFS {
         return {};
     }
 
+    async read_role_by_name({ role_name, owner_account_id }) {
+        return {};
+    }
+
     async read_bucket_sdk_info({ name }) {
         return {};
     }

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -899,6 +899,7 @@ interface Namespace {
 interface BucketSpace {
 
     read_account_by_access_key({ access_key: string }): Promise<any>;
+    read_role_by_name({ role_name, owner_account_id }: { role_name: string; owner_account_id: string }): Promise<any>;
     read_bucket_sdk_info({ name: string }): Promise<any>;
     check_same_stat_bucket(bucket_name: string, bucket_stat: nb.NativeFSStats); // only implemented in bucketspace_fs
     check_same_stat_account(account_name: string | Symbol, account_stat: nb.NativeFSStats); // only implemented in bucketspace_fs

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -65,6 +65,23 @@ const account_cache = new LRUCache({
     validate: (data, params) => _validate_account(data, params),
 });
 
+// IAM role cache — keyed by owner + role_name (role names are unique per account, not globally)
+const iam_roles_cache = new LRUCache({
+    name: 'IamRolesCache',
+    expiry_ms: config.IAM_ROLES_CACHE_EXPIRY_MS,
+    /**
+     * Set type for the generic template
+     * @param {{
+     *      role_name: string;
+     *      owner_account_id: string;
+     *      bucketspace: nb.BucketSpace;
+     * }} params
+     */
+    make_key: ({ role_name, owner_account_id }) => `${owner_account_id}:${role_name}`,
+    load: async ({ bucketspace, role_name, owner_account_id }) =>
+        bucketspace.read_role_by_name({ role_name, owner_account_id }),
+});
+
 const dn_cache = new LRUCache({
     name: 'DistinguishedNameCache',
     // TODO: Decide on a time that we want to invalidate, 1M for now
@@ -340,6 +357,27 @@ class ObjectSDK {
             if (error.rpc_code === 'NO_SUCH_USER') throw new RpcError('UNAUTHORIZED', `Distinguished name associated with access_key not found`);
             throw error;
         }
+    }
+
+    /**
+     * Load a single IAM role through the endpoint cache (not the public IAM GetRole API).
+     *
+     * Callers must pass owner_account_id (typically from the role ARN).
+     * (AssumeRoleWithWebIdentity) or be the caller rather than the role owner (AssumeRole).
+     *
+     * @param {string} role_name
+     * @param {string} owner_account_id
+     * @returns {Promise<object>}
+     */
+    async get_iam_role_by_name(role_name, owner_account_id) {
+        if (!owner_account_id) {
+            throw new RpcError('UNAUTHORIZED', 'owner_account_id is required');
+        }
+        return iam_roles_cache.get_with_cache({
+            bucketspace: this._get_bucketspace(),
+            role_name,
+            owner_account_id: String(owner_account_id),
+        });
     }
 
     async authorize_request_account(req) {
@@ -1306,11 +1344,13 @@ module.exports = {
     ObjectSDK,
     anonymous_access_key: anonymous_access_key,
     account_cache: account_cache,
+    iam_roles_cache: iam_roles_cache,
     dn_cache: dn_cache,
 };
 
 module.exports = ObjectSDK;
 module.exports.anonymous_access_key = anonymous_access_key;
 module.exports.account_cache = account_cache;
+module.exports.iam_roles_cache = iam_roles_cache;
 module.exports.dn_cache = dn_cache;
 module.exports.supplemental_groups_cache = supplemental_groups_cache;

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -138,6 +138,13 @@ function read_account_by_access_key(req) {
     return get_account_info(account);
 }
 
+function read_role_by_name(req) {
+    const { role_name, owner_account_id } = req.rpc_params;
+    const account_roles = _list_active_iam_roles_for_account(owner_account_id);
+    const iam_role = _get_iam_role_by_name_or_throw(account_roles, role_name);
+    return _return_iam_role_info(iam_role, String(owner_account_id));
+}
+
 /**
  *
  * GENERATE_ACCOUNT_KEYS
@@ -1948,6 +1955,7 @@ exports.ensure_support_account = ensure_support_account;
 exports.verify_authorized_account = verify_authorized_account;
 exports.get_account_usage = get_account_usage;
 exports.read_account_by_access_key = read_account_by_access_key;
+exports.read_role_by_name = read_role_by_name;
 exports.create_role = create_role;
 exports.get_role = get_role;
 exports.update_role = update_role;

--- a/src/test/unit_tests/util_functions_tests/test_iam_role_cache.js
+++ b/src/test/unit_tests/util_functions_tests/test_iam_role_cache.js
@@ -1,0 +1,138 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const mocha = require('mocha');
+const assert = require('assert');
+const { RpcError } = require('../../../rpc');
+// object_sdk exports the ObjectSDK class as module.exports, with caches as properties
+const ObjectSDK = require('../../../sdk/object_sdk');
+const { iam_roles_cache } = ObjectSDK;
+
+mocha.describe('iam_roles_cache', function() {
+    const owner_account_id = 'owner-123';
+    const role_name = 'test_role';
+    let num_loads = 0;
+    const role = {
+        role_id: 'role-id-1',
+        role_name,
+        iam_path: '/',
+        arn: 'arn:aws:iam::owner-123:role/test_role',
+        create_date: Date.now(),
+        assume_role_policy_document: { statement: [] },
+    };
+
+    const mock_bucketspace = {
+        read_role_by_name: async ({ role_name: name, owner_account_id: account_id }) => {
+            num_loads += 1;
+            assert.strictEqual(name, role_name);
+            assert.strictEqual(account_id, owner_account_id);
+            return role;
+        },
+    };
+
+    mocha.beforeEach(function() {
+        num_loads = 0;
+        iam_roles_cache.invalidate({ role_name, owner_account_id });
+        iam_roles_cache.invalidate({ role_name, owner_account_id: 'other-owner' });
+    });
+
+    mocha.it('should load role on cache miss', async function() {
+        const result = await iam_roles_cache.get_with_cache({
+            bucketspace: mock_bucketspace,
+            role_name,
+            owner_account_id,
+        });
+        assert.deepStrictEqual(result, role);
+        assert.strictEqual(num_loads, 1);
+    });
+
+    mocha.it('should return cached role without reloading', async function() {
+        await iam_roles_cache.get_with_cache({ bucketspace: mock_bucketspace, role_name, owner_account_id });
+        const result = await iam_roles_cache.get_with_cache({ bucketspace: mock_bucketspace, role_name, owner_account_id });
+        assert.deepStrictEqual(result, role);
+        assert.strictEqual(num_loads, 1);
+    });
+
+    mocha.it('should load separately when owner_account_id differs', async function() {
+        const other_role = { ...role, role_id: 'role-id-other' };
+        await iam_roles_cache.get_with_cache({ bucketspace: mock_bucketspace, role_name, owner_account_id });
+        const other_owner_bucketspace = {
+            read_role_by_name: async ({ owner_account_id: account_id }) => {
+                num_loads += 1;
+                assert.strictEqual(account_id, 'other-owner');
+                return other_role;
+            },
+        };
+        const result = await iam_roles_cache.get_with_cache({
+            bucketspace: other_owner_bucketspace,
+            role_name,
+            owner_account_id: 'other-owner',
+        });
+        assert.deepStrictEqual(result, other_role);
+        assert.strictEqual(num_loads, 2);
+    });
+
+    mocha.it('should reload role after invalidation', async function() {
+        await iam_roles_cache.get_with_cache({ bucketspace: mock_bucketspace, role_name, owner_account_id });
+        iam_roles_cache.invalidate({ role_name, owner_account_id });
+        await iam_roles_cache.get_with_cache({ bucketspace: mock_bucketspace, role_name, owner_account_id });
+        assert.strictEqual(num_loads, 2);
+    });
+});
+
+mocha.describe('ObjectSDK.get_iam_role_by_name', function() {
+    const owner_account_id = 'owner-789';
+    const role_name = 'my_role';
+    let num_loads = 0;
+    const role = {
+        role_id: 'role-id-4',
+        role_name,
+        iam_path: '/',
+        arn: `arn:aws:iam::${owner_account_id}:role/${role_name}`,
+        create_date: Date.now(),
+        assume_role_policy_document: { statement: [] },
+    };
+
+    const mock_bucketspace = {
+        read_role_by_name: async ({ role_name: name, owner_account_id: account_id }) => {
+            num_loads += 1;
+            assert.strictEqual(name, role_name);
+            assert.strictEqual(account_id, owner_account_id);
+            return role;
+        },
+    };
+
+    let object_sdk;
+
+    mocha.beforeEach(function() {
+        num_loads = 0;
+        iam_roles_cache.invalidate({ role_name, owner_account_id });
+        object_sdk = new ObjectSDK({
+            rpc_client: {},
+            internal_rpc_client: {},
+            object_io: {},
+            bucketspace: mock_bucketspace,
+        });
+    });
+
+    mocha.it('should load role through ObjectSDK on cache miss', async function() {
+        const result = await object_sdk.get_iam_role_by_name(role_name, owner_account_id);
+        assert.deepStrictEqual(result, role);
+        assert.strictEqual(num_loads, 1);
+    });
+
+    mocha.it('should serve get_iam_role_by_name from cache without reloading', async function() {
+        await object_sdk.get_iam_role_by_name(role_name, owner_account_id);
+        const result = await object_sdk.get_iam_role_by_name(role_name, owner_account_id);
+        assert.deepStrictEqual(result, role);
+        assert.strictEqual(num_loads, 1);
+    });
+
+    mocha.it('should throw when owner_account_id is missing', async function() {
+        await assert.rejects(
+            () => object_sdk.get_iam_role_by_name(role_name),
+            err => err instanceof RpcError && err.rpc_code === 'UNAUTHORIZED',
+        );
+        assert.strictEqual(num_loads, 0);
+    });
+});

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -17,6 +17,7 @@ require('../../unit_tests/util_functions_tests/test_linked_list');
 require('../../unit_tests/util_functions_tests/test_keys_lock');
 require('../../unit_tests/util_functions_tests/test_lru');
 require('../../unit_tests/util_functions_tests/test_lru_cache');
+require('../../unit_tests/util_functions_tests/test_iam_role_cache');
 require('../../unit_tests/util_functions_tests/test_prefetch');
 require('../../unit_tests/util_functions_tests/test_promise_utils');
 require('../../unit_tests/util_functions_tests/test_rpc');


### PR DESCRIPTION
### Describe the Problem
Implement IAM roles caching 

### Explain the Changes
1. Added an in-memory cache for IAM roles on the endpoint, keyed by role name and owner id .
2. Added a new internal RPC read_role_by_name so the endpoint can fetch a single role from core.
3. Added ObjectSDK.get_iam_role_by_name(role_name, owner_account_id) so S3/STS callers can read roles through the cache.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/RHSTOR-9422

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-protected role lookup by name in the account API (`read_role_by_name`), exposed in the SDK as `get_iam_role_by_name`.
  * Introduced an in-SDK IAM role cache to speed up repeated lookups, with configurable expiry (default: 1 minute).
* **Bug Fixes**
  * Role changes (update/delete/policy updates) now automatically refresh cached role data.
* **Tests**
  * Added unit tests covering cache miss/hit behavior, cache invalidation reloads, and missing-`owner_account_id` authorization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->