### PR TITLE
CI | Reduce Jest unit tests run time

### DIFF
--- a/src/test/unit_tests/internal/test_file_writer.test.js
+++ b/src/test/unit_tests/internal/test_file_writer.test.js
@@ -5,48 +5,53 @@ const config = require('../../../../config');
 const file_writer_hashing = require('../../../tools/file_writer_hashing');
 const orig_iov_max = config.NSFS_DEFAULT_IOV_MAX;
 
+// CI-friendly scale: enough concurrency to exercise FileWriter without multi-minute runs.
+const default_num_parts = 50;
+const default_part_size = 2 * 1024 * 1024;
+
 // on iov_max small tests we need to use smaller amount of parts and chunks to ensure that the test will finish
 // in a reasonable period of time because we will flush max 1/2 buffers at a time.
 const small_iov_num_parts = 20;
 
 describe('FileWriter', () => {
-    const RUN_TIMEOUT = 10 * 60 * 1000;
+    const RUN_TIMEOUT = 3 * 60 * 1000;
 
     afterEach(() => {
         config.NSFS_DEFAULT_IOV_MAX = orig_iov_max;
     });
 
     it('Concurrent FileWriter with hash target', async () => {
-        await file_writer_hashing.hash_target();
+        await file_writer_hashing.hash_target(undefined, default_num_parts, undefined, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with file target', async () => {
-        await file_writer_hashing.file_target();
+        await file_writer_hashing.file_target(undefined, default_num_parts, undefined, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with hash target - iov_max=1', async () => {
-        await file_writer_hashing.hash_target(undefined, small_iov_num_parts, 1);
+        await file_writer_hashing.hash_target(undefined, small_iov_num_parts, 1, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with file target - iov_max=1', async () => {
-        await file_writer_hashing.file_target(undefined, small_iov_num_parts, 1);
+        await file_writer_hashing.file_target(undefined, small_iov_num_parts, 1, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with hash target - iov_max=2', async () => {
-        await file_writer_hashing.hash_target(undefined, small_iov_num_parts, 2);
+        await file_writer_hashing.hash_target(undefined, small_iov_num_parts, 2, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with file target - iov_max=2', async () => {
-        await file_writer_hashing.file_target(undefined, small_iov_num_parts, 2);
+        await file_writer_hashing.file_target(undefined, small_iov_num_parts, 2, default_part_size);
     }, RUN_TIMEOUT);
 
     it('Concurrent FileWriter with file target - produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE_L', async () => {
         // The goal of this test is to produce num_chunks > 1024 && total_chunks_size < config.NSFS_BUF_SIZE_L
         // so we will flush buffers because of reaching max num of buffers and not because we reached the max NSFS buf size
-        // chunk size = 100, num_chunks = (10 * 1024 * 1024)/100 < 104587, 104587 = num_chunks > 1024 
+        // chunk size = 100, part_size = 128KiB => num_chunks = 1310 > 1024
         // chunk size = 100, total_chunks_size after having 1024 chunks is = 100 * 1024 < config.NSFS_BUF_SIZE_L
         const chunk_size = 100;
-        const parts_s = 50;
-        await file_writer_hashing.file_target(chunk_size, parts_s);
+        const parts_s = 20;
+        const part_size = 128 * 1024;
+        await file_writer_hashing.file_target(chunk_size, parts_s, undefined, part_size);
     }, RUN_TIMEOUT);
 });

--- a/src/tools/file_writer_hashing.js
+++ b/src/tools/file_writer_hashing.js
@@ -20,6 +20,8 @@ const CHUNK = Number(argv.chunk) || 16 * 1024;
 const PART_SIZE = Number(argv.part_size) || 20 * 1024 * 1024;
 const F_PREFIX = argv.dst_folder || '/tmp/file_writer_hashing/';
 const IOV_MAX = argv.iov_max || config.NSFS_DEFAULT_IOV_MAX;
+// Artificial writev delay for CLI load-shaping only. Jest must not pay this cost.
+const WRITEV_DELAY_MS = Number(argv.writev_delay) || 0;
 
 const DEFAULT_FS_CONFIG = {
     uid: Number(argv.uid) || process.getuid(),
@@ -40,7 +42,7 @@ class TargetHash {
         return this.hash.digest('hex');
     }
     async writev(_config, buffers) {
-        await P.delay(100);
+        if (WRITEV_DELAY_MS) await P.delay(WRITEV_DELAY_MS);
         for (const buf of buffers) this.hash.update(buf);
     }
 }
@@ -58,10 +60,17 @@ function assign_md5_to_fs_xattr(md5_digest, fs_xattr) {
     return fs_xattr;
 }
 
-async function hash_target(chunk_size = CHUNK, parts = PARTS, iov_max = IOV_MAX) {
+/**
+ * Runs concurrent FileWriter streams against an in-memory hash target.
+ * @param {number} [chunk_size]
+ * @param {number} [parts]
+ * @param {number} [iov_max]
+ * @param {number} [part_size]
+ */
+async function hash_target(chunk_size = CHUNK, parts = PARTS, iov_max = IOV_MAX, part_size = PART_SIZE) {
     config.NSFS_DEFAULT_IOV_MAX = iov_max;
     await P.map_with_concurrency(CONCURRENCY, Array(parts).fill(), async () => {
-        const data = crypto.randomBytes(PART_SIZE);
+        const data = crypto.randomBytes(part_size);
         const content_md5 = crypto.createHash('md5').update(data).digest('hex');
         // Using async generator function in order to push data in small chunks
         const source_stream = stream.Readable.from(async function*() {
@@ -91,12 +100,19 @@ async function hash_target(chunk_size = CHUNK, parts = PARTS, iov_max = IOV_MAX)
     });
 }
 
-async function file_target(chunk_size = CHUNK, parts = PARTS, iov_max = IOV_MAX) {
+/**
+ * Runs concurrent FileWriter streams against real files under F_PREFIX.
+ * @param {number} [chunk_size]
+ * @param {number} [parts]
+ * @param {number} [iov_max]
+ * @param {number} [part_size]
+ */
+async function file_target(chunk_size = CHUNK, parts = PARTS, iov_max = IOV_MAX, part_size = PART_SIZE) {
     config.NSFS_DEFAULT_IOV_MAX = iov_max;
     fs.mkdirSync(F_PREFIX, { recursive: true });
     await P.map_with_concurrency(CONCURRENCY, Array(parts).fill(), async () => {
         let target_file;
-        const data = crypto.randomBytes(PART_SIZE);
+        const data = crypto.randomBytes(part_size);
         const content_md5 = crypto.createHash('md5').update(data).digest('hex');
         const F_TARGET = path.join(F_PREFIX, content_md5);
         try {


### PR DESCRIPTION
### Describe the Problem
`run-jest-unit-tests` on master PRs averages ~18–20 minutes, largely gated by `test_file_writer.test.js` (~10+ minutes). That suite reused CLI stress defaults (`1000` parts × `20MiB`) plus an artificial `P.delay(100)` on every mock `writev`, which inflated wall clock without adding assertions.

### Explain the Changes
1. Shrink FileWriter Jest workloads: default cases use `parts=50` / `part_size=2MiB`; keep `iov_max=1/2` at `parts=20`; buffer-flush case still forces `num_chunks > 1024` with smaller parts/size.
2. Make `part_size` a parameter of `hash_target` / `file_target` (CLI defaults unchanged for manual stress runs).
3. Gate the artificial `TargetHash.writev` delay behind `--writev_delay` (default 0 so Jest does not pay it).
4. Lower suite `RUN_TIMEOUT` from 10m to 3m.

### Issues: Fixed #xxx / Gap #xxx
1. N/A — CI performance improvement.

### Testing Instructions:
1. Confirm Jest Unit Tests on this branch lands near ~8–10m (validated ~9.9m on fork: https://github.com/liranmauda/noobaa-core/actions/runs/29744468325).
2. Same 7 FileWriter cases still pass (hash/file targets, iov_max=1/2, num_chunks>1024 flush path).

- [ ] Doc added/updated
- [x] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable write pacing for file-writing via a new load-shaping delay option.
  * Added support for customizing per-part sizes in the hashing and file generation utilities.
* **Tests**
  * Improved file-writer test reliability and speed by using explicit concurrency parameters and reducing per-test timeouts.
  * Refined large-part scenarios to be more deterministic in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->