### PR TITLE
Added support for IAM role trust policy evaluation

### DIFF
--- a/src/endpoint/sts/ops/sts_post_assume_role.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role.js
@@ -12,9 +12,6 @@ const sts_utils = require('../../sts/sts_utils');
  */
 async function assume_role(req) {
     dbg.log1('sts_post_assume_role body: ', req.body);
-    const duration_ms = sts_utils.parse_sts_duration(req.body.duration_seconds);
-    const duration_sec = Math.ceil(duration_ms / 1000);
-    const expiration_time = Date.now() + duration_ms;
     let assumed_role;
     try {
         assumed_role = await req.sts_sdk.get_assumed_role(req);
@@ -24,6 +21,9 @@ async function assume_role(req) {
         }
         throw new StsError(StsError.InternalFailure);
     }
+
+    const { duration_sec, expiration_time } = sts_utils.get_session_duration_info(
+        req.body.duration_seconds, assumed_role.role_config.max_session_duration);
 
     // Temporary credentials are NOT stored in noobaa
     // The generated session token will store in it the temporary credentials and expiry and the role's access key

--- a/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
+++ b/src/endpoint/sts/ops/sts_post_assume_role_with_web_identity.js
@@ -13,9 +13,6 @@ const _ = require('lodash');
  */
 async function assume_role_with_web_identity(req) {
     dbg.log0('sts_post_assume_role_with_web_identity body: ', _.omit(req.body, 'web_identity_token'));
-    const duration_ms = sts_utils.parse_sts_duration(req.body.duration_seconds);
-    const duration_sec = Math.ceil(duration_ms / 1000);
-    const expiration_time = Date.now() + duration_ms;
     let assumed_role;
     try {
         // CHANGED: Use unified method that supports both LDAP and OIDC/Keycloak
@@ -33,6 +30,10 @@ async function assume_role_with_web_identity(req) {
         }
         throw new StsError(StsError.InternalFailure);
     }
+
+    const { duration_sec, expiration_time } = sts_utils.get_session_duration_info(
+        req.body.duration_seconds, assumed_role.role_config.max_session_duration);
+
     // Temporary credentials are NOT stored in noobaa
     // The generated session token will store in it the temporary credentials and expiry and the role's access key
     const access_keys = await req.sts_sdk.generate_temp_access_keys();

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -146,23 +146,36 @@ async function authorize_request(req) {
     await authorize_request_policy(req);
 }
 
+// not supported in trust evaluation: Principal.Service, bare Principal "*", NotPrincipal,
+// SAML, sts:TagSession / SetSourceIdentity, MFA / session-tag conditions, assumed-role session ARNs as Principal
 async function authorize_request_policy(req) {
     if (req.op_name !== 'post_assume_role' && req.op_name !== 'post_assume_role_with_web_identity') return;
 
     const assume_role_policy = await get_assume_role_policy(req);
-    if (!assume_role_policy) throw new StsError(StsError.AccessDeniedException);
+    if (!assume_role_policy) {
+        dbg.log0('sts_rest.authorize_request_policy: missing assume role policy for role', req.body.role_arn);
+        throw new StsError(StsError.AccessDeniedException);
+    }
     const method = _get_method_from_req(req);
-    const cur_account_email = req.sts_sdk.requesting_account && req.sts_sdk.requesting_account.email.unwrap();
+    const requesting_account = req.sts_sdk.requesting_account;
+    const cur_account_email = requesting_account && requesting_account.email.unwrap();
     // system owner by design can always assume role policy of any account
     // skip for NC environments since system owner is not applicable
-    if (!is_nc_environment() && (cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) return;
+    if (!is_nc_environment() && (cur_account_email === _get_system_owner().unwrap()) && req.op_name.endsWith('assume_role')) {
+        dbg.log1('sts_rest.authorize_request_policy: system owner bypass for role', req.body.role_arn);
+        return;
+    }
+
     const web_identity_info = fetch_web_identity_info(req);
-    const permission = has_assume_role_permission(assume_role_policy, method, req.sts_sdk.requesting_account, web_identity_info);
-    dbg.log0('sts_rest.authorize_request_policy permission is: ', permission);
+    const request_context = access_policy_utils.build_sts_trust_request_context(
+        req.body.external_id, requesting_account);
+    const permission = has_assume_role_permission(
+        assume_role_policy, method, requesting_account, web_identity_info, request_context);
+    dbg.log0('sts_rest.authorize_request_policy permission is:', permission,
+        'role', req.body.role_arn, 'method', method, 'account', cur_account_email);
     if (permission === 'DENY' || permission === 'IMPLICIT_DENY') {
         throw new StsError(StsError.AccessDeniedException);
     }
-    // permission is ALLOW, can return without error
 }
 
 function _get_system_owner() {
@@ -216,35 +229,37 @@ function handle_error(req, res, err) {
     res.end(reply);
 }
 
-function has_assume_role_permission(policy, method, account, web_identity_info) {
+/**
+ * has_assume_role_permission evaluates the role trust policy for AssumeRole
+ * @param {Object} policy
+ * @param {String} method
+ * @param {Object} account
+ * @param {Object} web_identity_info
+ * @param {Object} [request_context]
+ * @returns {'DENY'|'ALLOW'|'IMPLICIT_DENY'}
+ */
+function has_assume_role_permission(policy, method, account, web_identity_info, request_context = {}) {
     const [allow_statements, deny_statements] = _.partition(policy.Statement, statement => statement.Effect === 'Allow');
-    // look for explicit denies
-    if (_is_statements_fit(deny_statements, method, account, web_identity_info)) return 'DENY';
-    // look for explicit allows
-    if (_is_statements_fit(allow_statements, method, account, web_identity_info)) return 'ALLOW';
-
-    // implicit deny
+    if (_is_statements_fit(deny_statements, method, account, web_identity_info, request_context)) return 'DENY';
+    if (_is_statements_fit(allow_statements, method, account, web_identity_info, request_context)) return 'ALLOW';
     return 'IMPLICIT_DENY';
 }
 
-function _is_statements_fit(statements, method, account, web_identity_info) {
+/**
+ * _is_statements_fit returns true if any statement fits action, principal, and condition
+ * @param {Object[]} statements
+ * @param {String} method
+ * @param {Object} account
+ * @param {Object} web_identity_info
+ * @param {Object} request_context
+ * @returns {boolean}
+ */
+function _is_statements_fit(statements, method, account, web_identity_info, request_context) {
     for (const statement of statements) {
-        let action_fit = false;
-        let principal_fit = false;
-        dbg.log0('assume_role_policy: statement', statement);
-
-        // what action can be done
-
-        action_fit = _is_action_fit(method, statement);
-        dbg.log0('assume_role_policy: action fit?', action_fit);
-
-        principal_fit = _is_principal_fit(statement, account, web_identity_info);
-        dbg.log0('assume_role_policy: principal fit?', principal_fit);
-
-        const condition_fit = _is_condition_fit(statement.Condition, web_identity_info);
-        dbg.log0('assume_role_policy: condition fit?', condition_fit);
-
-        dbg.log0('assume_role_policy: is_statements_fit', action_fit, principal_fit, condition_fit);
+        const action_fit = _is_action_fit(method, statement);
+        const principal_fit = _is_principal_fit(statement, account, web_identity_info);
+        const condition_fit = _is_condition_fit(statement.Condition, web_identity_info, request_context);
+        dbg.log1('assume_role_policy: is_statements_fit', action_fit, principal_fit, condition_fit);
         if (action_fit && principal_fit && condition_fit) return true;
     }
     return false;
@@ -252,97 +267,75 @@ function _is_statements_fit(statements, method, account, web_identity_info) {
 
 /**
  * _is_principal_fit checks if the statement can be applied to the account
- * @param {Object | Array} statement - The condition(s) from the policy statement
- * @param {Object} account - The account to validate against
- * @param {Object} web_identity_info - The web identity information to validate against
- * @returns {boolean} - true if all principle are satisfied, false otherwise
+ * @param {Object} statement
+ * @param {Object} account
+ * @param {Object} web_identity_info
+ * @returns {boolean}
  */
 function _is_principal_fit(statement, account, web_identity_info) {
     const statement_principal = statement.Principal || statement.NotPrincipal;
+    if (!statement_principal) return false;
 
-        let principal_fit = false;
-        if (statement_principal.Federated) {
-            for (const federated of _.flatten([statement_principal.Federated])) {
-                const federated_url = typeof federated === 'string' ? federated : federated.unwrap();
-                dbg.log0('assume_role_policy: principal federated fit?', federated_url, web_identity_info.iss);
-                if (federated_url.split("oidc-provider/")[1] === web_identity_info.iss?.split('//')[1]) {
-                    principal_fit = true;
-                }
-            }
-        }
+    const federated_fit = Boolean(statement_principal.Federated) &&
+        _.flatten([statement_principal.Federated]).some(federated => {
+            const federated_url = typeof federated === 'string' ? federated : federated.unwrap();
+            dbg.log1('assume_role_policy: principal federated fit?', federated_url, web_identity_info.iss);
+            return federated_url.split('oidc-provider/')[1] === web_identity_info.iss?.split('//')[1];
+        });
 
-        if (statement_principal.AWS) {
-            for (const principal_aws of _.flatten([statement_principal.AWS])) {
-                const principal = typeof principal_aws === 'string' ? principal_aws : principal_aws.unwrap();
-                const cur_account_email = account?.email.unwrap();
-                // Added ARN to principle validation
-                const account_identifier_arn = account ? access_policy_utils.get_bucket_policy_principal_arn(account) : "";
-                dbg.log0('assume_role_policy: principal fit?', principal, cur_account_email, account_identifier_arn);
-                if ((principal === cur_account_email) || (principal === '*') || (principal === account_identifier_arn)) {
-                    principal_fit = true;
-                }
-            }
-        }
+    const aws_fit = Boolean(statement_principal.AWS) &&
+        _.flatten([statement_principal.AWS]).some(principal => {
+            const principal_str = typeof principal === 'string' ? principal : principal.unwrap();
+            const cur_account_email = account?.email?.unwrap?.() ?? account?.email;
+            const account_identifier_arn = account ?
+                access_policy_utils.get_bucket_policy_principal_arn(account) : '';
+            dbg.log1('assume_role_policy: principal fit?', principal_str, cur_account_email, account_identifier_arn);
+            return access_policy_utils.is_aws_trust_principal_match(principal, account);
+        });
 
+    const principal_fit = federated_fit || aws_fit;
     return statement.Principal ? principal_fit : !principal_fit;
 }
 
-
 /**
  * _is_action_fit checks if the method is allowed by the statement
- * @param {String} method - The account to validate against
- * @param {Object|Array} statement - The condition(s) from the policy statement
- * @returns {boolean} - true if all method are satisfied, false otherwise
+ * @param {String} method
+ * @param {Object} statement
+ * @returns {boolean}
  */
 function _is_action_fit(method, statement) {
     const statement_action = statement.Action || statement.NotAction;
-    let action_fit = false;
-    for (const action of _.flatten([statement_action])) {
-        dbg.log1('access_policy: ', statement.Action ? 'Action' : 'NotAction', ' fit?', action, method);
-        if (action === method || access_policy_utils._is_wildcard_match(action, method)) {
-            action_fit = true;
-            break;
-        }
-    }
+    const action_fit = _.flatten([statement_action]).some(action => {
+        dbg.log1('assume_role_policy:', statement.Action ? 'Action' : 'NotAction', 'fit?', action, method);
+        return action === method || access_policy_utils._is_wildcard_match(action, method);
+    });
     return statement.Action ? action_fit : !action_fit;
 }
 
-
 /**
- * _is_condition_fit checks if the statement conditions match the web identity info
- * @param {Object|Array} statement_condition - The condition(s) from the policy statement
- * @param {Object} web_identity_info - The web identity information to validate against
- * @returns {boolean} - true if all conditions are satisfied, false otherwise
+ * _is_condition_fit checks if the statement conditions match the web identity info and request context
+ * @param {Object|Array} statement_condition
+ * @param {Object} web_identity_info
+ * @param {Object} request_context
+ * @returns {boolean}
  */
-function _is_condition_fit(statement_condition, web_identity_info) {
+function _is_condition_fit(statement_condition, web_identity_info, request_context) {
     if (!statement_condition) return true;
-
-    let statement_conditions = statement_condition;
-    // if the condition is an object, wrap it in an array
-    if (!Array.isArray(statement_condition)) {
-        statement_conditions = [statement_condition];
-    }
-    const is_keycloak_request = web_identity_info.iss;
-    for (const condition of statement_conditions) {
-        const condition_fit = access_policy_utils._is_identity_condition_fit(is_keycloak_request, condition, web_identity_info);
-        if (!condition_fit) {
-            return false;
-        }
-    }
-    return true;
+    const conditions = Array.isArray(statement_condition) ? statement_condition : [statement_condition];
+    const is_keycloak_request = Boolean(web_identity_info.iss);
+    return conditions.every(condition =>
+        access_policy_utils._is_identity_condition_fit(
+            is_keycloak_request, condition, web_identity_info, request_context));
 }
 
 /**
- * fetch web identity object from request web_identity_token param
+ * fetch_web_identity_info fetches web identity object from request web_identity_token param
  * @param {Object} req - Request object
  * @returns {Object} - web_identity_info
  */
 function fetch_web_identity_info(req) {
-    let web_identity_info;
-    if (req.body.web_identity_token) {
-        web_identity_info = jwt.decode(req.body.web_identity_token, { json: true });
-    }
-    return web_identity_info || {};
+    if (!req.body.web_identity_token) return {};
+    return jwt.decode(req.body.web_identity_token, { json: true }) || {};
 }
 
 /**

--- a/src/endpoint/sts/sts_utils.js
+++ b/src/endpoint/sts/sts_utils.js
@@ -6,8 +6,8 @@ const { StsError } = require('./sts_errors');
 const jwt_utils = require('../../util/jwt_utils');
 const config = require('../../../config');
 
-// create and return the signed token
 /**
+ * generate_session_token creates and returns the signed session token
  * @param {Object} auth_options
  * @param {Number} expiry in seconds
  * @returns {String}
@@ -19,29 +19,52 @@ function generate_session_token(auth_options, expiry) {
 
 // TODO: Generalize and move to a utils file in the future
 /**
+ * parse_sts_duration parses and validates STS durationSeconds against role max session duration
  * @param {String|undefined} duration_input duration in seconds
+ * @param {Number} [role_max_session_duration] role MaxSessionDuration in seconds
  * @returns {Number} duration in milliseconds
  */
-function parse_sts_duration(duration_input) {
+function parse_sts_duration(duration_input, role_max_session_duration) {
+    const max_duration = role_max_session_duration === undefined ?
+        config.STS_MAX_DURATION_SECONDS :
+        Math.min(config.STS_MAX_DURATION_SECONDS, role_max_session_duration);
+
     if (duration_input === undefined) {
-        return config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS;
+        const default_ms = config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS;
+        if (default_ms > max_duration * 1000) {
+            throw new StsError(_sts_duration_validation_error(
+                String(default_ms / 1000), 'less', max_duration));
+        }
+        return default_ms;
     }
 
     const duration_sec = Number(duration_input);
-
     if (!Number.isInteger(duration_sec)) {
         throw new StsError(StsError.InvalidParameterValue);
     }
-
     if (duration_sec < config.STS_MIN_DURATION_SECONDS) {
+        dbg.log1('parse_sts_duration: duration below minimum', duration_sec, 'min', config.STS_MIN_DURATION_SECONDS);
         throw new StsError(_sts_duration_validation_error(duration_input, 'greater', config.STS_MIN_DURATION_SECONDS));
     }
-    if (duration_sec > config.STS_MAX_DURATION_SECONDS) {
-        throw new StsError(_sts_duration_validation_error(duration_input, 'less', config.STS_MAX_DURATION_SECONDS));
+    if (duration_sec > max_duration) {
+        dbg.log1('parse_sts_duration: duration above maximum', duration_sec, 'max', max_duration);
+        throw new StsError(_sts_duration_validation_error(duration_input, 'less', max_duration));
     }
+    return duration_sec * 1000;
+}
 
-    const duration_ms = duration_sec * 1000;
-    return duration_ms;
+/**
+ * get_session_duration_info resolves session duration fields for AssumeRole responses
+ * @param {String|undefined} duration_seconds
+ * @param {Number} [role_max_session_duration]
+ * @returns {{duration_sec: number, expiration_time: number}}
+ */
+function get_session_duration_info(duration_seconds, role_max_session_duration) {
+    const duration_ms = parse_sts_duration(duration_seconds, role_max_session_duration);
+    return {
+        duration_sec: Math.ceil(duration_ms / 1000),
+        expiration_time: Date.now() + duration_ms,
+    };
 }
 
 function _sts_duration_validation_error(duration_input, constraint, constraint_value) {
@@ -53,3 +76,4 @@ function _sts_duration_validation_error(duration_input, constraint, constraint_v
 
 exports.generate_session_token = generate_session_token;
 exports.parse_sts_duration = parse_sts_duration;
+exports.get_session_duration_info = get_session_duration_info;

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -81,7 +81,6 @@ class StsSDK {
             role_name: iam_role.name,
             account_id: account._id.toString(),
             access_key: account.access_keys[0].access_key.unwrap(),
-            assume_role_policy: iam_role.assume_role_policy,
         };
     }
 

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -436,6 +436,52 @@ function get_bucket_policy_principal_arn(account) {
 }
 
 /**
+ * get_principal_account_id returns account id used for trust Principal / condition keys (root _id, or IAM user's owner)
+ * @param {object} account
+ * @returns {string|undefined}
+ */
+function get_principal_account_id(account) {
+    if (!account) return undefined;
+    if (account.owner === undefined) return String(account._id);
+    return typeof account.owner === 'object' ? String(account.owner._id) : String(account.owner);
+}
+
+/**
+ * is_aws_trust_principal_match matches Principal.AWS for AssumeRole
+ * supports *, email (NooBaa legacy), exact principal ARN, account id, account root ARN
+ * not supported: Principal.Service, STS assumed-role session ARNs
+ * @param {string|object} principal
+ * @param {object} account
+ * @returns {boolean}
+ */
+function is_aws_trust_principal_match(principal, account) {
+    if (!account || principal === undefined || principal === null) return false;
+    const principal_str = typeof principal === 'string' ? principal : principal.unwrap();
+    if (principal_str === '*') return true;
+    const email = account.email?.unwrap?.() ?? account.email;
+    if (principal_str === email || principal_str === get_bucket_policy_principal_arn(account)) return true;
+    const account_id = get_principal_account_id(account);
+    return principal_str === account_id || principal_str === create_arn_for_root(account_id);
+}
+
+/**
+ * build_sts_trust_request_context builds AssumeRole request context keys for trust Condition evaluation
+ * keys are always set so missing ExternalId fails StringEquals (AWS-aligned)
+ * @param {string|undefined} external_id
+ * @param {object} account
+ * @returns {Object}
+ */
+function build_sts_trust_request_context(external_id, account) {
+    const account_id = get_principal_account_id(account);
+    return {
+        'sts:ExternalId': external_id,
+        'aws:PrincipalArn': account ? get_bucket_policy_principal_arn(account) : undefined,
+        'aws:PrincipalAccount': account_id,
+        'aws:SourceAccount': account_id,
+    };
+}
+
+/**
  *  Both NSFS NC and containerized will validate bucket policy against acccount id 
  *  but in containerized deplyment not against IAM user ID.
  * 
@@ -554,9 +600,11 @@ function _is_ldap_identity_fit(condition_key, expected_value, identity_info, pre
  * @param {Object} web_identity_info - The web identity info decoded from the JWT token.
  *   principal_tags are nested under the AWS OIDC claim key:
  *   web_identity_info["https://aws"]["amazon"]["com/tags"]["principal_tags"]
+ * @param {Object} [request_context] - AssumeRole request condition keys
+ *   (sts:ExternalId, aws:PrincipalArn, aws:PrincipalAccount, aws:SourceAccount)
  * @returns {boolean} - true if all method are satisfied, false otherwise
  */
-function _is_identity_condition_fit(is_keycloak_request, condition, web_identity_info) {
+function _is_identity_condition_fit(is_keycloak_request, condition, web_identity_info, request_context = {}) {
     const conditon_predicate_map = is_keycloak_request ? keycloak_predicate_map : ldap_predicate_map;
     const evaluation_context = {
         tags_claim: get_tags_claim(web_identity_info),
@@ -577,7 +625,17 @@ function _is_identity_condition_fit(is_keycloak_request, condition, web_identity
                     return false;
                 }
             } else if (expected_key.startsWith('ldap:')) { // LDAP identity condition
-                if (!_is_ldap_identity_fit(condition_key, expected_value, web_identity_info, predicate)) return false;
+                if (!_is_ldap_identity_fit(expected_key, expected_value, web_identity_info, predicate)) return false;
+            } else if (Object.hasOwn(request_context, expected_key)) {
+                if (!predicate(request_context[expected_key], expected_value)) {
+                    dbg.log0('_is_identity_condition_fit: Condition validation failed for operator:', condition_key,
+                        'expected_key:', expected_key, 'expected_value:', expected_value,
+                        'actual_value:', request_context[expected_key]);
+                    return false;
+                }
+            } else {
+                dbg.warn('_is_identity_condition_fit: Unsupported condition key:', expected_key);
+                return false;
             }
         }
     }
@@ -785,6 +843,9 @@ exports.validate_bucket_policy = validate_bucket_policy;
 exports.validate_vector_bucket_policy = validate_vector_bucket_policy;
 exports.allows_public_access = allows_public_access;
 exports.get_bucket_policy_principal_arn = get_bucket_policy_principal_arn;
+exports.get_principal_account_id = get_principal_account_id;
+exports.is_aws_trust_principal_match = is_aws_trust_principal_match;
+exports.build_sts_trust_request_context = build_sts_trust_request_context;
 exports.create_arn_for_root = create_arn_for_root;
 exports.get_account_identifier_id = get_account_identifier_id;
 exports._is_wildcard_match = _is_wildcard_match;


### PR DESCRIPTION
### Describe the Problem
AssumeRole trust policy evaluation was incomplete vs AWS (weak Principal matching, no ExternalId/request-context conditions, session duration not capped by role max).

### Explain the Changes
1. Evaluate trust policy with Deny → Allow → ImplicitDeny, including Principal.AWS (*, email, account id, root/user ARN) and Federated.
2. Support trust Conditions (sts:ExternalId, aws:PrincipalArn / PrincipalAccount / SourceAccount).
3. Enforce role `MaxSessionDuration` on AssumeRole session length.

### Issues: Fixed #xxx / Gap #xxx
1.  EPIC: https://redhat.atlassian.net/browse/MCGI-330
2.  Partial fix: https://github.com/noobaa/noobaa-core/pull/9735

### Testing Instructions:
1. Create role (trust allow example)

```
AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <iam-endpoint-url> iam create-role \
  --role-name test-role \
  --assume-role-policy-document file://trust-policy.json \
  --path / \
  --max-session-duration 3600
```

3. Update trust (ExternalId example)

```
AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <iam-endpoint-url> iam update-assume-role-policy \
  --role-name test-role \
  --policy-document file://trust-policy-external-id.json
```
4. Assume role

```
AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <sts-endpoint-url> sts assume-role \
  --role-arn arn:aws:iam::<account-id>:role/test-role \
  --role-session-name test-session
```

5. Assume role with ExternalId

```
AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <sts-endpoint-url> sts assume-role \
  --role-arn arn:aws:iam::<account-id>:role/test-role \
  --role-session-name test-session \
  --external-id secret-ext
```

6. Duration above role max (expect ValidationError)

```
AWS_ACCESS_KEY_ID=<access-key> AWS_SECRET_ACCESS_KEY=<secret-key> \
aws --no-verify-ssl --endpoint-url <sts-endpoint-url> sts assume-role \
  --role-arn arn:aws:iam::<account-id>:role/test-role \
  --role-session-name test-session \
  --duration-seconds 7200
```

7. Verify

Trust Principal.AWS: "*" / account id / root ARN → AssumeRole succeeds
Wrong principal / no matching statement → AccessDenied
Explicit Deny in trust → AccessDenied
ExternalId missing/wrong → AccessDenied; correct → succeeds
--duration-seconds > role MaxSessionDuration → ValidationError

```
$ cat trust-policy.json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": { "AWS": "*" },
      "Action": "sts:AssumeRole"
    }
  ]
}
$ cat trust-policy-external-id.json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": { "AWS": "*" },
      "Action": "sts:AssumeRole",
      "Condition": {
        "StringEquals": { "sts:ExternalId": "secret-ext" }
      }
    }
  ]
}

```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for role-specific maximum session durations when issuing temporary credentials.
  * Improved AssumeRole trust-policy evaluation for external IDs, principal accounts, principal ARNs, and source accounts.
  * Added broader AWS principal matching for account, root, user, and ARN formats.

* **Bug Fixes**
  * Improved validation and expiration handling for requested session durations.
  * Trust policies with unsupported conditions are now rejected consistently.
  * Missing trust policies now produce clearer access-denied handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->