### PR TITLE
DEEP_ARCHIVE | GetObject implementation and tests + CopyObject tests

### DIFF
--- a/docs/design/DeepArchiveAPIsSupport.md
+++ b/docs/design/DeepArchiveAPIsSupport.md
@@ -1048,7 +1048,7 @@ aws s3api restore-object \
   --restore-request '{"Days":7}'
 ```
 
-**Expected:** `202 Accepted`. NooBaa sets `restore_status.ongoing = true` and calls `RestoreObject` on IBM Deep Archive. A background worker eventually polls the archive, writes a temporary copy to standard storage, records `restore_status.restored_obj_id`, and sets `restore_status.expiry_time`.
+**Expected:** `202 Accepted`. NooBaa sets `restore_status.ongoing = true` and calls `RestoreObject` on IBM Deep Archive. A background worker eventually polls the archive, writes a temporary copy to standard storage, and sets `restore_status.expiry_time`.
 
 **Extend expiry** (object already restored and within expiry):
 

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -6,6 +6,7 @@ const S3Error = require('../s3_errors').S3Error;
 const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
 const rdma_utils = require('../../../util/rdma_utils');
+const { throw_if_restore_incomplete } = require('../../../util/deep_archive_utils');
 
 /* eslint-disable max-statements */
 
@@ -50,13 +51,7 @@ async function get_object(req, res) {
 
     s3_utils.set_response_object_md(res, object_md);
     s3_utils.set_encryption_response_headers(req, res, object_md.encryption);
-    if (s3_utils.GLACIER_STORAGE_CLASSES.includes(object_md.storage_class)) {
-        if (object_md.restore_status?.ongoing || !object_md.restore_status?.expiry_time) {
-            // Don't try to read the object if it's not restored yet
-            dbg.warn('Object is not restored yet', req.path, object_md.restore_status);
-            throw new S3Error(S3Error.InvalidObjectState);
-        }
-    }
+    throw_if_restore_incomplete(req.params.bucket, object_md);
     http_utils.set_response_headers_from_request(req, res);
     if (!version_id) await http_utils.set_expiration_header(req, res, object_md); // setting expiration header for bucket lifecycle
     const obj_size = object_md.size;

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -4,7 +4,7 @@
 const _ = require('lodash');
 const dbg = require('../util/debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
-const { get_archive_key } = require('../util/deep_archive_utils');
+const { get_archive_key, throw_if_restore_incomplete } = require('../util/deep_archive_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { get_create_object_upload_params, get_complete_object_upload_params } = require('../util/object_utils');
 
@@ -50,7 +50,11 @@ class NamespaceMultiStorageClass {
     }
 
     /**
-     * Server-side copy across the router is disabled (same restriction as NamespaceMerge).
+     * Server-side copy is disabled (same restriction as NamespaceMerge).
+     * CopyObject is still covered via ObjectSDK's stream fallback: because this returns
+     * false, fix_copy_source_params reads the source object via read_object_stream and passes it as source_stream to 
+     * the target namespace's upload_object. The target namespace is resolved by storage_class
+     * {@link upload_object}. Archive sources that are not restored throw InvalidObjectState.
      * @param {nb.Namespace} other
      * @param {nb.ObjectInfo} other_md
      * @param {object} params
@@ -133,6 +137,7 @@ class NamespaceMultiStorageClass {
      * STANDARD (default) objects are read from the metadata namespace.
      * Non-default storage classes (e.g. DEEP_ARCHIVE / GLACIER) are not
      * readable until restored — throw InvalidObjectState.
+     * add res to the params when NamespaceFS becomes a supported deep-archive resource
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<import('stream').Readable>}
@@ -141,7 +146,10 @@ class NamespaceMultiStorageClass {
         const object_md = params.object_md || await this._metadata_ns.read_object_md(params, object_sdk);
         const storage_class = s3_utils.parse_storage_class(object_md.storage_class);
         if (storage_class !== this.default_storage_class) {
-            throw new S3Error(S3Error.InvalidObjectState);
+            if (!s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) {
+                throw new S3Error(S3Error.NotImplemented);
+            }
+            throw_if_restore_incomplete(params.bucket, object_md);
         }
         return this._metadata_ns.read_object_stream({ ...params, object_md }, object_sdk);
     }

--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1359,10 +1359,14 @@ function check_namespace_resource_deletion(ns) {
 }
 
 function get_associated_buckets_ns(ns) {
+    const ns_id = String(ns._id);
     const associated_buckets = _.filter(ns.system.buckets_by_name, bucket => {
-        if (!bucket.namespace) return;
-        return (_.find(bucket.namespace.read_resources, read_resource => String(ns._id) === String(read_resource.resource._id)) ||
-            (String(ns._id) === String(bucket.namespace.write_resource.resource._id)));
+        if (bucket.namespace) {
+            return (_.find(bucket.namespace.read_resources, read_resource => ns_id === String(read_resource.resource._id)) ||
+            (ns_id === String(bucket.namespace.write_resource.resource._id)));
+        }
+        const archive_res = bucket.archive_policy?.deep_archive_resource?.resource;
+        return Boolean(archive_res && ns_id === String(archive_res._id));
     });
 
     return _.map(associated_buckets, 'name');

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -1,0 +1,329 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const coretest = require('../../../utils/coretest/coretest');
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
+
+const mocha = require('mocha');
+const assert = require('assert');
+const crypto = require('crypto');
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
+
+const config = require('../../../../../config');
+const http_utils = require('../../../../util/http_utils');
+const s3_utils = require('../../../../endpoint/s3/s3_utils');
+const { get_archive_key } = require('../../../../util/deep_archive_utils');
+const test_utils = require('../../../system_tests/test_utils');
+
+const { rpc_client, EMAIL } = coretest;
+
+const BUCKET = 'test-msc-s3-copy';
+const ARCHIVE_TARGET_BUCKET = 'test-msc-s3-copy-archive-target';
+const ARCHIVE_CONNECTION = 'msc_s3_copy_archive_connection';
+const ARCHIVE_NSR = 'msc_s3_copy_archive_nsr';
+
+/** @type {S3} */
+let s3;
+let bucket_id;
+
+/**
+ * @param {Error & { Code?: string, code?: string, name?: string }} err
+ * @returns {string}
+ */
+function err_code(err) {
+    return err.Code || err.code || err.name;
+}
+
+/**
+ * Asserts archived object MD and that payload lives under get_archive_key on the archive target.
+ * @param {{ key: string, buf: Buffer, storage_class: string }} args
+ * @returns {Promise<void>}
+ */
+async function assert_archived_via_s3({ key, buf, storage_class }) {
+    const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+    assert.strictEqual(md.storage_class, storage_class);
+    assert.strictEqual(md.size, buf.length);
+
+    const archive_key = get_archive_key(bucket_id, md.obj_id);
+    const archived = await s3.getObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: archive_key });
+    const archived_body = Buffer.from(await archived.Body.transformToByteArray());
+    assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+
+    await assert.rejects(
+        s3.headObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: key }),
+        err => err_code(err) === 'NotFound' || err_code(err) === 'NoSuchKey'
+    );
+
+    await assert.rejects(
+        s3.getObject({ Bucket: BUCKET, Key: key }),
+        err => err_code(err) === 'InvalidObjectState'
+    );
+}
+
+mocha.describe('deep_archive_via_s3', function() {
+    mocha.before(async function() {
+        const account_info = await rpc_client.account.read_account({ email: EMAIL });
+        const credentials = {
+            accessKeyId: account_info.access_keys[0].access_key.unwrap(),
+            secretAccessKey: account_info.access_keys[0].secret_key.unwrap(),
+        };
+        s3 = new S3({
+            endpoint: coretest.get_http_address(),
+            credentials,
+            forcePathStyle: true,
+            region: config.DEFAULT_REGION,
+            requestHandler: new NodeHttpHandler({
+                httpAgent: http_utils.get_unsecured_agent(coretest.get_http_address()),
+            }),
+        });
+
+        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        await s3.createBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
+        await rpc_client.account.add_external_connection({
+            name: ARCHIVE_CONNECTION,
+            endpoint: coretest.get_http_address(),
+            endpoint_type: 'S3_COMPATIBLE',
+            auth_method: 'AWS_V4',
+            identity: credentials.accessKeyId,
+            secret: credentials.secretAccessKey,
+        });
+        await rpc_client.pool.create_namespace_resource({
+            name: ARCHIVE_NSR,
+            connection: ARCHIVE_CONNECTION,
+            target_bucket: ARCHIVE_TARGET_BUCKET,
+            archive: true,
+        });
+        await rpc_client.bucket.create_bucket({
+            name: BUCKET,
+            archive_policy: {
+                deep_archive_resource: { resource: ARCHIVE_NSR },
+            },
+        });
+        const bucket_info = await rpc_client.bucket.read_bucket_sdk_info({ name: BUCKET });
+        bucket_id = String(bucket_info._id);
+    });
+
+    mocha.after(async function() {
+        try {
+            await test_utils.empty_and_delete_buckets(rpc_client, [BUCKET]);
+            await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+            await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+            await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET_BUCKET]);
+        } finally {
+            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+        }
+    });
+
+    mocha.describe('PutObject', function() {
+
+    mocha.it('puts STANDARD objects and allows reading via getObject', async function() {
+        const key = 's3-put/standard';
+        const buf = crypto.randomBytes(64);
+
+        const put_res = await s3.putObject({
+            Bucket: BUCKET,
+            Key: key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+            StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+        });
+        assert.ok(put_res.ETag);
+
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        assert.strictEqual(md.size, buf.length);
+        assert.ok(!md.storage_class || md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+
+        const get_res = await s3.getObject({ Bucket: BUCKET, Key: key });
+        const body = Buffer.from(await get_res.Body.transformToByteArray());
+        assert.strictEqual(Buffer.compare(body, buf), 0);
+    });
+
+    mocha.it('defaults to STANDARD when StorageClass is unset', async function() {
+        const key = 's3-put/default-sc';
+        const buf = crypto.randomBytes(32);
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+        });
+
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        assert.strictEqual(md.size, buf.length);
+        assert.ok(!md.storage_class || md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+
+        const get_res = await s3.getObject({ Bucket: BUCKET, Key: key });
+        const body = Buffer.from(await get_res.Body.transformToByteArray());
+        assert.strictEqual(Buffer.compare(body, buf), 0);
+    });
+
+    mocha.it('puts object with StorageClass=DEEP_ARCHIVE', async function() {
+        const key = 's3-put/deep-archive';
+        const buf = Buffer.from('deep-archive-payload');
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+            StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+
+        await assert_archived_via_s3({
+            key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+    });
+
+    mocha.it('puts object with StorageClass=GLACIER', async function() {
+        const key = 's3-put/glacier';
+        const buf = Buffer.from('glacier-payload');
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+            StorageClass: s3_utils.STORAGE_CLASS_GLACIER,
+        });
+
+        await assert_archived_via_s3({
+            key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+        });
+    });
+
+    mocha.it('rejects StorageClass=GLACIER_IR with NotImplemented', async function() {
+        await assert.rejects(
+            s3.putObject({
+                Bucket: BUCKET,
+                Key: 's3-put/glacier-ir',
+                Body: Buffer.from('x'),
+                ContentType: 'application/octet-stream',
+                StorageClass: s3_utils.STORAGE_CLASS_GLACIER_IR,
+            }),
+            err => err_code(err) === 'NotImplemented'
+        );
+    });
+
+    }); // PutObject
+
+    mocha.describe('CopyObject', function() {
+
+    mocha.it('copies STANDARD → STANDARD via s3.copyObject', async function() {
+        const source_key = 's3-copy/std-to-std-src';
+        const dest_key = 's3-copy/std-to-std-dst';
+        const body = 's3-copy-std-payload';
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: source_key,
+            Body: body,
+            ContentType: 'application/octet-stream',
+        });
+
+        const copy_res = await s3.copyObject({
+            Bucket: BUCKET,
+            Key: dest_key,
+            CopySource: `/${BUCKET}/${source_key}`,
+            StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+        });
+        assert.ok(copy_res.CopyObjectResult?.ETag || copy_res.$metadata.httpStatusCode === 200);
+
+        const get_res = await s3.getObject({ Bucket: BUCKET, Key: dest_key });
+        const copied_body = await get_res.Body.transformToString();
+        assert.strictEqual(copied_body, body);
+        assert.ok(!get_res.StorageClass || get_res.StorageClass === s3_utils.STORAGE_CLASS_STANDARD);
+    });
+
+    mocha.it('copies STANDARD → DEEP_ARCHIVE via s3.copyObject', async function() {
+        const source_key = 's3-copy/std-to-archive-src';
+        const dest_key = 's3-copy/std-to-archive-dst';
+        const buf = Buffer.from('s3-copy-to-deep-archive');
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: source_key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+        });
+
+        await s3.copyObject({
+            Bucket: BUCKET,
+            Key: dest_key,
+            CopySource: `/${BUCKET}/${source_key}`,
+            StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+
+        await assert_archived_via_s3({
+            key: dest_key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+    });
+
+    mocha.it('copies STANDARD → GLACIER via s3.copyObject', async function() {
+        const source_key = 's3-copy/std-to-glacier-src';
+        const dest_key = 's3-copy/std-to-glacier-dst';
+        const buf = Buffer.from('s3-copy-to-glacier');
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: source_key,
+            Body: buf,
+            ContentType: 'application/octet-stream',
+        });
+
+        await s3.copyObject({
+            Bucket: BUCKET,
+            Key: dest_key,
+            CopySource: `/${BUCKET}/${source_key}`,
+            StorageClass: s3_utils.STORAGE_CLASS_GLACIER,
+        });
+
+        await assert_archived_via_s3({
+            key: dest_key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+        });
+    });
+
+    mocha.it('rejects s3.copyObject from an unrestored archive source with InvalidObjectState', async function() {
+        const source_key = 's3-copy/unrestored-src';
+        const dest_key = 's3-copy/unrestored-dst';
+        const body = 's3-unrestored';
+
+        await s3.putObject({
+            Bucket: BUCKET,
+            Key: source_key,
+            Body: body,
+            ContentType: 'application/octet-stream',
+            StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+
+        await assert.rejects(
+            s3.copyObject({
+                Bucket: BUCKET,
+                Key: dest_key,
+                CopySource: `/${BUCKET}/${source_key}`,
+                StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+            }),
+            err => err_code(err) === 'InvalidObjectState'
+        );
+
+        await assert.rejects(
+            s3.headObject({ Bucket: BUCKET, Key: dest_key }),
+            err => err_code(err) === 'NotFound' || err_code(err) === 'NoSuchKey'
+        );
+    });
+
+    }); // CopyObject
+
+    // TODO: add GetObject tests (STANDARD read, unrestored / ongoing / expired restore →
+    // InvalidObjectState, restored archive read) once RestoreObject is implemented.
+});

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -15,6 +15,7 @@ const mocha = require('mocha');
 const assert = require('assert');
 const P = require('../../../../util/promise');
 const azure_storage = require('@azure/storage-blob');
+const test_utils = require('../../../system_tests/test_utils');
 
 // If any of these variables are not defined,
 // use the noobaa endpoint to create buckets
@@ -1903,12 +1904,14 @@ mocha.describe('s3_ops', function() {
         });
 
         mocha.after(async function() {
-            await rpc_client.bucket.delete_bucket({ name: ARCHIVE_BUCKET });
-            await rpc_client.bucket.delete_bucket({ name: NO_ARCHIVE_BUCKET });
-            await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
-            await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
-            await s3.deleteBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
-            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+            try {
+                await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_BUCKET, NO_ARCHIVE_BUCKET]);
+                await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+                await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+                await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET_BUCKET]);
+            } finally {
+                config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+            }
         });
 
         mocha.it('should return supported storage classes header with GLACIER and DEEP_ARCHIVE for bucket with archive policy', async function() {

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
@@ -22,10 +22,11 @@ const http_utils = require('../../../util/http_utils');
 const { get_archive_key } = require('../../../util/deep_archive_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const S3Error = require('../../../endpoint/s3/s3_errors').S3Error;
+const test_utils = require('../../system_tests/test_utils');
 
 const { rpc_client, EMAIL } = coretest;
 
-const BUCKET = 'test-msc-upload-object';
+const BUCKET = 'test-msc';
 const ARCHIVE_TARGET_BUCKET = 'test-msc-archive-target';
 const ARCHIVE_CONNECTION = 'msc_archive_connection';
 const ARCHIVE_NSR = 'msc_archive_nsr';
@@ -116,6 +117,40 @@ async function upload_buf(msc, object_sdk, { key, buf, storage_class }) {
 }
 
 /**
+ * Simulates ObjectSDK CopyObject fallback when is_server_side_copy is false:
+ * read source stream, then upload with source_stream (copy_source cleared).
+ * @param {NamespaceMultiStorageClass} msc
+ * @param {object} object_sdk
+ * @param {{ source_key: string, source_md: object, dest_key: string, dest_storage_class?: string, buf: Buffer }} params
+ * @returns {Promise<object>}
+ */
+async function copy_via_stream_fallback(msc, object_sdk, {
+    source_key,
+    source_md,
+    dest_key,
+    dest_storage_class,
+    buf,
+}) {
+    const source_stream = await msc.read_object_stream({
+        bucket: BUCKET,
+        key: source_key,
+        object_md: source_md,
+    }, object_sdk);
+
+    return msc.upload_object({
+        bucket: BUCKET,
+        key: dest_key,
+        size: buf.length,
+        content_type: 'application/octet-stream',
+        md5_b64: crypto.createHash('md5').update(buf).digest('base64'),
+        storage_class: dest_storage_class,
+        source_stream,
+        // ObjectSDK clears copy_source before upload in the fallback path
+        copy_source: null,
+    }, object_sdk);
+}
+
+/**
  * Asserts object md (storage_class, size), that archive data is stored under get_archive_key
  * (via the archive namespace), not the user key, and that MSC read_object_stream rejects
  * with InvalidObjectState.
@@ -160,8 +195,9 @@ async function assert_archived_payload({ msc, arch_ns, object_sdk, key, buf, sto
     );
 }
 
-mocha.describe('NamespaceMultiStorageClass.upload_object', function() {
+mocha.describe('NamespaceMultiStorageClass', function() {
     const object_sdk = make_object_sdk();
+
     mocha.before(async function() {
         const account_info = await rpc_client.account.read_account({ email: EMAIL });
         s3_creds = {
@@ -194,32 +230,28 @@ mocha.describe('NamespaceMultiStorageClass.upload_object', function() {
             target_bucket: ARCHIVE_TARGET_BUCKET,
             archive: true,
         });
-        await rpc_client.bucket.create_bucket({ name: BUCKET });
+        await rpc_client.bucket.create_bucket({
+            name: BUCKET,
+            archive_policy: {
+                deep_archive_resource: { resource: ARCHIVE_NSR },
+            },
+        });
         const bucket_info = await rpc_client.bucket.read_bucket_sdk_info({ name: BUCKET });
         bucket_id = String(bucket_info._id);
     });
 
     mocha.after(async function() {
         try {
-            await rpc_client.bucket.delete_bucket({ name: BUCKET });
-        } catch (err) { /* ignore */ }
-        try {
+            await test_utils.empty_and_delete_buckets(rpc_client, [BUCKET]);
             await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
-        } catch (err) { /* ignore */ }
-        try {
             await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
-        } catch (err) { /* ignore */ }
-        try {
-            // Empty archive target via namespace, then delete the bucket via S3
-            const arch_ns = make_archive_namespace_s3();
-            const listed = await arch_ns.list_objects({ bucket: ARCHIVE_TARGET_BUCKET }, object_sdk);
-            for (const obj of listed.objects || []) {
-                await arch_ns.delete_object({ bucket: ARCHIVE_TARGET_BUCKET, key: obj.key }, object_sdk);
-            }
-            await s3.deleteBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
-        } catch (err) { /* ignore */ }
-        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+            await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET_BUCKET]);
+        } finally {
+            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+        }
     });
+
+    mocha.describe('upload_object', function() {
 
     mocha.it('uploads STANDARD objects via the metadata namespace and allows reading', async function() {
         const { msc } = get_new_multi_storage_class_namespace();
@@ -318,4 +350,237 @@ mocha.describe('NamespaceMultiStorageClass.upload_object', function() {
             err => err.rpc_code === 'NO_SUCH_OBJECT' || err.rpc_code === 'NO_SUCH_UPLOAD'
         );
     });
-});
+
+    }); // upload_object
+
+    mocha.describe('CopyObject (stream fallback)', function() {
+
+    mocha.it('disables server-side copy so ObjectSDK uses the stream fallback', function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        assert.strictEqual(msc.is_server_side_copy({}, {}, {}), false);
+    });
+
+    mocha.it('copies STANDARD → STANDARD via metadata namespace', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const source_key = 'copy/std-to-std-src';
+        const dest_key = 'copy/std-to-std-dst';
+        const buf = crypto.randomBytes(48);
+
+        await upload_buf(msc, object_sdk, { key: source_key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const source_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: source_key });
+
+        const reply = await copy_via_stream_fallback(msc, object_sdk, {
+            source_key,
+            source_md,
+            dest_key,
+            dest_storage_class: s3_utils.STORAGE_CLASS_STANDARD,
+            buf,
+        });
+        assert.ok(reply.etag);
+
+        const dest_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: dest_key });
+        assert.strictEqual(dest_md.size, buf.length);
+        assert.ok(!dest_md.storage_class || dest_md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key: dest_key, object_md: dest_md }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    mocha.it('copies STANDARD → DEEP_ARCHIVE (MD in NB, data under archive_key)', async function() {
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const source_key = 'copy/std-to-archive-src';
+        const dest_key = 'copy/std-to-archive-dst';
+        const buf = Buffer.from('copy-to-deep-archive');
+
+        await upload_buf(msc, object_sdk, { key: source_key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const source_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: source_key });
+
+        const reply = await copy_via_stream_fallback(msc, object_sdk, {
+            source_key,
+            source_md,
+            dest_key,
+            dest_storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            buf,
+        });
+
+        await assert_archived_payload({
+            msc, arch_ns, object_sdk,
+            key: dest_key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            etag: reply.etag,
+        });
+    });
+
+    mocha.it('copies restored archive → STANDARD via metadata namespace', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const source_key = 'copy/restored-to-std-src';
+        const dest_key = 'copy/restored-to-std-dst';
+        const buf = Buffer.from('restored-copy-src');
+
+        // Data lives in NB (STANDARD upload); md is marked as restored archive for the read gate.
+        await upload_buf(msc, object_sdk, { key: source_key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const source_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: source_key });
+        source_md.storage_class = s3_utils.STORAGE_CLASS_DEEP_ARCHIVE;
+        source_md.restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z'),
+        };
+
+        const reply = await copy_via_stream_fallback(msc, object_sdk, {
+            source_key,
+            source_md,
+            dest_key,
+            dest_storage_class: s3_utils.STORAGE_CLASS_STANDARD,
+            buf,
+        });
+        assert.ok(reply.etag);
+
+        const dest_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: dest_key });
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key: dest_key, object_md: dest_md }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    mocha.it('copies restored archive → DEEP_ARCHIVE', async function() {
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const source_key = 'copy/restored-to-archive-src';
+        const dest_key = 'copy/restored-to-archive-dst';
+        const buf = Buffer.from('restored-rearchive');
+
+        await upload_buf(msc, object_sdk, { key: source_key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const source_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: source_key });
+        source_md.storage_class = s3_utils.STORAGE_CLASS_GLACIER;
+        source_md.restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-06-01T00:00:00Z'),
+        };
+
+        const reply = await copy_via_stream_fallback(msc, object_sdk, {
+            source_key,
+            source_md,
+            dest_key,
+            dest_storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            buf,
+        });
+
+        await assert_archived_payload({
+            msc, arch_ns, object_sdk,
+            key: dest_key,
+            buf,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            etag: reply.etag,
+        });
+    });
+
+    mocha.it('rejects copy from an unrestored archive source with InvalidObjectState', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const source_key = 'copy/unrestored-src';
+        const dest_key = 'copy/unrestored-dst';
+        const buf = Buffer.from('unrestored');
+
+        await upload_buf(msc, object_sdk, { key: source_key, buf, storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE });
+        const source_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key: source_key });
+
+        await assert.rejects(
+            copy_via_stream_fallback(msc, object_sdk, {
+                source_key,
+                source_md,
+                dest_key,
+                dest_storage_class: s3_utils.STORAGE_CLASS_STANDARD,
+                buf,
+            }),
+            err => err instanceof S3Error && err.code === 'InvalidObjectState'
+        );
+
+        await assert.rejects(
+            rpc_client.object.read_object_md({ bucket: BUCKET, key: dest_key }),
+            err => err.rpc_code === 'NO_SUCH_OBJECT'
+        );
+    });
+
+    }); // CopyObject (stream fallback)
+
+    mocha.describe('read_object_stream', function() {
+
+    mocha.it('reads STANDARD objects from the metadata namespace', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'read/standard';
+        const buf = crypto.randomBytes(40);
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const object_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key, object_md }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    mocha.it('throws InvalidObjectState when archive object is not restored', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'read/archive-ongoing';
+        const buf = Buffer.from('ongoing-restore');
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE });
+        const object_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        object_md.restore_status = { ongoing: true };
+
+        await assert.rejects(
+            msc.read_object_stream({ bucket: BUCKET, key, object_md }, object_sdk),
+            err => err instanceof S3Error && err.code === 'InvalidObjectState'
+        );
+    });
+
+    mocha.it('throws InvalidObjectState when archive object has no restore expired', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'read/archive-expired-restore';
+        const buf = Buffer.from('expired-restore');
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_GLACIER });
+        const object_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        object_md.restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2000-01-01T00:00:00Z'),
+        };
+
+        await assert.rejects(
+            msc.read_object_stream({ bucket: BUCKET, key, object_md }, object_sdk),
+            err => err instanceof S3Error && err.code === 'InvalidObjectState'
+        );
+    });
+
+    mocha.it('reads restored archive objects from the metadata namespace', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'read/restored-archive';
+        const buf = Buffer.from('restored-payload');
+
+        // Data in NB; md marked as restored archive for the read gate.
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+        const object_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        object_md.storage_class = s3_utils.STORAGE_CLASS_DEEP_ARCHIVE;
+        object_md.restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z'),
+        };
+
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key, object_md }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    mocha.it('loads object_md when not provided', async function() {
+        const { msc } = get_new_multi_storage_class_namespace();
+        const key = 'read/load-md';
+        const buf = crypto.randomBytes(24);
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_STANDARD });
+
+        const read_stream = await msc.read_object_stream({ bucket: BUCKET, key }, object_sdk);
+        const read_buf = await buffer_utils.read_stream_join(read_stream);
+        assert.strictEqual(Buffer.compare(read_buf, buf), 0);
+    });
+
+    }); // read_object_stream
+
+}); // NamespaceMultiStorageClass

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -88,11 +88,12 @@ require('../../integration_tests/internal/test_map_reader'); /////////////
 require('../../integration_tests/internal/test_object_io');
 require('../../integration_tests/internal/test_agent_blocks_reclaimer');
 require('../../integration_tests/api/s3/test_s3_ops');
+require('../../integration_tests/api/s3/test_deep_archive_via_s3');
 require('../../integration_tests/api/s3/test_s3_encryption');
 require('../../integration_tests/api/s3/test_s3_bucket_policy');
 // require('./test_node_allocator');
 require('../../unit_tests/internal/test_namespace_cache');
-require('../../unit_tests/internal/test_namespace_multi_storage_class_upload_object');
+require('../../unit_tests/internal/test_namespace_multi_storage_class');
 require('../../integration_tests/api/s3/test_namespace_auth');
 require('../../integration_tests/internal/test_encryption');
 require('../../integration_tests/api/s3/test_bucket_replication');

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -2,6 +2,12 @@
 'use strict';
 
 const NB_INTERNAL_STORAGE_DIR = 'noobaa_storage/';
+const dbg = require('../util/debug_module')(__filename);
+const S3Error = require('../endpoint/s3/s3_errors').S3Error;
+const { GLACIER_STORAGE_CLASSES } = require('../endpoint/s3/s3_utils');
+
+
+
 /**
  * Returns the key used to store object data in the deep-archive backend.
  * Format: `{bucket_id}/{obj_md_id}`
@@ -14,4 +20,23 @@ function get_archive_key(bucket_id, obj_md_id) {
     return `${NB_INTERNAL_STORAGE_DIR}${String(bucket_id)}/${String(obj_md_id)}`;
 }
 
+/**
+ * For glacier/archive storage classes, throws InvalidObjectState when the object
+ * is not restored yet (restore ongoing, missing expiry_time, or expiry in the past).
+ * No-op otherwise.
+ * @param {string} bucket_name
+ * @param {nb.ObjectInfo} object_md
+ */
+function throw_if_restore_incomplete(bucket_name, object_md) {
+    if (!GLACIER_STORAGE_CLASSES.includes(object_md?.storage_class)) return;
+    const restore = object_md.restore_status;
+    const expiry_time = restore?.expiry_time && new Date(restore.expiry_time);
+    const is_restored = Boolean(expiry_time) && !restore.ongoing && expiry_time > new Date();
+    if (is_restored) return;
+    // Don't try to read the object if it's not restored yet
+    dbg.warn('Object is not restored yet', bucket_name, object_md.key, object_md.storage_class, restore);
+    throw new S3Error(S3Error.InvalidObjectState);
+}
+
 exports.get_archive_key = get_archive_key;
+exports.throw_if_restore_incomplete = throw_if_restore_incomplete;


### PR DESCRIPTION
### Describe the Problem

### Explain the Changes
1. NamespaceMultiStorageClass - Implemented read_object_stream().
2. s3_get_object.js  - refactored inline check for restore status and moved it to a function called throw_if_restore_incomplete() so it can be called from NamespaceMultiStorageClass.
3. Added tests for GetObject and for PutObject with copySource.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `node node_modules/mocha/bin/mocha.js src/test/integration_tests/api/s3/test_deep_archive_via_s3.js`
2. `node node_modules/mocha/bin/mocha.js -src/test/unit_tests/internal/test_namespace_multi_storage_class_upload_object.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added restore-aware handling for S3 reads and copy flows for Glacier/Deep Archive objects.
  * Enhanced stream-fallback behavior when server-side copy isn’t available.

* **Bug Fixes**
  * Unified restore completeness validation to reliably block reads/copies when restoration is ongoing or expired.
  * Tightened streaming support rules for non-restored deep-archive sources.

* **Documentation**
  * Updated the Deep Archive “Happy Path Guide” expected restore initiation text.

* **Tests**
  * Added end-to-end integration tests for deep-archive via S3.
  * Expanded unit/integration coverage for restore-state, streaming fallback, and copy scenarios.

* **Chores**
  * Improved archive-policy bucket cleanup in S3 test teardown.
  * Broadened namespace resource association detection for deep-archive policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->