### PR TITLE
[Deep Archive] - Add archive API under bg worker process

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -31,6 +31,7 @@ api_schema.register_api(require('./cluster_internal_api'));
 api_schema.register_api(require('./server_inter_process_api'));
 api_schema.register_api(require('./hosted_agents_api'));
 api_schema.register_api(require('./replication_api'));
+api_schema.register_api(require('./archive_api'));
 
 api_schema.compile();
 
@@ -112,6 +113,7 @@ function new_rpc_from_routing(routing_table) {
             func_api: 'md',
             scrubber_api: 'bg',
             replication_api: 'bg',
+            archive_api: 'bg',
             hosted_agents_api: 'hosted_agents',
             node_api: 'master',
             host_api: 'master'

--- a/src/api/archive_api.js
+++ b/src/api/archive_api.js
@@ -1,0 +1,43 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+/**
+ *
+ * ARCHIVE API
+ *
+ * RPC API for the archive background worker that handles
+ * streaming data to/from archive storage classes (GLACIER, DEEP_ARCHIVE, etc).
+ *
+ */
+module.exports = {
+
+    $id: 'archive_api',
+
+    methods: {
+
+        archive_object: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['obj_id', 'bucket_id', 'target_storage_class'],
+                properties: {
+                    obj_id: { objectid: true },
+                    bucket_id: { objectid: true },
+                    target_storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    success: { type: 'boolean' },
+                }
+            },
+            auth: { system: 'admin' }
+        },
+
+    },
+
+    definitions: {
+
+    }
+};

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -9,7 +9,17 @@ const COMMON_CONSTANTS = {
       DISABLED: "DISABLED"
     },
     VERSION_NULL: 'null'
-  }
+  },
+  ARCHIVE: {
+    STORAGE_CLASS: {
+      DEEP_ARCHIVE: 'DEEP_ARCHIVE',
+      GLACIER: 'GLACIER',
+    },
+    TRANSITION_STATUS: {
+      IN_PROGRESS: 'IN_PROGRESS',
+      DONE: 'DONE',
+    },
+  },
 };
 
 module.exports = COMMON_CONSTANTS;

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -711,6 +711,7 @@ interface APIClient {
     readonly func: APIGroup;
     readonly func_node: APIGroup;
     readonly replication: APIGroup;
+    readonly archive: APIGroup;
 
     options: {
         auth_token?: string;

--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -1,0 +1,15 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const dbg = require('../../util/debug_module')(__filename);
+
+/* 
+    This function will transition an object from Standard storage class to Deep Archive storage class.
+    It will use the endpoint defined by the deep_archive_resource of the bucket.
+*/
+async function archive_object(req) {
+    dbg.log1('archive_object', req.rpc_params);
+    throw new Error('archive_object not yet implemented');
+}
+
+exports.archive_object = archive_object;

--- a/src/server/server_rpc.js
+++ b/src/server/server_rpc.js
@@ -128,6 +128,8 @@ class ServerRpc {
             require('./bg_services/scrubber'), options);
         rpc.register_service(schema.replication_api,
             require('./bg_services/replication_server'), options);
+        rpc.register_service(schema.archive_api,
+            require('./bg_services/archive_server'), options);
     }
 
     register_hosted_agents_services() {


### PR DESCRIPTION
### Explain the Changes
1. Add new RPC API to support transitioning objects to deep_archive and register it under bg services.
2. Added few constants related to S3 deep archive.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added archive API support to the SDK/RPC interface, including an admin-only operation to archive an object.
  * Introduced new archive-related storage classes and transition status values (e.g., Deep Archive/Glacier; in-progress/done).

* **Limitations**
  * The new `archive_object` operation is currently registered but not yet functional; requests return a “not yet implemented” error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->