### PR TITLE
KeyCloack | Support aws:PrincipalTag in S3 request flow

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -407,30 +407,7 @@ module.exports = {
                                         type: 'string'
                                     },
                                     Condition: {
-                                        type: 'object',
-                                        properties: {
-                                            StringEquals: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            StringNotEquals: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            StringEqualsIgnoreCase: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            StringNotEqualsIgnoreCase: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            StringLike: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            StringNotLike: {
-                                                $ref: '#/definitions/bucket_policy_string_condition'
-                                            },
-                                            Null: {
-                                                $ref: '#/definitions/bucket_policy_null_condition'
-                                            }
-                                        }
+                                        $ref: '#/definitions/policy_condition'
                                     }
                                 }
                             },
@@ -491,7 +468,7 @@ module.exports = {
         },
 
         // based on bucket policy without Principal and NotPrincipal since are not used in inline policies
-        // removed the Condition as we don't support it yet
+        // This schema is used for IAM user and roles.
         iam_user_policy_document: {
             type: 'object',
             required: ['Statement'],
@@ -522,6 +499,9 @@ module.exports = {
                                     Effect: {
                                         enum: ['Allow', 'Deny'],
                                         type: 'string'
+                                    },
+                                    Condition: {
+                                        $ref: '#/definitions/policy_condition'
                                     },
                                 }
                             },
@@ -560,6 +540,33 @@ module.exports = {
                         ]
                     }
                 },
+            }
+        },
+        policy_condition: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+                StringEquals: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                StringNotEquals: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                StringEqualsIgnoreCase: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                StringNotEqualsIgnoreCase: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                StringLike: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                StringNotLike: {
+                    $ref: '#/definitions/bucket_policy_string_condition'
+                },
+                Null: {
+                    $ref: '#/definitions/bucket_policy_null_condition'
+                }
             }
         },
 

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -11,6 +11,7 @@ const jwt = require('jsonwebtoken');
 const { resolve_iam_role_by_arn } = require('../endpoint/iam/iam_utils');
 const ldap_client = require('../util/ldap_client');
 const keycloak_client = require('../util/keycloak_client');
+const { get_tags_claim } = require('../util/access_policy_utils');
 
 class StsSDK {
 
@@ -170,13 +171,16 @@ class StsSDK {
                 await keycloak_instance.initialize();
             }
             // JWT token decoded and check token issuer is in provider list
-            await keycloak_instance.verify_token(req.body.web_identity_token);
+            const decoded_token = await keycloak_instance.verify_token(req.body.web_identity_token);
 
             // Introspect token with Keycloak using client_id, client_secret, and access_token
             // This is the key implementation for Keycloak - validates token is active and not revoked
             const introspection_resp = await keycloak_instance.introspect_token(
                 req.body.web_identity_token
             );
+
+            // Extract session tags from decoded token.
+            const session_tags = get_tags_claim(decoded_token);
 
             // Assume role
             const role_config = await this._assume_role(req.body.role_arn);
@@ -189,6 +193,7 @@ class StsSDK {
                 sub: introspection_resp.sub,
                 aud: introspection_resp.client_id || introspection_resp.aud,
                 iss: introspection_resp.iss,
+                session_tags,
                 // Store additional claims for audit
                 email: introspection_resp.email,
                 name: introspection_resp.name,

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -116,7 +116,8 @@ const predicate_map = {
 const condition_fit_functions = {
     's3:ExistingObjectTag': _is_object_tag_fit,
     's3:x-amz-server-side-encryption': _is_server_side_encryption_fit,
-    's3:VersionId': _is_object_version_fit
+    's3:VersionId': _is_object_version_fit,
+    'aws:PrincipalTag': _is_aws_principal_tag_fit
 };
 
 const keycloak_predicate_map = {
@@ -131,6 +132,11 @@ const supported_actions = {
     's3:x-amz-server-side-encryption': ['s3:PutObject'],
     's3:VersionId': ['s3:GetObjectVersion', 's3:DeleteObjectVersion', 's3:GetObjectVersionAttributes', 's3:GetObjectVersionTagging', 's3:PutObjectVersionTagging', 's3:DeleteObjectVersionTagging']
 };
+
+// Condition keys that are principal/session-scoped rather than action-scoped —
+// they apply regardless of which S3 method is being called.
+const SKIPPED_CONDITIONS_ACTION = new Set(['aws:PrincipalTag']);
+
 
 const SUPPORTED_BUCKET_POLICY_CONDITIONS = Object.keys(supported_actions);
 
@@ -154,6 +160,19 @@ async function _is_object_version_fit(req, predicate, value) {
     const version_id = req.query.versionId;
     const res = predicate(version_id, value);
     dbg.log1('access_policy: version-id fit? version-id, policy version-id, match :', version_id, value, res);
+    return res;
+}
+
+async function _is_aws_principal_tag_fit(req, predicate, value) {
+    const auth_token = req.object_sdk.get_auth_token();
+    const session_tags = auth_token?.session_tags;
+    // If S3 request is not with temp session tags, should not check the aws:PrincipalTag
+    if (!session_tags) {
+        return true;
+    }
+    const tag_value = session_tags?.[value.key] ?? undefined;
+    const res = predicate(tag_value, value.value);
+    dbg.log1('access_policy: principal tag fit?', value, tag_value, res);
     return res;
 }
 
@@ -427,7 +446,7 @@ async function _is_condition_fit(policy_statement, req, method, { web_identity_i
         for (const [condition, condition_statements] of Object.entries(policy_statement.Condition)) {
             const predicate = predicate_map[condition];
             for (const [condition_key, value] of Object.entries(condition_statements)) {
-                if (!supported_actions[condition_key].includes(method)) {
+                if (!SKIPPED_CONDITIONS_ACTION.has(condition_key) && !supported_actions[condition_key].includes(method)) {
                     continue;
                 }
                 if (await condition_fit_functions[condition_key](req, predicate, value) === false) {
@@ -738,7 +757,7 @@ function _is_identity_condition_fit(is_keycloak_request, condition, web_identity
  * path. Returns undefined when neither format is present.
  *
  * @param {Object} web_identity_info - Decoded JWT payload from the web identity token.
- * @returns {Object|undefined} - The principal_tags map, or undefined if not present.
+ * @returns {Object} - The principal_tags map, or undefined if not present.
  */
 function get_tags_claim(web_identity_info) {
     if (web_identity_info?.["https://aws.amazon.com/tags"]) {
@@ -943,3 +962,4 @@ exports._is_identity_condition_fit = _is_identity_condition_fit;
 exports.keycloak_predicate_map = keycloak_predicate_map;
 exports.extract_tag_key_from_condition = extract_tag_key_from_condition;
 exports.fetch_web_identity_info = fetch_web_identity_info;
+exports.get_tags_claim = get_tags_claim;

--- a/src/util/keycloak_client.js
+++ b/src/util/keycloak_client.js
@@ -73,14 +73,16 @@ class KeyCloakClientManager {
     }
 
     /**
-     * This method decode the token, introspects will do actual verification
+     * This method decode the token and returns the decoded token object
      * @param {String} token - token
+     * @return {Promise<Object>} - recoded token
      */
     async verify_token(token) {
         const decoded = jwt.decode(token);
         if (!decoded || !decoded.iss) {
             throw new Error('Invalid token: missing issuer');
         }
+        return decoded;
     }
 
     /**

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -380,6 +380,7 @@ function authenticate_request_by_service(req, sdk) {
         auth_token.access_key = req.session_token.assumed_role_access_key;
         auth_token.temp_access_key = req.session_token.access_key;
         auth_token.temp_secret_key = req.session_token.secret_key;
+        auth_token.session_tags = req.session_token.session_tags;
     }
     sdk.set_auth_token(auth_token);
     check_request_expiry(req);


### PR DESCRIPTION
### Describe the Problem

aws:PrincipalTag was not suopported before

### Explain the Changes
1. Session tags are pulled from the Keycloak-issued JWT (get_tags_claim)
2. Threaded through sts_sdk.js → session token → signature_utils.js (auth_token.session_tags)
3. Evaluated in access_policy_utils.js against bucket/role policy Condition blocks
4. Matching schema addition in common_api.js for Condition on trust policies


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `Condition` rules in IAM policy statements, shared with bucket policy condition handling.
  * Added extraction of session tags from OIDC/Keycloak identity tokens and included them in assumed-role responses.
  * Added support for evaluating `aws:PrincipalTag` conditions in S3 bucket policies.
* **Bug Fixes**
  * Fixed token verification to return decoded identity claims for use during authentication.
  * Preserved session tags when authenticating service requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->