### PR TITLE
[Deep Archive] - Transition lifecycle rule implementation in lifecycle bg worker

### DIFF
--- a/config.js
+++ b/config.js
@@ -520,6 +520,7 @@ config.LIFECYCLE_INTERVAL = 8 * 60 * 60 * 1000; // 8h
 config.LIFECYCLE_BATCH_SIZE = 1000;
 config.LIFECYCLE_SCHEDULE_MIN = 5 * 1000 * 60; // run every 5 minutes
 config.LIFECYCLE_ENABLED = true;
+config.LIFECYCLE_TRANSITION_BATCH_SIZE = 50;
 
 /////////////////////
 // ARCHIVE CHECK   //

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1540,6 +1540,93 @@ module.exports = {
             auth: { system: ['admin', 'user'] }
         },
 
+        find_objects_to_transition: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['bucket', 'transition_ts'],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    transition_ts: { type: 'number' },
+                    batch_size: { type: 'integer' },
+                    key_marker: { type: 'string' },
+                },
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    objects: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/object_info'
+                        },
+                    },
+                    is_truncated: { type: 'boolean' },
+                    next_marker: { type: 'string' },
+                },
+            },
+            auth: {
+                system: 'admin',
+            },
+        },
+
+        find_versioned_objects_to_transition: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: ['bucket', 'transition_ts'],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    is_latest: { type: 'boolean' },
+                    transition_ts: { type: 'number' },
+                    batch_size: { type: 'integer' },
+                    key_marker: { type: 'string' },
+                    version_seq_marker: { type: 'integer' },
+                    noncurrent_days: { type: 'integer' },
+                    newer_noncurrent_versions: { type: 'integer' },
+                },
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    objects: {
+                        type: 'array',
+                        items: {
+                            $ref: '#/definitions/object_info'
+                        },
+                    },
+                    is_truncated: { type: 'boolean' },
+                    next_marker: { type: 'string' },
+                    next_version_seq_marker: { type: 'integer' },
+                },
+            },
+            auth: {
+                system: 'admin',
+            },
+        },
+
+        update_transition_status: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['obj_id'],
+                properties: {
+                    obj_id: { objectid: true },
+                    update_transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
+                    deleted: { idate: true },
+                    transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
+                    unset_transition_status: { type: 'boolean' },
+                    storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                },
+            },
+            reply: {
+                type: 'boolean'
+            },
+            auth: {
+                system: 'admin',
+            },
+        },
+
         get_object_restore_info: {
             method: 'GET',
             params: {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -235,6 +235,9 @@ interface Bucket extends Base {
     };
     lifecycle_configuration_rules?: object;
     master_key_id: ID;
+    archive_policy?: {
+        deep_archive_resource?: object;
+    };
 }
 
 interface CacheConfig {

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -12,6 +12,12 @@ const auth_server = require('../common_services/auth_server');
 const config = require('../../../config');
 const { get_notification_logger, check_notif_relevant,
     OP_TO_EVENT, compose_notification_lifecycle } = require('../../util/notifications_util');
+const COMMON_CONSTANTS = require('../../common/constants');
+
+/*************************/
+/******* CONSTANTS *******/
+/*************************/
+const ARCHIVE = COMMON_CONSTANTS.ARCHIVE;
 
 function get_expiration_timestamp(expiration) {
     if (!expiration) {
@@ -20,6 +26,124 @@ function get_expiration_timestamp(expiration) {
         return Math.floor(new Date(expiration.date).getTime() / 1000);
     } else if (expiration.days) {
         return moment().subtract(expiration.days, 'days').unix();
+    }
+}
+
+/**
+ * Gets the Unix timestamp associated with a transition.
+ * Transition for objects can be set to 0 unlike expiration which should be a positive integer.
+ *
+ * @param {Object} transition - The transition configuration.
+ * @param {string|Date} [transition.date] - An absolute date to convert to a
+ * Unix timestamp.
+ * @param {number} [transition.days] - The number of days to subtract from
+ * the current time.
+ * @returns {number|undefined} The Unix timestamp in seconds, or `undefined`
+ * if no valid transition value is provided.
+ */
+function get_transition_timestamp(transition) {
+    if (!transition) {
+        return undefined; // undefined
+    } else if (transition.date !== undefined) {
+        return Math.floor(new Date(transition.date).getTime() / 1000);
+    } else if (transition.days !== undefined) {
+        return moment().subtract(transition.days, 'days').unix();
+    }
+}
+
+/**
+ * Transition eligible objects from standard storage to the archive backend.
+ * Transition is done based on the set transition lifecycle rule.
+ *
+ * @param {Object} system - the NooBaa system object from system_store
+ * @param {nb.Bucket} bucket_info - the bucket object (includes name, _id, versioning, archive_policy)
+ * @param {Object} rule - the lifecycle rule containing transition or noncurrent_version_transition
+ */
+async function process_transition(system, bucket_info, rule) {
+    if (!rule) {
+        return;
+    }
+
+    try {
+        const batch_size = config.LIFECYCLE_BATCH_SIZE;
+        const object_server = server_rpc.client.object;
+        const target_storage_class = rule.storage_class;
+
+        const transition = {
+            days: rule.days ?? rule.noncurrent_days,
+            date: rule.date
+        };
+        const transition_ts = get_transition_timestamp(transition);
+        if (!transition_ts) {
+            dbg.error("found transition rule with invalid transition day/date", bucket_info.name, rule);
+            return;
+        } else if (Object.keys(bucket_info.archive_policy?.deep_archive_resource || {}).length <= 0) {
+            dbg.error("found bucket with invalid archive resource", bucket_info.name, bucket_info.archive_policy);
+            return;
+        } else if (!Object.keys(ARCHIVE.STORAGE_CLASS).includes(target_storage_class)) {
+            dbg.error(`target storage class should be one of: ${Object.keys(ARCHIVE.STORAGE_CLASS)}`);
+            return;
+        }
+
+        // Behavior for versioning suspended bucket is same as an enabled bucket
+        const versioning_disabled = bucket_info.versioning === COMMON_CONSTANTS.S3.VERSIONING.DISABLED;
+        let is_truncated = true;
+        let key_marker = '';
+        let version_seq_marker;
+        // List objects that are not deleted, reclaimed and not having transition_status as in_progress
+        while (is_truncated) {
+            let result;
+            if (versioning_disabled) {
+                result = await object_server.find_objects_to_transition({
+                    bucket: bucket_info.name,
+                    batch_size,
+                    key_marker,
+                    transition_ts,
+                }, {
+                    auth_token: auth_server.make_auth_token({
+                        system_id: system._id,
+                        account_id: system.owner._id,
+                        role: 'admin'
+                    })
+                });
+            } else {
+                /* 
+                For versioned buckets, the objects depends on the following rules: 
+                    1. Transition - All the latest versions of the objects
+                    2. NoncurrentVersionTransition - AND operation between NoncurrentDays and NewerNoncurrentVersions
+                */
+                const is_latest = !(rule.noncurrent_days || rule.newer_noncurrent_versions);
+                result = await object_server.find_versioned_objects_to_transition({
+                    bucket: bucket_info.name,
+                    batch_size,
+                    key_marker,
+                    version_seq_marker,
+                    transition_ts,
+                    is_latest,
+                    noncurrent_days: rule.noncurrent_days,
+                    newer_noncurrent_versions: rule.newer_noncurrent_versions,
+                }, {
+                    auth_token: auth_server.make_auth_token({
+                        system_id: system._id,
+                        account_id: system.owner._id,
+                        role: 'admin'
+                    })
+                });
+            }
+
+            try {
+                const obj_ids = await transition_objects(system, bucket_info, result.objects, target_storage_class);
+                dbg.log1("successfully transitioned batch with object id's", obj_ids);
+            } catch (err) {
+                dbg.error("error occurred while transitioning objects batch", err);
+            }
+
+            key_marker = result.next_marker;
+            version_seq_marker = result.next_version_seq_marker;
+            is_truncated = result.is_truncated;
+        }
+    } catch (e) {
+        dbg.error("error occurred while executing batch transition", e);
     }
 }
 
@@ -126,7 +250,8 @@ async function handle_bucket_rule(system, rule, j, bucket) {
     if (
         rule.expiration === undefined &&
         rule.abort_incomplete_multipart_upload === undefined &&
-        rule.noncurrent_version_expiration === undefined
+        rule.noncurrent_version_expiration === undefined &&
+        !rule.transition && !rule.noncurrent_version_transition
     ) {
         dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'rule contains no expiration parameters');
         return;
@@ -214,6 +339,19 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         );
     }
 
+    if (rule.transition || rule.noncurrent_version_transition) {
+        // NoncurrentVersionTransition has no effect on versioning disabled buckets
+        if (rule.noncurrent_version_transition &&
+            bucket.versioning === COMMON_CONSTANTS.S3.VERSIONING.DISABLED) {
+            dbg.log1("skipping noncurrent_version_transition rule as bucket versioning is disabled", bucket.name);
+        } else {
+            await process_transition(system, bucket, rule.transition);
+            await process_transition(system, bucket, rule.noncurrent_version_transition);
+
+            dbg.log1("bucket", bucket.name, "transition batch completed");
+        }
+    }
+
     if (num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true;
 
     bucket.lifecycle_configuration_rules[j].last_sync = Date.now();
@@ -265,4 +403,108 @@ function update_lifecycle_rules_last_sync(bucket, rules) {
         }
     });
 }
+
+/**
+ * Reset an object's transition_status by unsetting it on its object_md.
+ *
+ * @param {Object} rpc_client - the RPC client (server_rpc.client)
+ * @param {Object} system - the NooBaa system object from system_store
+ * @param {string} object_id - the object's _id to reset
+ * @returns {Promise<boolean>} true if the update succeeded
+ */
+function unset_transition_status(rpc_client, system, object_id) {
+    return rpc_client.object.update_transition_status({
+        unset_transition_status: true,
+        obj_id: object_id,
+        transition_status: ARCHIVE.TRANSITION_STATUS.IN_PROGRESS,
+    }, {
+        auth_token: auth_server.make_auth_token({
+            system_id: system._id,
+            account_id: system.owner._id,
+            role: 'admin'
+        })
+    });
+}
+
+/**
+ * Transitions a batch of objects to archive storage class.
+ * For each object in the batch, calls archive_object on the archive_server which handles IO
+ *
+ * @param {Object} system - The NooBaa system object.
+ * @param {nb.Bucket} bucket_info - The bucket descriptor.
+ * @param {Array<Object>} objects - Array of object descriptors (each with an obj_id property)
+ *                                  to transition.
+ * @param {string} target_storage_class - The target storage class to transition objects to (e.g. 'GLACIER').
+ * @returns {Promise<string[]>} Array of successfully transitioned object IDs.
+ */
+async function transition_objects(system, bucket_info, objects, target_storage_class) {
+    const batch_size = config.LIFECYCLE_TRANSITION_BATCH_SIZE;
+    const failed_objects = [];
+    const rpc_client = server_rpc.rpc.new_client({
+        auth_token: auth_server
+            .make_auth_token({
+                system_id: system._id,
+                account_id: system.owner._id,
+                role: 'admin'
+            })
+    });
+    const obj_ids = await P.map_with_concurrency(batch_size, objects, (async obj => {
+        const obj_id = obj.obj_id;
+        try {
+            const res = await server_rpc.client.object.update_transition_status({
+                update_transition_status: ARCHIVE.TRANSITION_STATUS.IN_PROGRESS,
+                obj_id,
+            }, {
+                auth_token: auth_server.make_auth_token({
+                    system_id: system._id,
+                    account_id: system.owner._id,
+                    role: 'admin'
+                })
+            });
+
+            if (!res) {
+                dbg.warn("LIFECYCLE_TRANSITION: object no longer valid for transition", obj_id);
+                return;
+            }
+
+            dbg.log1("LIFECYCLE_TRANSITION: transition status updated to 'in_progress' for object:", obj_id);
+
+            const archive_status = await rpc_client.archive.archive_object({
+                obj_id: obj_id,
+                bucket_id: bucket_info._id,
+                target_storage_class,
+            });
+
+            if (archive_status.success) {
+                await server_rpc.client.object.update_transition_status({
+                    update_transition_status: ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_status: ARCHIVE.TRANSITION_STATUS.IN_PROGRESS,
+                    storage_class: target_storage_class,
+                    obj_id,
+                }, {
+                    auth_token: auth_server.make_auth_token({
+                        system_id: system._id,
+                        account_id: system.owner._id,
+                        role: 'admin'
+                    })
+                });
+                dbg.log1('object successfully transitioned', obj_id);
+                return obj_id;
+            } else {
+                dbg.log1("got success false status from archive_server for object", obj_id);
+                throw new Error("archive_server failed to transition object", obj.key);
+            }
+        } catch (e) {
+            failed_objects.push(obj_id);
+            dbg.error("failed to archive object", obj_id, "retry in next cycle", e);
+            await unset_transition_status(server_rpc.client, system, obj_id);
+        }
+    }));
+
+    if (failed_objects.length) {
+        dbg.warn("failed to archive objects", failed_objects, "retry in next cycle");
+    }
+    return obj_ids.filter(Boolean);
+}
+
 exports.background_worker = background_worker;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2600]*/
+/*eslint max-lines: ["error", 2800]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -181,6 +181,23 @@ class MDStore {
     async update_object_by_id(obj_id, set_updates, unset_updates, inc_updates) {
         dbg.log1('update_object_by_id:', obj_id, compact_updates(set_updates, unset_updates, inc_updates));
         const res = await this._objects.updateOne({ _id: obj_id },
+            compact_updates(set_updates, unset_updates, inc_updates)
+        );
+        db_client.instance().check_update_one(res, 'object');
+    }
+
+    /**
+     * Finds a single object matching the given filter and applies the specified updates.
+     *
+     * @param {Object} filter - A query object selecting the object document to update.
+     * @param {Object} [set_updates] - Fields to set on the matched object.
+     * @param {Object} [unset_updates] - Fields to remove from the matched object.
+     * @param {Object} [inc_updates] - Numeric fields to increment on the matched object.
+     * @returns {Promise<void>} A promise that resolves when the update has been applied or rejects if no object was updated.
+     */
+    async find_and_update_object(filter, set_updates, unset_updates, inc_updates) {
+        dbg.log1('find_and_update_object:', compact_updates(set_updates, unset_updates, inc_updates));
+        const res = await this._objects.updateOne(filter,
             compact_updates(set_updates, unset_updates, inc_updates)
         );
         db_client.instance().check_update_one(res, 'object');
@@ -2401,6 +2418,193 @@ class MDStore {
         const params = [now, bucket_id, keys];
         const result = await db_client.instance().executeSQL(query, params, { preferred_pool: this._postgres_pool });
         return result.rows;
+    }
+
+    /*************************/
+    /**** S3 TRANSITION ******/
+    /*************************/
+
+    /**
+    * Find current object versions eligible for lifecycle transition.
+    *
+    * Uses Amazon S3 lifecycle transition timing semantics:
+    * * The object creation time is rounded up to the next midnight UTC
+    * * The resulting time is compared with the transition timestamp
+    *
+    * An object is eligible when:
+    * * Its rounded-up lifecycle transition time is before transition_ts
+    * * It is not deleted or reclaimed
+    * * It is not an incomplete multipart upload
+    * * It is the current version, not a noncurrent version
+    * * It is not a delete marker
+    * * It is not already being transitioned
+    *
+    * Supports keyset pagination via key_marker.
+    *
+    * @param {{
+    * bucket: {_id: nb.ID},
+    * transition_ts: number,
+    * batch_size?: number,
+    * key_marker?: string,
+    * }} params
+    * @returns {Promise<nb.ObjectMD[]>}
+    */
+
+    async find_objects_to_transition(params) {
+        const query_limit = params.batch_size || 100;
+        const bucket_id = String(params.bucket._id);
+        const create_time_cutoff = moment.unix(params.transition_ts).toISOString();
+        const values = [bucket_id, create_time_cutoff];
+
+        let key_marker_condition = '';
+        let idx = 3;
+        if (params.key_marker) {
+            values.push(params.key_marker);
+            key_marker_condition = `AND data->>'key' > $${idx}`;
+            idx += 1;
+        }
+
+        /* 
+           Amazon S3 calculates the time by adding the number of days specified in the rule to the 
+           object creation time and rounding up the resulting time to the next day at midnight UTC 
+        */
+        const query = `SELECT *
+        FROM ${this._objects.name}
+        WHERE data->>'bucket' = $1
+        AND (
+                date_trunc('day', (data->>'create_time')::timestamptz) + interval '1 day'
+            ) < $2::timestamptz
+        AND (data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)
+        AND (data->'reclaimed' IS NULL OR data->'reclaimed' = 'null'::jsonb)
+        AND (data->'upload_started' IS NULL OR data->'upload_started' = 'null'::jsonb)
+        AND (data->'version_past' IS NULL OR data->'version_past' = 'null'::jsonb)
+        AND (data->'delete_marker' IS NULL OR data->'delete_marker' = 'null'::jsonb)
+        AND (data->'transition_status' IS NULL OR data->'transition_status' = 'null'::jsonb)
+        ${key_marker_condition}
+        ORDER BY data->>'key' ASC
+        LIMIT $${idx};`;
+        values.push(query_limit);
+
+        const result = await db_client.instance().executeSQL(query, values, {
+            preferred_pool: 'read_only',
+        });
+        return result.rows.map(row => decode_json(this._objects.schema, row.data));
+    }
+
+    /**
+     * Find noncurrent object versions eligible for NoncurrentVersionTransition.
+     *
+     * Uses window functions to compute:
+     *  - successor_time: when this version became noncurrent (create_time of the next version)
+     *  - rn: rank among versions of the same key (1 = newest noncurrent, 2 = next, etc.)
+     *
+     * A version is eligible when BOTH conditions are met (AND logic per S3 spec):
+     *  - It has been noncurrent for >= noncurrent_days
+     *  - There are > newer_noncurrent_versions newer noncurrent versions of the same key
+     *    (if newer_noncurrent_versions is specified)
+     *
+     * Excludes deleted, reclaimed, currently-transitioning, and delete-marker objects.
+     * Supports keyset pagination via key_marker + version_seq_marker.
+     *
+     * @param {{
+     *   bucket_id: nb.ID,
+     *   noncurrent_days: number,
+     *   newer_noncurrent_versions?: number,
+     *   prefix?: string,
+     *   size_less?: number,
+     *   size_greater?: number,
+     *   tags?: Array<{key: string, value: string}>,
+     *   batch_size: number,
+     *   key_marker?: string,
+     *   version_seq_marker?: number,
+     * }} params
+     * @returns {Promise<nb.ObjectMD[]>}
+     */
+    async find_versioned_objects_to_transition({
+        bucket_id,
+        noncurrent_days,
+        newer_noncurrent_versions,
+        prefix,
+        size_less,
+        size_greater,
+        tags,
+        batch_size,
+        key_marker,
+        version_seq_marker,
+    }) {
+        const table_name = this._objects.name;
+        const query_limit = batch_size || 100;
+
+        if (noncurrent_days === undefined) throw new Error('noncurrent_days is required');
+
+        // --- CTE base filters (applied before window functions) ---
+        const base_conditions = [
+            `data->>'bucket' = '${String(bucket_id)}'`,
+            `(data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)`,
+            `(data->'upload_started' IS NULL OR data->'upload_started' = 'null'::jsonb)`,
+            `(data->'reclaimed' IS NULL OR data->'reclaimed' = 'null'::jsonb)`,
+            `(data->'delete_marker' IS NULL OR data->'delete_marker' = 'null'::jsonb)`,
+        ];
+
+        // --- Ranked result filters (applied after window functions) ---
+        const ranked_conditions = [
+            // Must be noncurrent for at least noncurrent_days
+            `(successor_time IS NOT NULL AND (CURRENT_TIMESTAMP - successor_time) >= interval '${noncurrent_days} days')`,
+            // Not already transitioned or in progress
+            `(transition_status IS NULL OR transition_status = 'null'::jsonb)`,
+        ];
+
+        // NewerNoncurrentVersions: rn=1 is the newest noncurrent version, rn=2 is next, etc.
+        // Only transition versions ranked beyond the retention count.
+        if (newer_noncurrent_versions) {
+            ranked_conditions.push(`(rn > ${newer_noncurrent_versions} + 1)`);
+        }
+
+        // Composite keyset pagination on (key, version_seq).
+        // Results are ordered by key ASC, version_seq DESC, so for the same key
+        // we resume from versions with a lower version_seq than the marker.
+        if (key_marker && version_seq_marker) {
+            ranked_conditions.push(
+                `((key = '${key_marker}' AND version_seq < ${version_seq_marker}) OR key > '${key_marker}')`
+            );
+        } else if (key_marker) {
+            ranked_conditions.push(`key > '${key_marker}'`);
+        }
+
+        const query = `
+            WITH ranked AS (
+                SELECT
+                    _id,
+                    data->>'key' AS key,
+                    (data->>'version_seq')::BIGINT AS version_seq,
+                    (data->>'size')::BIGINT AS size,
+                    data->'tagging' AS tags,
+                    data->'transition_status' AS transition_status,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY data->>'key'
+                        ORDER BY (data->>'version_seq')::BIGINT DESC
+                    ) AS rn,
+                    LEAD((data->>'create_time')::timestamptz) OVER (
+                        PARTITION BY data->>'key'
+                        ORDER BY (data->>'version_seq')::BIGINT
+                    ) AS successor_time
+                FROM ${table_name}
+                WHERE
+                    ${sql_and_conditions(...base_conditions)}
+            )
+            SELECT t.*
+            FROM ${table_name} t
+            INNER JOIN ranked ON ranked._id = t._id
+            WHERE
+                ${sql_and_conditions(...ranked_conditions)}
+            ORDER BY ranked.key ASC, ranked.version_seq DESC
+            LIMIT ${query_limit};`;
+
+        dbg.log1('[find_versioned_objects_to_transition] generated query:', query);
+        const result = await db_client.instance().executeSQL(query, [], {
+            preferred_pool: 'read_only',
+        });
+        return result.rows.map(row => decode_json(this._objects.schema, row.data));
     }
 }
 

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2600]*/
+/*eslint max-lines: ["error", 2700]*/
 'use strict';
 
 require('../../util/fips');
@@ -1080,7 +1080,145 @@ async function update_object_md(req) {
     await MDStore.instance().update_object_by_id(obj._id, set_updates);
 }
 
+/**
+ * Finds current (non-versioned) objects eligible for S3 lifecycle Transition.
+ *
+ * Queries the metadata store for objects in the specified bucket whose creation time
+ * has passed the transition timestamp cutoff. Only returns objects that are not deleted,
+ * reclaimed, upload-in-progress, version-past, delete markers, or already transitioning.
+ * Supports paginated listing via key_marker.
+ *
+ * @param {Object} req - The RPC request object.
+ * @returns {Promise<{objects: Array<Object>, is_truncated: boolean, next_marker: string|undefined}>}
+ *          Paginated list of object_info items with truncation flag and continuation marker.
+ * @throws {RpcError}
+ */
+async function find_objects_to_transition(req) {
+    throw_if_maintenance(req);
+    load_bucket(req, { include_deleting: true });
 
+    const { key_marker, transition_ts } = req.rpc_params;
+    const batch_size = req.rpc_params.batch_size || 1000;
+    const objects = await MDStore.instance().find_objects_to_transition({
+        bucket: req.bucket,
+        batch_size,
+        key_marker,
+        transition_ts,
+    });
+
+    return {
+        objects: objects.map(get_object_info),
+        is_truncated: objects.length >= batch_size,
+        next_marker: objects.length ? objects[objects.length - 1].key : undefined,
+    };
+}
+
+/**
+ * Finds versioned objects eligible for S3 lifecycle transition.
+ *
+ * Handles two distinct transition rule types based on the is_latest flag:
+ *  - is_latest=true (Transition rule): Finds the latest (current) versions of objects
+ *    whose creation time is older than the transition timestamp.
+ *  - is_latest=false (NoncurrentVersionTransition rule): Finds noncurrent object versions
+ *    that have been noncurrent for at least noncurrent_days, optionally retaining up to
+ *    newer_noncurrent_versions newer noncurrent versions per key.
+ *
+ * Supports paginated listing via key_marker and version_seq_marker.
+ *
+ * @param {Object} req - The RPC request object.
+ * @returns {Promise<{objects: Array<Object>, is_truncated: boolean, next_marker: string|undefined, next_version_seq_marker: number|undefined}>}
+ *          Paginated list of object_info items with truncation flag and continuation markers.
+ * @throws {RpcError}
+ */
+async function find_versioned_objects_to_transition(req) {
+    throw_if_maintenance(req);
+    load_bucket(req, { include_deleting: true });
+
+    const { key_marker, version_seq_marker, transition_ts, is_latest,
+        newer_noncurrent_versions, noncurrent_days } = req.rpc_params;
+    const batch_size = req.rpc_params.batch_size || 1000;
+    let objects = [];
+
+    if (is_latest) {
+        objects = await MDStore.instance().find_objects_to_transition({
+            bucket: req.bucket,
+            batch_size,
+            key_marker,
+            transition_ts,
+        });
+    } else {
+        objects = await MDStore.instance().find_versioned_objects_to_transition({
+            bucket_id: req.bucket._id,
+            batch_size,
+            key_marker,
+            version_seq_marker,
+            noncurrent_days,
+            newer_noncurrent_versions,
+        });
+    }
+
+    const last_obj = objects.length ? objects[objects.length - 1] : undefined;
+    return {
+        objects: objects.map(get_object_info),
+        is_truncated: objects.length >= batch_size,
+        next_marker: last_obj ? last_obj.key : undefined,
+        next_version_seq_marker: last_obj ? last_obj.version_seq : undefined,
+    };
+}
+
+/**
+ * Updates the transition status of an object during lifecycle archival.
+ * Can also unset the transition_status entirely (used to roll back on failure).
+ *
+ * @param {Object} req - The RPC request object.
+ * @returns {Promise<boolean>} true if the update succeeded, false if the object did not match
+ *                             the filter criteria (NO_SUCH_OBJECT).
+ * @throws {RpcError}
+ */
+async function update_transition_status(req) {
+    dbg.log1("rececived object transition request", req.rpc_params);
+    throw_if_maintenance(req);
+    const { rpc_params } = req;
+
+    let set_updates;
+    if (rpc_params.update_transition_status) {
+        set_updates = {
+            transition_status: rpc_params.update_transition_status
+        };
+        if (rpc_params.update_transition_status === CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE) {
+            if (!rpc_params.storage_class) {
+                throw new Error("update_transition_status: storage class is required");
+            }
+            set_updates.storage_class = rpc_params.storage_class;
+            set_updates.data_expired = new Date();
+        }
+    }
+
+    let unset_updates;
+    if (rpc_params.unset_transition_status) {
+        unset_updates = {
+            transition_status: 1
+        };
+    }
+
+    const filter = {
+        _id: rpc_params.obj_id,
+        deleted: rpc_params.deleted || null,
+        transition_status: rpc_params.transition_status || null,
+    };
+
+    try {
+        await MDStore.instance().find_and_update_object(filter, set_updates, unset_updates);
+    } catch (e) {
+        if (e instanceof RpcError && e.rpc_code === 'NO_SUCH_OBJECT') {
+            dbg.warn("object to transition may be deleted or already being transitioned",
+                req.rpc_params);
+            return false;
+        }
+        throw e;
+    }
+    return true;
+}
 
 /**
  *
@@ -2509,6 +2647,10 @@ exports.get_object_legal_hold = get_object_legal_hold;
 exports.put_object_retention = put_object_retention;
 exports.get_object_retention = get_object_retention;
 exports.calc_retention = calc_retention;
+// lifecycle
+exports.find_objects_to_transition = find_objects_to_transition;
+exports.find_versioned_objects_to_transition = find_versioned_objects_to_transition;
+exports.update_transition_status = update_transition_status;
 
 if (process.env.NODE_ENV === 'test') {
     exports.__testing = {


### PR DESCRIPTION
### Description
Implement S3-compatible lifecycle `Transition` and `NoncurrentVersionTransition` rules in the lifecycle background worker, enabling objects to be moved from standard storage to an archive backend (e.g., DEEP_ARCHIVE).

- Each rule is processed in batches with a configurable size.
- The eligible objects from each batch are processed async by `archive_worker`, which would be reading from the standard storage class and writing the object to archive storage class configured in the `deep_archive_resource` of the namespace store.
- Objects with errors are retried on the next cycle of lifecycle.

### Explain the Changes
1. Added md store functions to find objects to transition.
2. lifecycle bg worker processes `Transition` and `NoncurrentVersionTransition` rules.

### Issues: Fixed #xxx / Gap #xxx
1. Additional S3 filters are not yet handled.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Lifecycle transition rules can now archive eligible objects to configured archival storage classes, including noncurrent/versioned transitions.
  * Added admin endpoints to discover objects pending transition and to update an individual object’s transition status.
  * Added optional deep-archive resource support and batched/paginated transition processing.

* **Bug Fixes**
  * Objects that fail during transition have their transition state cleared for safe retry in later runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->