### PR TITLE
DEEP_ARCHIVE | PutObject implementation

### DIFF
--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -1,8 +1,12 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
+const _ = require('lodash');
+const dbg = require('../util/debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
+const { get_archive_key } = require('../util/deep_archive_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
+const { get_create_object_upload_params, get_complete_object_upload_params } = require('../util/object_utils');
 
 
 /**
@@ -126,12 +130,20 @@ class NamespaceMultiStorageClass {
 
     /**
      * Streams object data.
+     * STANDARD (default) objects are read from the metadata namespace.
+     * Non-default storage classes (e.g. DEEP_ARCHIVE / GLACIER) are not
+     * readable until restored — throw InvalidObjectState.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<import('stream').Readable>}
      */
     async read_object_stream(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const object_md = params.object_md || await this._metadata_ns.read_object_md(params, object_sdk);
+        const storage_class = s3_utils.parse_storage_class(object_md.storage_class);
+        if (storage_class !== this.default_storage_class) {
+            throw new S3Error(S3Error.InvalidObjectState);
+        }
+        return this._metadata_ns.read_object_stream({ ...params, object_md }, object_sdk);
     }
 
     ///////////////////
@@ -139,13 +151,26 @@ class NamespaceMultiStorageClass {
     ///////////////////
 
     /**
-     * Uploads object data to the storage-class backend and writes metadata to NB.
+     * Uploads an object. Mirrors object_io.upload_object (create → data → complete),
+     * but writes data plain to the storage-class target and MD via NamespaceNB helpers.
+     * STANDARD (default namespace): full NB upload (data + MD).
+     * Non-default storage classes: Currently only DEEP_ARCHIVE and GLACIER are supported
+     * MD-only create/complete in NB; data written to the target namespace under get_archive_key(bucket_id, obj_id).
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async upload_object(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const storage_class = s3_utils.parse_storage_class(params.storage_class);
+        const target_ns = this.namespace_by_storage_class[storage_class];
+        if (!target_ns) {
+            throw new S3Error(S3Error.NotImplemented);
+        }
+
+        if (storage_class === this.default_storage_class) {
+            return target_ns.upload_object(params, object_sdk);
+        }
+        return this._upload_object_non_standard_sc(params, object_sdk, { storage_class, target_ns });
     }
 
     /**
@@ -394,6 +419,63 @@ class NamespaceMultiStorageClass {
     //////////////
     // INTERNAL //
     //////////////
+
+    /**
+     * Upload path for non-default storage classes: MD in NB, data plain to target_ns.
+     * Flow: create_object_upload (NB MD) → upload_object to archive under
+     * get_archive_key(bucket_id, obj_id) → complete_object_upload (NB MD).
+     * On failure after MD create, aborts the NB upload.
+     *
+     * Also covers CopyObject into an archive storage class: when
+     * is_server_side_copy is false, ObjectSDK replaces copy_source with
+     * source_stream via read_object_stream, so this path receives a normal
+     * streamed upload (no separate copy handling needed here).
+     *
+     * Failure cleanup: abort_object_upload only soft-deletes the NB MD
+     * (sets `deleted`). It does not remove data already written to target_ns.
+     * A dedicated BG worker will delete archive objects for deleted object_mds
+     * (same path as user DeleteObject), using get_archive_key(bucket_id, obj_id).
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {{ storage_class: string, target_ns: nb.Namespace }} options
+     * @returns {Promise<object>}
+     */
+    async _upload_object_non_standard_sc(params, object_sdk, { storage_class, target_ns }) {
+        try {
+            const create_params = get_create_object_upload_params({ ...params, storage_class });
+            dbg.log1('NamespaceMultiStorageClass._upload_object_non_standard_sc: start MD upload', create_params);
+            const create_reply = await this._metadata_ns.create_object_upload(create_params, object_sdk);
+            params.obj_id = create_reply.obj_id;
+
+            const archive_key = get_archive_key(create_reply.bucket_id, params.obj_id);
+            const data_res = await target_ns.upload_object({ ...params, key: archive_key, storage_class }, object_sdk);
+            const { etag, last_modified_time } = data_res || {};
+
+            const complete_params = get_complete_object_upload_params({ ...params, etag, last_modified_time });
+            dbg.log1('NamespaceMultiStorageClass._upload_object_non_standard_sc: uploaded data to target ns', {...complete_params, archive_key });
+
+            const complete_reply = await this._metadata_ns.complete_object_upload(complete_params, object_sdk);
+            dbg.log1('NamespaceMultiStorageClass._upload_object_non_standard_sc: complete MD upload', complete_params);
+            return complete_reply;
+        } catch (err) {
+            const abort_params = _.pick(params, 'bucket', 'key', 'obj_id');
+            dbg.warn('NamespaceMultiStorageClass._upload_object_non_standard_sc: failed upload', abort_params, err);
+            // Destroy if the body was never attached (e.g. create_object_upload failed).
+            // No err arg: avoid emitting 'error' on a stream with no listeners; original err is rethrown.
+            if (params.source_stream && typeof params.source_stream.destroy === 'function') {
+                params.source_stream.destroy();
+            }
+            if (abort_params.obj_id) {
+                try {
+                    await this._metadata_ns.abort_object_upload(abort_params, object_sdk);
+                    dbg.log0('NamespaceMultiStorageClass._upload_object_non_standard_sc: aborted MD upload', abort_params);
+                } catch (abort_err) {
+                    dbg.warn('NamespaceMultiStorageClass._upload_object_non_standard_sc: Failed to abort MD upload', abort_params, abort_err);
+                }
+            }
+            throw err;
+        }
+    }
 
     /**
      * Resolves the namespace for a write based on `storage_class`.

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -19,6 +19,7 @@ const system_store = require('../server/system_services/system_store').get_insta
 const { MapClient } = require('./map_client');
 const { ChunkAPI } = require('./map_api_types');
 const { RpcError } = require('../rpc');
+const { get_create_object_upload_params } = require('../util/object_utils');
 
 Object.isFrozen(RpcError); // otherwise unused
 
@@ -192,21 +193,7 @@ class ObjectIO {
      * @param {UploadParams} params
      */
     async upload_object(params) {
-        const create_params = _.pick(params,
-            'bucket',
-            'key',
-            'content_type',
-            'content_encoding',
-            'size',
-            'md5_b64',
-            'sha256_b64',
-            'xattr',
-            'tagging',
-            'encryption',
-            'lock_settings',
-            'storage_class',
-            'last_modified_time',
-        );
+        const create_params = get_create_object_upload_params(params);
         if (!params.copy_source) {
             // Server may return objectmd in the reply and skip insert (see create_object_upload);
             // _upload_chunks then defers or flushes put_mapping by size.

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_upload_object.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_upload_object.js
@@ -1,0 +1,321 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('../../utils/coretest/coretest');
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
+
+const mocha = require('mocha');
+const assert = require('assert');
+const crypto = require('crypto');
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
+
+const config = require('../../../../config');
+const NamespaceNB = require('../../../sdk/namespace_nb');
+const NamespaceS3 = require('../../../sdk/namespace_s3');
+const NamespaceMultiStorageClass = require('../../../sdk/namespace_multi_storage_class');
+const ObjectIO = require('../../../sdk/object_io');
+const s3_utils = require('../../../endpoint/s3/s3_utils');
+const buffer_utils = require('../../../util/buffer_utils');
+const http_utils = require('../../../util/http_utils');
+const { get_archive_key } = require('../../../util/deep_archive_utils');
+const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
+const S3Error = require('../../../endpoint/s3/s3_errors').S3Error;
+
+const { rpc_client, EMAIL } = coretest;
+
+const BUCKET = 'test-msc-upload-object';
+const ARCHIVE_TARGET_BUCKET = 'test-msc-archive-target';
+const ARCHIVE_CONNECTION = 'msc_archive_connection';
+const ARCHIVE_NSR = 'msc_archive_nsr';
+
+// AWS S3 client is used only for archive-target bucket create/delete
+// (NamespaceS3.create_uls / delete_uls are unimplemented). Object I/O goes through namespaces.
+let s3;
+let bucket_id;
+let s3_creds;
+
+/**
+ * Minimal object_sdk for NamespaceNB / NamespaceS3 upload and read paths.
+ * @returns {object}
+ */
+function make_object_sdk() {
+    const object_io = new ObjectIO();
+    return {
+        rpc_client,
+        object_io,
+        abort_controller: new AbortController(),
+        throw_if_aborted() {
+            if (this.abort_controller.signal.aborted) throw new Error('request aborted signal');
+        },
+    };
+}
+
+/**
+ * Builds a NamespaceS3 pointed at the archive target (or overrides for failure tests).
+ * @param {{ namespace_resource_id?: string, bucket?: string }} [args]
+ * @returns {NamespaceS3}
+ */
+function make_archive_namespace_s3({ namespace_resource_id, bucket } = {}) {
+    return new NamespaceS3({
+        namespace_resource_id: namespace_resource_id || ARCHIVE_NSR,
+        bucket: bucket || ARCHIVE_TARGET_BUCKET,
+        stats: endpoint_stats_collector.instance(),
+        s3_params: {
+            endpoint: coretest.get_http_address(),
+            credentials: {
+                accessKeyId: s3_creds.accessKeyId,
+                secretAccessKey: s3_creds.secretAccessKey,
+            },
+            forcePathStyle: true,
+            region: config.DEFAULT_REGION,
+            requestHandler: new NodeHttpHandler({
+                httpAgent: http_utils.get_unsecured_agent(coretest.get_http_address()),
+            }),
+        },
+    });
+}
+
+/**
+ * Builds a NamespaceMultiStorageClass with NamespaceNB (STANDARD) and NamespaceS3 (archive).
+ * @param {{ metadata_ns?: nb.Namespace, archive_ns?: nb.Namespace, archive_ns_args?: { namespace_resource_id?: string, bucket?: string} }} [args]
+ * @returns {{ msc: NamespaceMultiStorageClass, md_ns: nb.Namespace, arch_ns: nb.Namespace }}
+ */
+function get_new_multi_storage_class_namespace({ metadata_ns, archive_ns, archive_ns_args } = {}) {
+    const md_ns = metadata_ns || new NamespaceNB();
+    const arch_ns = archive_ns || make_archive_namespace_s3(archive_ns_args);
+    const msc = new NamespaceMultiStorageClass({
+        namespace_by_storage_class: {
+            [s3_utils.STORAGE_CLASS_STANDARD]: md_ns,
+            [s3_utils.STORAGE_CLASS_DEEP_ARCHIVE]: arch_ns,
+            [s3_utils.STORAGE_CLASS_GLACIER]: arch_ns,
+        },
+    });
+    return { msc, md_ns, arch_ns };
+}
+
+/**
+ * Uploads a buffer via NamespaceMultiStorageClass.upload_object.
+ * @param {NamespaceMultiStorageClass} msc
+ * @param {object} object_sdk
+ * @param {{ key: string, buf: Buffer, storage_class?: string }} params
+ * @returns {Promise<object>}
+ */
+async function upload_buf(msc, object_sdk, { key, buf, storage_class }) {
+    const source_stream = buffer_utils.buffer_to_read_stream(buf);
+    return msc.upload_object({
+        bucket: BUCKET,
+        key,
+        size: buf.length,
+        content_type: 'application/octet-stream',
+        md5_b64: crypto.createHash('md5').update(buf).digest('base64'),
+        storage_class,
+        source_stream,
+    }, object_sdk);
+}
+
+/**
+ * Asserts object md (storage_class, size), that archive data is stored under get_archive_key
+ * (via the archive namespace), not the user key, and that MSC read_object_stream rejects
+ * with InvalidObjectState.
+ * @param {{ msc: NamespaceMultiStorageClass, arch_ns: nb.Namespace, object_sdk: object, key: string, buf: Buffer, storage_class: string, etag: string }} args
+ * @returns {Promise<void>}
+ */
+async function assert_archived_payload({ msc, arch_ns, object_sdk, key, buf, storage_class, etag }) {
+    const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+    assert.strictEqual(md.storage_class, storage_class);
+    assert.strictEqual(md.size, buf.length);
+    assert.strictEqual(md.etag, etag);
+
+    const archive_key = get_archive_key(bucket_id, md.obj_id);
+    // mock for archive target bucket listing, we use the same noobaa endpoint as the archive 
+    const listed = await arch_ns.list_objects({
+        bucket: ARCHIVE_TARGET_BUCKET,
+        prefix: 'noobaa_storage/',
+    }, object_sdk);
+    const keys = (listed.objects || []).map(o => o.key);
+    assert.ok(
+        keys.includes(archive_key),
+        `expected archive key ${archive_key} in target, got: ${JSON.stringify(keys)}`
+    );
+
+    const archived_stream = await arch_ns.read_object_stream({
+        bucket: ARCHIVE_TARGET_BUCKET,
+        key: archive_key,
+    }, object_sdk);
+    const archived_buf = await buffer_utils.read_stream_join(archived_stream);
+    assert.strictEqual(Buffer.compare(archived_buf, buf), 0);
+
+    // User-facing key must not be used for archive data
+    await assert.rejects(
+        arch_ns.read_object_md({ bucket: ARCHIVE_TARGET_BUCKET, key }, object_sdk),
+        err => err.rpc_code === 'NO_SUCH_OBJECT'
+    );
+
+    // GetObject / read_object_stream on archived objects is not allowed until restore
+    await assert.rejects(
+        msc.read_object_stream({ bucket: BUCKET, key, object_md: md }, object_sdk),
+        err => err instanceof S3Error && err.code === 'InvalidObjectState'
+    );
+}
+
+mocha.describe('NamespaceMultiStorageClass.upload_object', function() {
+    const object_sdk = make_object_sdk();
+    mocha.before(async function() {
+        const account_info = await rpc_client.account.read_account({ email: EMAIL });
+        s3_creds = {
+            accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+            secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+        };
+        s3 = new S3({
+            endpoint: coretest.get_http_address(),
+            credentials: s3_creds,
+            forcePathStyle: true,
+            region: config.DEFAULT_REGION,
+            requestHandler: new NodeHttpHandler({
+                httpAgent: http_utils.get_unsecured_agent(coretest.get_http_address()),
+            }),
+        });
+
+        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        await s3.createBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
+        await rpc_client.account.add_external_connection({
+            name: ARCHIVE_CONNECTION,
+            endpoint: coretest.get_http_address(),
+            endpoint_type: 'S3_COMPATIBLE',
+            auth_method: 'AWS_V4',
+            identity: s3_creds.accessKeyId,
+            secret: s3_creds.secretAccessKey,
+        });
+        await rpc_client.pool.create_namespace_resource({
+            name: ARCHIVE_NSR,
+            connection: ARCHIVE_CONNECTION,
+            target_bucket: ARCHIVE_TARGET_BUCKET,
+            archive: true,
+        });
+        await rpc_client.bucket.create_bucket({ name: BUCKET });
+        const bucket_info = await rpc_client.bucket.read_bucket_sdk_info({ name: BUCKET });
+        bucket_id = String(bucket_info._id);
+    });
+
+    mocha.after(async function() {
+        try {
+            await rpc_client.bucket.delete_bucket({ name: BUCKET });
+        } catch (err) { /* ignore */ }
+        try {
+            await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+        } catch (err) { /* ignore */ }
+        try {
+            await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+        } catch (err) { /* ignore */ }
+        try {
+            // Empty archive target via namespace, then delete the bucket via S3
+            const arch_ns = make_archive_namespace_s3();
+            const listed = await arch_ns.list_objects({ bucket: ARCHIVE_TARGET_BUCKET }, object_sdk);
+            for (const obj of listed.objects || []) {
+                await arch_ns.delete_object({ bucket: ARCHIVE_TARGET_BUCKET, key: obj.key }, object_sdk);
+            }
+            await s3.deleteBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
+        } catch (err) { /* ignore */ }
+        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+    });
+
+    mocha.it('uploads STANDARD objects via the metadata namespace and allows reading', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'standard/object';
+        const buf = crypto.randomBytes(64);
+
+        const reply = await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        assert.ok(reply.etag);
+
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        assert.strictEqual(md.size, buf.length);
+        assert.ok(!md.storage_class || md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key, object_md: md }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    mocha.it('defaults to STANDARD when storage_class is unset', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'standard/default-sc';
+        const buf = crypto.randomBytes(32);
+
+        await upload_buf(msc, object_sdk, { key, buf });
+
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        assert.strictEqual(md.size, buf.length);
+        assert.ok(!md.storage_class || md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+    });
+
+    mocha.it('upload_object to sc=DEEP_ARCHIVE storage class', async function() {
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const key = 'archive/deep-object';
+        const buf = Buffer.from('deep-archive-payload');
+
+        const reply = await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE });
+
+        await assert_archived_payload({
+            msc, arch_ns, object_sdk, key, buf,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            etag: reply.etag,
+        });
+    });
+
+    mocha.it('upload_object to sc=GLACIER storage class', async function() {
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const key = 'archive/glacier-object';
+        const buf = Buffer.from('glacier-payload');
+
+        const reply = await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_GLACIER });
+
+        await assert_archived_payload({
+            msc, arch_ns, object_sdk, key, buf,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            etag: reply.etag,
+        });
+    });
+
+    mocha.it('upload_object to STORAGE_CLASS_GLACIER_IR which is unsupported - should fail with NotImplemented', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const buf = Buffer.from('x');
+
+        await assert.rejects(
+            upload_buf(msc, object_sdk, { key: 'unmapped', buf, storage_class: s3_utils.STORAGE_CLASS_GLACIER_IR }),
+            err => err instanceof S3Error && err.code === 'NotImplemented'
+        );
+    });
+
+    // we intentionally not calling upload_buf here to avoid the actual upload failure
+    // so we can check that the source_stream is destroyed and the upload is aborted
+    mocha.it('aborts upload_object when upload fails, sc=DEEP_ARCHIVE', async function() {
+        const { msc } = get_new_multi_storage_class_namespace({
+            archive_ns_args: {
+                namespace_resource_id: 'missing-archive-nsr',
+                bucket: 'nonexistent-archive-target-bucket',
+            },
+        });
+        const key = 'archive/fail-data';
+        const buf = Buffer.from('will-fail');
+        const source_stream = buffer_utils.buffer_to_read_stream(buf);
+
+        await assert.rejects(msc.upload_object({
+            bucket: BUCKET,
+            key,
+            size: buf.length,
+            content_type: 'application/octet-stream',
+            md5_b64: crypto.createHash('md5').update(buf).digest('base64'),
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            source_stream,
+        }, object_sdk));
+
+        assert.strictEqual(source_stream.destroyed, true);
+
+        await assert.rejects(
+            rpc_client.object.read_object_md({ bucket: BUCKET, key }),
+            err => err.rpc_code === 'NO_SUCH_OBJECT' || err.rpc_code === 'NO_SUCH_UPLOAD'
+        );
+    });
+});

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -92,6 +92,7 @@ require('../../integration_tests/api/s3/test_s3_encryption');
 require('../../integration_tests/api/s3/test_s3_bucket_policy');
 // require('./test_node_allocator');
 require('../../unit_tests/internal/test_namespace_cache');
+require('../../unit_tests/internal/test_namespace_multi_storage_class_upload_object');
 require('../../integration_tests/api/s3/test_namespace_auth');
 require('../../integration_tests/internal/test_encryption');
 require('../../integration_tests/api/s3/test_bucket_replication');

--- a/src/util/object_utils.js
+++ b/src/util/object_utils.js
@@ -1,0 +1,55 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const _ = require('lodash');
+
+const CREATE_OBJECT_UPLOAD_PARAMS = [
+    'bucket',
+    'key',
+    'content_type',
+    'content_encoding',
+    'size',
+    'md5_b64',
+    'sha256_b64',
+    'xattr',
+    'tagging',
+    'encryption',
+    'lock_settings',
+    'storage_class',
+    'last_modified_time',
+    'archive_upload_id',
+];
+
+const COMPLETE_OBJECT_UPLOAD_PARAMS = [
+    'obj_id',
+    'bucket',
+    'key',
+    'md_conditions',
+    'size',
+    'md5_b64',
+    'sha256_b64',
+    'etag',
+    'num_parts',
+    'last_modified_time',
+];
+
+/**
+ * Picks the params accepted by object.create_object_upload.
+ * @param {object} params
+ * @returns {object}
+ */
+function get_create_object_upload_params(params) {
+    return _.pick(params, CREATE_OBJECT_UPLOAD_PARAMS);
+}
+
+/**
+ * Picks the params accepted by object.complete_object_upload.
+ * @param {object} params
+ * @returns {object}
+ */
+function get_complete_object_upload_params(params) {
+    return _.pick(params, COMPLETE_OBJECT_UPLOAD_PARAMS);
+}
+
+exports.get_create_object_upload_params = get_create_object_upload_params;
+exports.get_complete_object_upload_params = get_complete_object_upload_params;


### PR DESCRIPTION
### Describe the Problem

### Explain the Changes
1. Added changed in respect to putObject with storage_class=DEEP_ARCHIVE.
2. object_md is maintained in NamespaceNB while the data is uploaded plain to deep archive using NamespaceS3.
3. CopyObject - is_server_side_copy is always false, therefore it should work out of the box (expect when copying from the same bucket, there we need GetObject implementation in NamespaceMultiStorageClass).
4. implemented minimal read_object_stream that reads only from standard
### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of release changes

* **New Features**
  * Uploads are now routed based on the selected storage class, with archived uploads stored in the appropriate archive target.
* **Bug Fixes**
  * Streaming/read behavior is restricted for objects not matching the configured default storage class to prevent invalid downloads.
  * Failed non-standard uploads are cleaned up to avoid leaving behind incomplete upload artifacts.
* **Other**
  * Unsupported storage classes now return a clear “Not Implemented” error.
* **Tests**
  * Added unit coverage for storage-class upload routing and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->