### PR TITLE
NamespaceMultiStorageClass base

### DIFF
--- a/docs/design/DeepArchiveAPIsSupport.md
+++ b/docs/design/DeepArchiveAPIsSupport.md
@@ -822,7 +822,7 @@ aws s3api list-objects-v2 \
   --bucket "$BUCKET"
 ```
 
-**Expected:** Archived objects appear in the listing with `StorageClass: DEEP_ARCHIVE`. Internal NooBaa paths such as `restored_objects/` are not exposed to callers.
+**Expected:** Archived objects appear in the listing with `StorageClass: DEEP_ARCHIVE`.
 
 Beyond the basic listing, also exercise list parameters such as `Prefix`, `Delimiter`, `MaxKeys`, `StartAfter` / `ContinuationToken` (ListObjectsV2), and `Marker` (ListObjects) to confirm pagination and filtering behave correctly for archived objects.
 
@@ -1048,7 +1048,7 @@ aws s3api restore-object \
   --restore-request '{"Days":7}'
 ```
 
-**Expected:** `202 Accepted`. NooBaa sets `restore_status.ongoing = true` and calls `RestoreObject` on IBM Deep Archive. A background worker eventually polls the archive, writes a temporary copy to standard storage at the internal path `restored_objects/<key>` (not exposed in listings), and sets `restore_status.expiry_time`.
+**Expected:** `202 Accepted`. NooBaa sets `restore_status.ongoing = true` and calls `RestoreObject` on IBM Deep Archive. A background worker eventually polls the archive, writes a temporary copy to standard storage, records `restore_status.restored_obj_id`, and sets `restore_status.expiry_time`.
 
 **Extend expiry** (object already restored and within expiry):
 

--- a/src/api/bucket_api.js
+++ b/src/api/bucket_api.js
@@ -1548,6 +1548,22 @@ module.exports = {
                         },
                     },
                 },
+                // Extended resource info (not name-only archive_policy) so the endpoint
+                // can build NamespaceS3 via _setup_single_namespace.
+                archive_policy: {
+                    type: 'object',
+                    required: ['deep_archive_resource'],
+                    properties: {
+                        deep_archive_resource: {
+                            type: 'object',
+                            required: ['resource'],
+                            properties: {
+                                resource: { $ref: 'pool_api#/definitions/namespace_resource_extended_info' },
+                                path: { type: 'string' },
+                            },
+                        },
+                    },
+                },
                 active_triggers: {
                     type: 'array',
                     items: {

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -61,6 +61,7 @@ module.exports = {
                         idate: true
                     },
                     storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                    archive_upload_id: { type: 'string' },
                     defer_put_mapping: { type: 'boolean' },
                 }
             },
@@ -1588,6 +1589,7 @@ module.exports = {
                 s3_signed_url: { type: 'string' },
                 lock_settings: { $ref: 'common_api#/definitions/lock_settings' },
                 storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                archive_upload_id: { type: 'string' },
                 // currently no properties for the object as there is no implementation
                 object_owner: {
                     type: 'object',

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -1,0 +1,411 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const s3_utils = require('../endpoint/s3/s3_utils');
+const S3Error = require('../endpoint/s3/s3_errors').S3Error;
+
+
+/**
+ * NamespaceMultiStorageClass routes operations to different namespaces based on
+ * the object's storage class — analogous to NamespaceMerge, but keyed by
+ * storage_class instead of read/write resources.
+ *
+ * Metadata (MD) is always stored in the default (STANDARD) namespace and is
+ * the single source of truth for all storage classes. Non-default namespaces
+ * (e.g. NamespaceS3 for DEEP_ARCHIVE) store only object data.
+ *
+ * @implements {nb.Namespace}
+ */
+class NamespaceMultiStorageClass {
+
+    /**
+     * @param {{
+     *   namespace_by_storage_class: { [storage_class: string]: nb.Namespace },
+     *   default_storage_class?: string,
+     * }} args
+     */
+    constructor({ namespace_by_storage_class, default_storage_class }) {
+        if (!namespace_by_storage_class || !Object.keys(namespace_by_storage_class).length) {
+            throw new Error('NamespaceMultiStorageClass requires a non-empty namespaces map');
+        }
+        this.namespace_by_storage_class = namespace_by_storage_class;
+        this.default_storage_class = default_storage_class || s3_utils.STORAGE_CLASS_STANDARD;
+        this._metadata_ns = this.namespace_by_storage_class[this.default_storage_class];
+        if (!this._metadata_ns) {
+            throw new Error(`NamespaceMultiStorageClass: missing namespace for default storage class '${this.default_storage_class}'`);
+        }
+    }
+
+    /**
+     * Returns this router as the write target.
+     * Used by ObjectSDK copy to resolve the actual write backend for server-side copy checks.
+     * @returns {nb.Namespace}
+     */
+    get_write_resource() {
+        return this;
+    }
+
+    /**
+     * Server-side copy across the router is disabled (same restriction as NamespaceMerge).
+     * @param {nb.Namespace} other
+     * @param {nb.ObjectInfo} other_md
+     * @param {object} params
+     * @returns {boolean}
+     */
+    is_server_side_copy(other, other_md, params) {
+        return false;
+    }
+
+    /**
+     * @param {string} bucket
+     * @returns {string}
+     */
+    get_bucket(bucket) {
+        return bucket;
+    }
+
+    /**
+     * Always writable. Deep-archive data is NooBaa-managed (like a pool/backingstore),
+     * so namespace-resource access_mode does not apply.
+     * @returns {boolean}
+     */
+    is_readonly_namespace() {
+        return false;
+    }
+
+    /////////////////
+    // OBJECT LIST //
+    /////////////////
+
+    /**
+     * Lists objects from the metadata namespace only.
+     * Metadata for all storage classes is stored there.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async list_objects(params, object_sdk) {
+        return this._metadata_ns.list_objects(params, object_sdk);
+    }
+
+    /**
+     * Lists in-progress multipart uploads from the metadata namespace.
+     * Client UploadId is the NB obj_id; archive_upload_id is stored on the upload
+     * object and looked up when talking to the archive backend.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async list_uploads(params, object_sdk) {
+        return this._metadata_ns.list_uploads(params, object_sdk);
+    }
+
+    /**
+     * Lists object versions from the metadata namespace only.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async list_object_versions(params, object_sdk) {
+        return this._metadata_ns.list_object_versions(params, object_sdk);
+    }
+
+    /////////////////
+    // OBJECT READ //
+    /////////////////
+
+    /**
+     * Reads object metadata from the metadata namespace
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<nb.ObjectInfo>}
+     */
+    async read_object_md(params, object_sdk) {
+        return this._metadata_ns.read_object_md(params, object_sdk);
+    }
+
+    /**
+     * Streams object data.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<import('stream').Readable>}
+     */
+    async read_object_stream(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    ///////////////////
+    // OBJECT UPLOAD //
+    ///////////////////
+
+    /**
+     * Uploads object data to the storage-class backend and writes metadata to NB.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async upload_object(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    upload_blob_block(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    commit_blob_block_list(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    get_blob_block_lists(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /////////////////////////////
+    // OBJECT MULTIPART UPLOAD //
+    /////////////////////////////
+
+    /**
+     * Creates a multipart upload.
+     * For archive storage classes: create on archive + NB (pass archive_upload_id into
+     * NB create_object_upload), return the NB obj_id as the client UploadId.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async create_object_upload(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async upload_multipart(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * Lists uploaded parts from the metadata namespace (source of truth for part metadata).
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async list_multiparts(params, object_sdk) {
+        return this._metadata_ns.list_multiparts(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async complete_object_upload(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async abort_object_upload(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    ///////////////////
+    // OBJECT DELETE //
+    ///////////////////
+
+    /**
+     * Deletes object metadata via the default (STANDARD) namespace only.
+     *
+     * For deep archive objects, a separate BG worker (similar to objects_reclaimer)
+     * will delete the actual archive data asynchronously.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async delete_object(params, object_sdk) {
+        return this._metadata_ns.delete_object(params, object_sdk);
+    }
+
+    /**
+     * Deletes object metadata via the default (STANDARD) namespace only.
+     *
+     * For deep archive objects, a separate BG worker (similar to objects_reclaimer)
+     * will delete the actual archive data asynchronously.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object[]>}
+     */
+    async delete_multiple_objects(params, object_sdk) {
+        return this._metadata_ns.delete_multiple_objects(params, object_sdk);
+    }
+
+    ////////////////////
+    // OBJECT TAGGING //
+    ////////////////////
+
+    // Tags are stored in NB metadata — route directly to the default namespace.
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async get_object_tagging(params, object_sdk) {
+        return this._metadata_ns.get_object_tagging(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async delete_object_tagging(params, object_sdk) {
+        return this._metadata_ns.delete_object_tagging(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async put_object_tagging(params, object_sdk) {
+        return this._metadata_ns.put_object_tagging(params, object_sdk);
+    }
+
+    //////////
+    // ACLs //
+    //////////
+
+    // ACLs are stored in NB metadata — route directly to the default namespace.
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async get_object_acl(params, object_sdk) {
+        return this._metadata_ns.get_object_acl(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async put_object_acl(params, object_sdk) {
+        return this._metadata_ns.put_object_acl(params, object_sdk);
+    }
+
+    ///////////////////
+    //  OBJECT LOCK  //
+    ///////////////////
+
+    // Object lock settings (legal hold, retention) are stored exclusively in NB
+    // metadata — they have no representation in the archive backend. All four
+    // operations therefore go directly to the default namespace without reading
+    // the object's storage class first.
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async get_object_legal_hold(params, object_sdk) {
+        return this._metadata_ns.get_object_legal_hold(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async put_object_legal_hold(params, object_sdk) {
+        return this._metadata_ns.put_object_legal_hold(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async get_object_retention(params, object_sdk) {
+        return this._metadata_ns.get_object_retention(params, object_sdk);
+    }
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<object>}
+     */
+    async put_object_retention(params, object_sdk) {
+        return this._metadata_ns.put_object_retention(params, object_sdk);
+    }
+
+    ///////////////////
+    //      ULS      //
+    ///////////////////
+
+    /**
+     * @returns {Promise<never>}
+     */
+    async create_uls() {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * @returns {Promise<never>}
+     */
+    async delete_uls() {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    ////////////////////
+    // OBJECT RESTORE //
+    ////////////////////
+
+    /**
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<{ accepted: boolean }>}
+     */
+    async restore_object(params, object_sdk) {
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    //////////////
+    // INTERNAL //
+    //////////////
+
+    /**
+     * Resolves the namespace for a write based on `storage_class`.
+     * Falls back to `default_storage_class` when unset or unmapped.
+     * @param {string} [storage_class]
+     * @returns {nb.Namespace}
+     */
+    _ns_for_storage_class(storage_class) {
+        const sc = s3_utils.parse_storage_class(storage_class);
+        return this.namespace_by_storage_class[sc] || this.namespace_by_storage_class[this.default_storage_class];
+    }
+}
+
+
+module.exports = NamespaceMultiStorageClass;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -430,6 +430,7 @@ interface ObjectMD {
     md5_b64: string;
     sha256_b64: string;
     storage_class?: StorageClass;
+    archive_upload_id?: string;
     xattr: {};
     stats: { reads: number; last_read: Date; };
     encryption: { algorithm: string; kms_key_id: string; context_b64: string; key_md5_b64: string; key_b64: string; };
@@ -479,6 +480,7 @@ interface ObjectInfo {
     content_range?: string;
     ns?: Namespace;
     storage_class?: StorageClass;
+    archive_upload_id?: string;
     restore_status?: RestoreStatus;
     checksum?: Checksum;
     object_parts?: GetObjectAttributesParts;

--- a/src/sdk/object_sdk.js
+++ b/src/sdk/object_sdk.js
@@ -23,7 +23,9 @@ const NamespaceMerge = require('./namespace_merge');
 const NamespaceCache = require('./namespace_cache');
 const NamespaceMultipart = require('./namespace_multipart');
 const NamespaceNetStorage = require('./namespace_net_storage');
+const NamespaceMultiStorageClass = require('./namespace_multi_storage_class');
 const BucketSpaceNB = require('./bucketspace_nb');
+const s3_utils = require('../endpoint/s3/s3_utils');
 const { RpcError } = require('../rpc');
 const noobaa_s3_client = require('../sdk/noobaa_s3_client/noobaa_s3_client');
 
@@ -425,6 +427,14 @@ class ObjectSDK {
         const time = Date.now();
         dbg.log1('_load_bucket_namespace', bucket);
         try {
+            if (bucket.archive_policy) {
+                return {
+                    ns: this._setup_multi_storage_class_namespace(bucket),
+                    bucket,
+                    valid_until: time + config.OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS,
+                };
+            }
+
             if (bucket.namespace) {
 
                 if (bucket.namespace.caching) {
@@ -510,6 +520,27 @@ class ObjectSDK {
             },
             active_triggers: bucket.active_triggers
         });
+    }
+
+    /**
+     * Builds a NamespaceMultiStorageClass for buckets with an archive_policy.
+     * STANDARD maps to NamespaceNB (metadata + data).
+     * DEEP_ARCHIVE / GLACIER map to NamespaceS3 (data only); metadata is owned by NamespaceMultiStorageClass
+     * @returns {nb.Namespace}
+     */
+    _setup_multi_storage_class_namespace(bucket) {
+        const namespace_nb = new NamespaceNB();
+        namespace_nb.set_triggers_for_bucket(bucket.name.unwrap(), bucket.active_triggers);
+
+        const namespace_by_storage_class = { [s3_utils.STORAGE_CLASS_STANDARD]: namespace_nb };
+
+        if (bucket.archive_policy?.deep_archive_resource) {
+            const deep_archive_ns = this._setup_single_namespace(bucket.archive_policy.deep_archive_resource);
+            namespace_by_storage_class[s3_utils.STORAGE_CLASS_DEEP_ARCHIVE] = deep_archive_ns;
+            namespace_by_storage_class[s3_utils.STORAGE_CLASS_GLACIER] = deep_archive_ns;
+        }
+
+        return new NamespaceMultiStorageClass({ namespace_by_storage_class });
     }
 
     /**

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -73,6 +73,7 @@ async function create_object_upload(req) {
             'application/octet-stream',
         tagging: req.rpc_params.tagging,
         storage_class: req.rpc_params.storage_class,
+        archive_upload_id: req.rpc_params.archive_upload_id,
         encryption
     };
 
@@ -1745,6 +1746,7 @@ function get_object_info(md, options = {}) {
         md5_b64: md.md5_b64 || undefined,
         sha256_b64: md.sha256_b64 || undefined,
         storage_class: md.storage_class,
+        archive_upload_id: md.archive_upload_id || undefined,
         content_type: md.content_type || 'application/octet-stream',
         content_encoding: md.content_encoding,
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -97,6 +97,10 @@ module.exports = {
 
         storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
 
+        // Remote archive S3 UploadId for in-progress deep-archive multipart uploads.
+        // Client UploadId remains the NB obj_id; this field is used when calling the archive backend.
+        archive_upload_id: { type: 'string' },
+
         // xattr saved as free form object
         xattr: {
             type: 'object',

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -845,6 +845,15 @@ async function read_bucket_sdk_info(req) {
             should_create_underlying_storage: bucket.namespace.should_create_underlying_storage
         };
     }
+    if (bucket.archive_policy && bucket.archive_policy.deep_archive_resource) {
+        reply.archive_policy = {
+            deep_archive_resource: {
+                resource: pool_server.get_namespace_resource_extended_info(
+                    bucket.archive_policy.deep_archive_resource.resource),
+                path: bucket.archive_policy.deep_archive_resource.path,
+            }
+        };
+    }
     return reply;
 }
 

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -1,0 +1,17 @@
+/* Copyright (C) 2024 NooBaa */
+'use strict';
+
+const NB_INTERNAL_STORAGE_DIR = 'noobaa_storage/';
+/**
+ * Returns the key used to store object data in the deep-archive backend.
+ * Format: `{bucket_id}/{obj_md_id}`
+ *
+ * @param {string|nb.ID} bucket_id
+ * @param {string|nb.ID} obj_md_id
+ * @returns {string}
+ */
+function get_archive_key(bucket_id, obj_md_id) {
+    return `${NB_INTERNAL_STORAGE_DIR}${String(bucket_id)}/${String(obj_md_id)}`;
+}
+
+exports.get_archive_key = get_archive_key;


### PR DESCRIPTION


### Explain the Changes
* Add NamespaceMultiStorageClass: MD always in NB (STANDARD); data for DEEP_ARCHIVE/GLACIER routed to archive NamespaceS3. List/head/delete/tagging/ACL/lock pass through MD; put/get/MPU/restore are stubs.
* Wire it from object_sdk when the bucket has an archive_policy.
* Expose archive_policy (extended NSR info) on read_bucket_sdk_info / bucket_sdk_info.
* Add archive_upload_id on object MD/API so archive MPU UploadIds can be stored while the client keeps using the NB obj_id.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for bucket archive policies with deep-archive resource and path details.
  - Added multi-storage-class bucket routing for standard, deep archive, and glacier storage.
  - Added archive upload identifiers to object uploads and object metadata.
  - Added support for retrieving archive policy details through bucket information APIs.
  - Added consistent deep-archive object key generation.

- **Documentation**
  - Updated deep-archive listing and restore behavior guidance, including restored-object status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->