### PR TITLE
[Backport into 5.22] revert lancdb to 0.30.0 to avoid an issue (21/07/2026)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "wtfnode": "0.10.1"
       },
       "optionalDependencies": {
-        "@lancedb/lancedb": "0.31.0"
+        "@lancedb/lancedb": "0.30.0"
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -1244,6 +1244,8 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1407,25 +1409,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@huggingface/jinja": {
-      "version": "0.3.4",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@huggingface/transformers": {
-      "version": "3.0.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@huggingface/jinja": "^0.3.0",
-        "onnxruntime-node": "1.19.2",
-        "onnxruntime-web": "1.21.0-dev.20241024-d9ca84ef96",
-        "sharp": "^0.33.5"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "dev": true,
@@ -1477,40 +1460,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -1554,7 +1503,9 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -2008,7 +1959,9 @@
       }
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.31.0",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.30.0.tgz",
+      "integrity": "sha512-d0FoEL6cthqgsulqAc7fck6kRXrSRGMTqlKYbhSGSazHU6vB2GEpD737Mu0HZd7fMyBUdhR9sD1W2C9uQZ5p0Q==",
       "cpu": [
         "x64",
         "arm64"
@@ -2027,22 +1980,22 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@huggingface/transformers": "3.0.2",
-        "@lancedb/lancedb-darwin-arm64": "0.31.0",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.31.0",
-        "@lancedb/lancedb-linux-arm64-musl": "0.31.0",
-        "@lancedb/lancedb-linux-x64-gnu": "0.31.0",
-        "@lancedb/lancedb-linux-x64-musl": "0.31.0",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.31.0",
-        "@lancedb/lancedb-win32-x64-msvc": "0.31.0",
-        "openai": "4.29.2"
+        "@lancedb/lancedb-darwin-arm64": "0.30.0",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.30.0",
+        "@lancedb/lancedb-linux-arm64-musl": "0.30.0",
+        "@lancedb/lancedb-linux-x64-gnu": "0.30.0",
+        "@lancedb/lancedb-linux-x64-musl": "0.30.0",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.30.0",
+        "@lancedb/lancedb-win32-x64-msvc": "0.30.0"
       },
       "peerDependencies": {
         "apache-arrow": ">=15.0.0 <=18.1.0"
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.31.0",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-x6dmsjRIv0xumELYnFAEfyFDxqcO/n4rHYCJvC27RbRez0UmbByi6OMTgbSoSTatrQSPRCL7JJSa5pwNeawnIg==",
       "cpu": [
         "arm64"
       ],
@@ -2050,6 +2003,102 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.30.0.tgz",
+      "integrity": "sha512-CWUex7hRNiLkXFeTQlUGPyy5VktbXoUmQdZuiVCETZ6ggljEC7c7Qvzu2ge+jEZML+UE7tXL2lVC3klRFGczng==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-arm64-musl": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.30.0.tgz",
+      "integrity": "sha512-2MHmAS4tKePNVbwfgDrjCFj6BVuAgXlL2c9iWk7TfcwL+jcSxo52LFx03O0+ArpVCF2sI6aoDqZaQNre5zMniQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-x64-gnu": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.30.0.tgz",
+      "integrity": "sha512-0OpDNxsDE4OXD+PIFd7KdE42xhYIE+fZL+jCm1v3dTug4UEhumWBuSgbUIBP7t0yJZHwh62/QivVh/V1cPB2Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-x64-musl": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.30.0.tgz",
+      "integrity": "sha512-4Bq7VngQt+lyxIcu79EN8nYJs8gvUnrIT6I/t2MSlpG/BXWHZG2A+PRii1Zq4GCUlRTTG+RlieCv8CBGSPm8bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.30.0.tgz",
+      "integrity": "sha512-N2DQg2XBWZirn5jS6kRJUxF679t3sKcIxBwP9zY4Idq5OVLAj0yfLueWIKhYxv8en7pBFYWdgw5j9dTS7XajyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-x64-msvc": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.30.0.tgz",
+      "integrity": "sha512-CDgN/ZmYqSlVX2nBJAF2PYEwqBBxotCVORjagmvrd0k5D7RBLlAQUEAR4gDMum2BpYsUkzdTYQpquLjRCVbwbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 18"
@@ -2454,15 +2503,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/pg": {
@@ -3140,17 +3180,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
@@ -3478,10 +3507,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3829,14 +3854,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "dev": true,
@@ -3853,7 +3870,9 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -3939,18 +3958,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "devOptional": true,
@@ -3966,15 +3973,6 @@
       "version": "1.1.4",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4129,14 +4127,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
@@ -4283,7 +4273,9 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4303,15 +4295,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -5118,65 +5101,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "license": "MIT",
@@ -5536,11 +5460,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/has": {
       "version": "1.0.4",
       "dev": true,
@@ -5610,6 +5529,7 @@
     },
     "node_modules/heapdump": {
       "version": "0.3.15",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "nan": "^2.13.2"
@@ -5721,14 +5641,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -5852,11 +5764,6 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -6989,16 +6896,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
@@ -7131,7 +7028,9 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7139,7 +7038,9 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -7383,24 +7284,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
@@ -7570,49 +7453,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/onnxruntime-common": {
-      "version": "1.19.2",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/onnxruntime-node": {
-      "version": "1.19.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "onnxruntime-common": "1.19.2",
-        "tar": "^7.0.1"
-      }
-    },
-    "node_modules/onnxruntime-web": {
-      "version": "1.21.0-dev.20241024-d9ca84ef96",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "flatbuffers": "^1.12.0",
-        "guid-typescript": "^1.0.9",
-        "long": "^5.2.3",
-        "onnxruntime-common": "1.20.0-dev.20241016-2b8fc5529b",
-        "platform": "^1.3.6",
-        "protobufjs": "^7.2.4"
-      }
-    },
-    "node_modules/onnxruntime-web/node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "optional": true
-    },
-    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.20.0-dev.20241016-2b8fc5529b",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/open": {
       "version": "10.2.0",
       "license": "MIT",
@@ -7628,38 +7468,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.29.2",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/optional-require": {
       "version": "1.1.10",
@@ -8357,11 +8165,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "license": "MIT",
@@ -9004,44 +8807,6 @@
       "version": "1.2.0",
       "license": "ISC"
     },
-    "node_modules/sharp": {
-      "version": "0.33.5",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "dev": true,
@@ -9178,19 +8943,6 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/sinon": {
       "version": "21.1.2",
@@ -9557,7 +9309,9 @@
     },
     "node_modules/tar": {
       "version": "7.5.20",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -9613,7 +9367,9 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
-      "devOptional": true,
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10096,14 +9852,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,6 @@
     "wtfnode": "0.10.1"
   },
   "optionalDependencies": {
-    "@lancedb/lancedb": "0.31.0"
+    "@lancedb/lancedb": "0.30.0"
   }
 }


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.22] revert lancdb to 0.30.0 to avoid an issue (21/07/2026)

(cherry picked from commit d5b5bbbe54f1f9acf512978f5befe46a5454c8b4)
