### PR TITLE
Test coverage for IAM Roles

### DIFF
--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -27,7 +27,10 @@ const { ListUsersCommand, CreateUserCommand, GetUserCommand, UpdateUserCommand, 
     ListRoleTagsCommand, ListSAMLProvidersCommand, ListServerCertificatesCommand,
     ListServerCertificateTagsCommand, ListServiceSpecificCredentialsCommand,
     ListSigningCertificatesCommand, ListSSHPublicKeysCommand,
-    ListVirtualMFADevicesCommand } = require('@aws-sdk/client-iam');
+    ListVirtualMFADevicesCommand,
+    CreateRoleCommand, GetRoleCommand, UpdateRoleCommand, DeleteRoleCommand,
+    PutRolePolicyCommand, GetRolePolicyCommand, DeleteRolePolicyCommand, ListRolePoliciesCommand,
+    UpdateAssumeRolePolicyCommand } = require('@aws-sdk/client-iam');
 const { ACCESS_KEY_STATUS_ENUM } = require('../../../../endpoint/iam/iam_constants');
 const IamError = require('../../../../endpoint/iam/iam_errors').IamError;
 
@@ -369,6 +372,149 @@ mocha.describe('IAM integration tests', async function() {
                 };
                 const command = new DeleteUserPolicyCommand(input);
                 const response = await iam_account.send(command);
+                _check_status_code_ok(response);
+            });
+        });
+
+        mocha.describe('IAM Role API', async function() {
+            // containerized-only (NotImplemented on NC)
+            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+            const role_name = 'TestRole';
+            const updated_role_description = 'updated-role-description';
+            const assume_role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}';
+            const assume_role_with_web_identity_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRoleWithWebIdentity"}]}';
+
+            mocha.it('list roles - should be empty', async function() {
+                const response = await iam_account.send(new ListRolesCommand({}));
+                _check_status_code_ok(response);
+                assert.equal(response.Roles.length, 0);
+            });
+
+            mocha.it('create a role', async function() {
+                const response = await iam_account.send(new CreateRoleCommand({
+                    RoleName: role_name,
+                    AssumeRolePolicyDocument: assume_role_policy,
+                    Description: 'integration-test-role',
+                    MaxSessionDuration: 7200,
+                }));
+                _check_status_code_ok(response);
+                assert.equal(response.Role.RoleName, role_name);
+                assert.equal(response.Role.MaxSessionDuration, 7200);
+
+                const list_response = await iam_account.send(new ListRolesCommand({}));
+                _check_status_code_ok(list_response);
+                assert.equal(list_response.Roles.length, 1);
+                assert.equal(list_response.Roles[0].RoleName, role_name);
+            });
+
+            mocha.it('get a role', async function() {
+                const response = await iam_account.send(new GetRoleCommand({ RoleName: role_name }));
+                _check_status_code_ok(response);
+                assert.equal(response.Role.RoleName, role_name);
+                assert(response.Role.AssumeRolePolicyDocument !== undefined);
+            });
+
+            mocha.it('update a role', async function() {
+                const response = await iam_account.send(new UpdateRoleCommand({
+                    RoleName: role_name,
+                    Description: updated_role_description,
+                    MaxSessionDuration: 3600,
+                }));
+                _check_status_code_ok(response);
+
+                const get_response = await iam_account.send(new GetRoleCommand({ RoleName: role_name }));
+                _check_status_code_ok(get_response);
+                assert.equal(get_response.Role.Description, updated_role_description);
+                assert.equal(get_response.Role.MaxSessionDuration, 3600);
+            });
+
+            mocha.it('update assume role policy', async function() {
+                const response = await iam_account.send(new UpdateAssumeRolePolicyCommand({
+                    RoleName: role_name,
+                    PolicyDocument: assume_role_with_web_identity_policy,
+                }));
+                _check_status_code_ok(response);
+
+                const get_response = await iam_account.send(new GetRoleCommand({ RoleName: role_name }));
+                _check_status_code_ok(get_response);
+                const assume_role_policy_document = JSON.parse(get_response.Role.AssumeRolePolicyDocument);
+                assert.equal(assume_role_policy_document.Statement[0].Action, 'sts:AssumeRoleWithWebIdentity');
+            });
+
+            mocha.it('delete a role', async function() {
+                const response = await iam_account.send(new DeleteRoleCommand({ RoleName: role_name }));
+                _check_status_code_ok(response);
+
+                const list_response = await iam_account.send(new ListRolesCommand({}));
+                _check_status_code_ok(list_response);
+                assert.equal(list_response.Roles.length, 0);
+            });
+        });
+
+        mocha.describe('IAM Role Policy API', async function() {
+            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+            const role_name = 'PolicyTestRole';
+            const policy_name = 'RoleS3Access';
+            const assume_role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}';
+            const role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}';
+
+            mocha.before(async function() {
+                const response = await iam_account.send(new CreateRoleCommand({
+                    RoleName: role_name,
+                    AssumeRolePolicyDocument: assume_role_policy,
+                }));
+                _check_status_code_ok(response);
+            });
+
+            mocha.after(async function() {
+                const list_response = await iam_account.send(new ListRolePoliciesCommand({ RoleName: role_name }));
+                for (const name of list_response.PolicyNames) {
+                    await iam_account.send(new DeleteRolePolicyCommand({
+                        RoleName: role_name,
+                        PolicyName: name,
+                    }));
+                }
+                const response = await iam_account.send(new DeleteRoleCommand({ RoleName: role_name }));
+                _check_status_code_ok(response);
+            });
+
+            mocha.it('list role policies - should be empty', async function() {
+                const response = await iam_account.send(new ListRolePoliciesCommand({ RoleName: role_name }));
+                _check_status_code_ok(response);
+                assert.equal(response.PolicyNames.length, 0);
+            });
+
+            mocha.it('put role policy', async function() {
+                const response = await iam_account.send(new PutRolePolicyCommand({
+                    RoleName: role_name,
+                    PolicyName: policy_name,
+                    PolicyDocument: role_policy,
+                }));
+                _check_status_code_ok(response);
+
+                const list_response = await iam_account.send(new ListRolePoliciesCommand({ RoleName: role_name }));
+                _check_status_code_ok(list_response);
+                assert.equal(list_response.PolicyNames.length, 1);
+                assert.equal(list_response.PolicyNames[0], policy_name);
+            });
+
+            mocha.it('get role policy', async function() {
+                const response = await iam_account.send(new GetRolePolicyCommand({
+                    RoleName: role_name,
+                    PolicyName: policy_name,
+                }));
+                _check_status_code_ok(response);
+                assert.equal(response.RoleName, role_name);
+                assert.equal(response.PolicyName, policy_name);
+                const policy_document = JSON.parse(response.PolicyDocument);
+                assert.deepEqual(policy_document.Statement[0], { Effect: 'Allow', Action: 's3:*', Resource: '*' });
+            });
+
+            mocha.it('delete role policy', async function() {
+                const response = await iam_account.send(new DeleteRolePolicyCommand({
+                    RoleName: role_name,
+                    PolicyName: policy_name,
+                }));
                 _check_status_code_ok(response);
             });
         });
@@ -2129,6 +2275,435 @@ mocha.describe('IAM integration tests', async function() {
                 });
             });
         });
+
+        mocha.describe('IAM Role API', async function() {
+            // containerized-only (NotImplemented on NC)
+            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+
+            const role_name = 'AdvRole';
+            const role_path = '/div_a/sub_div_b/';
+            const assume_role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}';
+            const role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}';
+            const policy_name = 'AdvRolePolicy';
+            const iam_username = 'RoleTestUser';
+            let access_key_id;
+            let iam_user_client;
+
+            mocha.before(async function() {
+                await create_iam_role(iam_account, role_name, assume_role_policy);
+                await create_iam_user(iam_account, iam_username);
+                const res = await create_access_key_iam_user(iam_account, iam_username);
+                access_key_id = res.access_key_id;
+                iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
+            });
+
+            mocha.after(async function() {
+                await delete_all_inline_role_policies(iam_account, role_name);
+                await delete_iam_role(iam_account, role_name);
+                if (access_key_id) await delete_access_key_iam_user(iam_account, access_key_id, iam_username);
+                await delete_iam_user(iam_account, iam_username);
+            });
+
+            mocha.describe('IAM CreateRole API', async function() {
+                mocha.it('create a role with role name that already exists should fail', async function() {
+                    try {
+                        await iam_account.send(new CreateRoleCommand({
+                            RoleName: role_name, AssumeRolePolicyDocument: assume_role_policy,
+                        }));
+                        assert.fail('create role with existing role name - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.EntityAlreadyExists.code);
+                        assert.strictEqual(err_message, `Role with name ${role_name} already exists.`);
+                    }
+                });
+
+                mocha.it('create a role - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new CreateRoleCommand({
+                            RoleName: 'RoleByIamUser', AssumeRolePolicyDocument: assume_role_policy,
+                        }));
+                        assert.fail('create role - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:CreateRole'));
+                    }
+                });
+            });
+
+            mocha.describe('IAM GetRole API', async function() {
+                mocha.it('get a role - non-existing role - should fail', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new GetRoleCommand({ RoleName: role_name_non_existing }));
+                        assert.fail('get role - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('get a role - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new GetRoleCommand({ RoleName: role_name }));
+                        assert.fail('get role - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:GetRole'));
+                    }
+                });
+            });
+
+            mocha.describe('IAM UpdateRole API', async function() {
+                mocha.it('update a role - non-existing role - should fail', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new UpdateRoleCommand({
+                            RoleName: role_name_non_existing, Description: 'updated description',
+                        }));
+                        assert.fail('update role - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('update a role - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new UpdateRoleCommand({
+                            RoleName: role_name, Description: 'updated by iam user',
+                        }));
+                        assert.fail('update role - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:UpdateRole'));
+                    }
+                });
+            });
+
+            mocha.describe('IAM UpdateAssumeRolePolicy API', async function() {
+                mocha.it('update assume role policy - non-existing role - should fail', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new UpdateAssumeRolePolicyCommand({
+                            RoleName: role_name_non_existing, PolicyDocument: assume_role_policy,
+                        }));
+                        assert.fail('update assume role policy - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('update assume role policy - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new UpdateAssumeRolePolicyCommand({
+                            RoleName: role_name, PolicyDocument: assume_role_policy,
+                        }));
+                        assert.fail('update assume role policy - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:UpdateAssumeRolePolicy'));
+                    }
+                });
+            });
+
+            mocha.describe('IAM DeleteRole API', async function() {
+                mocha.it('delete a role - non-existing role - should fail', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new DeleteRoleCommand({ RoleName: role_name_non_existing }));
+                        assert.fail('delete role - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('delete a role - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new DeleteRoleCommand({ RoleName: role_name }));
+                        assert.fail('delete role - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:DeleteRole'));
+                    }
+                });
+
+                mocha.it('delete a role - role has inline IAM policy - should fail', async function() {
+                    await iam_account.send(new PutRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name, PolicyDocument: role_policy,
+                    }));
+                    try {
+                        await iam_account.send(new DeleteRoleCommand({ RoleName: role_name }));
+                        assert.fail('delete role - role has inline IAM policy - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.DeleteConflict.code);
+                        assert.strictEqual(err_message, 'Cannot delete entity, must delete policies first.');
+                    }
+                    await iam_account.send(new DeleteRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name,
+                    }));
+                });
+            });
+
+            mocha.describe('IAM ListRoles API', async function() {
+                mocha.it('list roles - requester is IAM user - should fail', async function() {
+                    try {
+                        await iam_user_client.send(new ListRolesCommand({}));
+                        assert.fail('list roles - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:ListRoles'));
+                    }
+                });
+
+                mocha.it('list roles - by path prefix', async function() {
+                    const role_under_path = 'test-role-1';
+                    await create_iam_role(iam_account, role_under_path, assume_role_policy, role_path);
+                    const response = await iam_account.send(new ListRolesCommand({ PathPrefix: role_path }));
+                    _check_status_code_ok(response);
+                    assert.equal(response.Roles.length, 1);
+                    assert.equal(response.Roles[0].RoleName, role_under_path);
+                    assert.equal(response.Roles[0].Path, role_path);
+                    await delete_iam_role(iam_account, role_under_path);
+                });
+            });
+        });
+
+        mocha.describe('IAM Role Policy API', async function() {
+            // containerized-only (NotImplemented on NC)
+            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+
+            const role_name = 'AdvPolicyRole';
+            const assume_role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"sts:AssumeRole"}]}';
+            const iam_username = 'RolePolicyTestUser';
+            const policy_name = 'AllAccessPolicy';
+            const role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}';
+            const policy_name_to_replace = 'my_policy';
+            const role_policy_replaced = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:CreateBucket","Resource":"*"}]}';
+            const policy_name_multiple_statements = 'MultipleStatementsPolicy';
+            const role_policy_multiple_statements = '{"Version":"2012-10-17","Statement":[{"Sid":"id1","Effect":"Allow","Action":"s3:GetBucketLocation","Resource":"*"},{"Sid":"id2","Effect":"Allow","Action":"s3:CreateBucket","Resource":"*"},{"Sid":"","Effect":"Allow","Action":"s3:HeadBucket","Resource":"*"}]}';
+            let access_key_id;
+            let iam_user_client;
+
+            mocha.before(async function() {
+                await create_iam_role(iam_account, role_name, assume_role_policy);
+                await create_iam_user(iam_account, iam_username);
+                const res = await create_access_key_iam_user(iam_account, iam_username);
+                access_key_id = res.access_key_id;
+                iam_user_client = generate_iam_client(res.access_key_id, res.secret_access_key, coretest_endpoint_iam);
+            });
+
+            mocha.after(async function() {
+                await delete_all_inline_role_policies(iam_account, role_name);
+                await delete_iam_role(iam_account, role_name);
+                await delete_access_key_iam_user(iam_account, access_key_id, iam_username);
+                await delete_iam_user(iam_account, iam_username);
+            });
+
+            mocha.describe('IAM PutRolePolicy API', async function() {
+                mocha.it('put role policy - non-existing role - should throw an error', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new PutRolePolicyCommand({
+                            RoleName: role_name_non_existing, PolicyName: policy_name, PolicyDocument: role_policy,
+                        }));
+                        assert.fail('put role policy - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('put role policy - requester is IAM user - should throw an error', async function() {
+                    try {
+                        await iam_user_client.send(new PutRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name, PolicyDocument: role_policy,
+                        }));
+                        assert.fail('put role policy - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:PutRolePolicy'));
+                    }
+                });
+
+                mocha.it('put role policy - with large number of statements - should throw an error', async function() {
+                    const large_policy = JSON.stringify({
+                        Version: '2012-10-17',
+                        Statement: Array.from({ length: 50 }, () => ({ Effect: 'Allow', Action: '*', Resource: '*' })),
+                    });
+                    try {
+                        await iam_account.send(new PutRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name, PolicyDocument: large_policy,
+                        }));
+                        assert.fail('put role policy - with large number of statements - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.LimitExceeded.code);
+                        assert.strictEqual(err_message, `Maximum policy size of 2048 bytes exceeded for role ${role_name}`);
+                    }
+                });
+
+                mocha.it('put role policy with multiple statements', async function() {
+                    const response = await iam_account.send(new PutRolePolicyCommand({
+                        RoleName: role_name,
+                        PolicyName: policy_name_multiple_statements,
+                        PolicyDocument: role_policy_multiple_statements,
+                    }));
+                    _check_status_code_ok(response);
+                });
+
+                mocha.it('put role policy with the same policy name - should replace the policy', async function() {
+                    await iam_account.send(new PutRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name_to_replace, PolicyDocument: role_policy,
+                    }));
+                    await iam_account.send(new PutRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name_to_replace, PolicyDocument: role_policy_replaced,
+                    }));
+                    const response = await iam_account.send(new GetRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name_to_replace,
+                    }));
+                    _check_status_code_ok(response);
+                    assert.deepEqual(JSON.parse(response.PolicyDocument).Statement[0],
+                        { Effect: 'Allow', Action: 's3:CreateBucket', Resource: '*' });
+                });
+            });
+
+            mocha.describe('IAM GetRolePolicy API', async function() {
+                mocha.it('get role policy - non-existing role - should throw an error', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new GetRolePolicyCommand({
+                            RoleName: role_name_non_existing, PolicyName: policy_name,
+                        }));
+                        assert.fail('get role policy - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('get role policy - non-existing role policy - should throw an error', async function() {
+                    const policy_name_non_existing = 'non-existing-policy';
+                    try {
+                        await iam_account.send(new GetRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name_non_existing,
+                        }));
+                        assert.fail('get role policy - non-existing role policy - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role policy with name ${policy_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('get role policy - requester is IAM user - should throw an error', async function() {
+                    try {
+                        await iam_user_client.send(new GetRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name,
+                        }));
+                        assert.fail('get role policy - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:GetRolePolicy'));
+                    }
+                });
+
+                mocha.it('get role policy with multiple statements', async function() {
+                    const response = await iam_account.send(new GetRolePolicyCommand({
+                        RoleName: role_name, PolicyName: policy_name_multiple_statements,
+                    }));
+                    _check_status_code_ok(response);
+                    const statements = JSON.parse(response.PolicyDocument).Statement;
+                    assert.strictEqual(statements.length, 3);
+                    assert.deepStrictEqual(statements.map(s => s.Sid), ['id1', 'id2', '']);
+                });
+            });
+
+            mocha.describe('IAM DeleteRolePolicy API', async function() {
+                mocha.it('delete role policy - non-existing role - should throw an error', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new DeleteRolePolicyCommand({
+                            RoleName: role_name_non_existing, PolicyName: policy_name,
+                        }));
+                        assert.fail('delete role policy - non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('delete role policy - non-existing role policy - should throw an error', async function() {
+                    const policy_name_non_existing = 'non-existing-policy';
+                    try {
+                        await iam_account.send(new DeleteRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name_non_existing,
+                        }));
+                        assert.fail('delete role policy - non-existing role policy - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role policy with name ${policy_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('delete role policy - requester is IAM user - should throw an error', async function() {
+                    try {
+                        await iam_user_client.send(new DeleteRolePolicyCommand({
+                            RoleName: role_name, PolicyName: policy_name,
+                        }));
+                        assert.fail('delete role policy - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:DeleteRolePolicy'));
+                    }
+                });
+            });
+
+            mocha.describe('IAM ListRolePolicies API', async function() {
+                mocha.it('list role policies for non-existing role - should throw an error', async function() {
+                    const role_name_non_existing = 'non-existing-role';
+                    try {
+                        await iam_account.send(new ListRolePoliciesCommand({ RoleName: role_name_non_existing }));
+                        assert.fail('list role policies for non-existing role - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.NoSuchEntity.code);
+                        assert.strictEqual(err_message, `The role with name ${role_name_non_existing} cannot be found.`);
+                    }
+                });
+
+                mocha.it('list role policies - requester is IAM user - should throw an error', async function() {
+                    try {
+                        await iam_user_client.send(new ListRolePoliciesCommand({ RoleName: role_name }));
+                        assert.fail('list role policies - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes('not authorized to perform: iam:ListRolePolicies'));
+                    }
+                });
+            });
+        });
     });
 });
 
@@ -2255,4 +2830,44 @@ function _get_err_code_and_message(err) {
     const err_code = err.Error?.Code || err.Code;
     const err_message = err.Error?.Message || err.Message || err.message;
     return { err_code, err_message };
+}
+
+/**
+ * Create an IAM role with the given role name.
+ * Use this function for before/after hooks to avoid code duplication
+ * @param {object} iam_client
+ * @param {string} role_name_to_create
+ * @param {string} assume_role_policy_document
+ * @param {string} [iam_path]
+ */
+async function create_iam_role(iam_client, role_name_to_create, assume_role_policy_document, iam_path) {
+    const input = {
+        RoleName: role_name_to_create,
+        AssumeRolePolicyDocument: assume_role_policy_document,
+    };
+    if (iam_path) input.Path = iam_path;
+    _check_status_code_ok(await iam_client.send(new CreateRoleCommand(input)));
+}
+
+/**
+ * Delete an IAM role with the given role name.
+ * Use this function for before/after hooks to avoid code duplication
+ * @param {object} iam_client
+ * @param {string} role_name_to_delete
+ */
+async function delete_iam_role(iam_client, role_name_to_delete) {
+    _check_status_code_ok(await iam_client.send(new DeleteRoleCommand({ RoleName: role_name_to_delete })));
+}
+
+/**
+ * Delete all inline policies from an IAM role.
+ * Use this function for before/after hooks to avoid code duplication
+ * @param {object} iam_client
+ * @param {string} role_name
+ */
+async function delete_all_inline_role_policies(iam_client, role_name) {
+    const list_response = await iam_client.send(new ListRolePoliciesCommand({ RoleName: role_name }));
+    for (const name of list_response.PolicyNames) {
+        await iam_client.send(new DeleteRolePolicyCommand({ RoleName: role_name, PolicyName: name }));
+    }
 }

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -18,6 +18,7 @@ const http_utils = require('../../../../util/http_utils');
 const s3_utils = require('../../../../endpoint/s3/s3_utils');
 const { get_archive_key } = require('../../../../util/deep_archive_utils');
 const test_utils = require('../../../system_tests/test_utils');
+const { err_code } = test_utils;
 const { MDStore } = require('../../../../server/object_services/md_store');
 const db_client = require('../../../../util/db_client');
 const { ObjectsReclaimer } = require('../../../../server/bg_services/objects_reclaimer');
@@ -36,14 +37,6 @@ const ARCHIVE_NSR = 'msc_s3_copy_archive_nsr';
 /** @type {S3} */
 let s3;
 let bucket_id;
-
-/**
- * @param {Error & { Code?: string, code?: string, name?: string }} err
- * @returns {string}
- */
-function err_code(err) {
-    return err.Code || err.code || err.name;
-}
 
 /**
  * @param {string} obj_id

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -2,7 +2,7 @@
 'use strict';
 
 // setup coretest first to prepare the env
-const {require_coretest, is_nc_coretest, TMP_PATH} = require('../../../system_tests/test_utils');
+const {require_coretest, is_nc_coretest, TMP_PATH, err_code} = require('../../../system_tests/test_utils');
 const coretest = require_coretest();
 coretest.setup({ pools_to_create: coretest.POOL_LIST });
 const { S3 } = require('@aws-sdk/client-s3');
@@ -23,7 +23,7 @@ async function assert_throws_async(promise, expected_code = 'AccessDenied', expe
         await promise;
         assert.fail('Test was suppose to fail on ' + expected_message);
     } catch (err) {
-        const actual_code = err.Code || err.code || err.name;
+        const actual_code = err_code(err);
         if (err.message !== expected_message || actual_code !== expected_code) throw err;
     }
 }

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -2,10 +2,11 @@
 'use strict';
 
 // setup coretest first to prepare the env
-const { require_coretest, is_nc_coretest, generate_iam_client } = require('../../../system_tests/test_utils');
+const { require_coretest, is_nc_coretest, generate_iam_client,
+    generate_s3_client, generate_sts_client, err_code } = require('../../../system_tests/test_utils');
 const coretest = require_coretest();
 coretest.setup();
-// TODO: Migrate the AWS package to lates on, avoid importing multiple places line #24   
+// TODO: Migrate remaining AWS.S3 usages in this file to SDK v3
 const AWS = require('aws-sdk');
 const https = require('https');
 const path = require('path');
@@ -14,14 +15,15 @@ const mocha = require('mocha');
 const assert = require('assert');
 const jwt = require('jsonwebtoken');
 const stsErr = require('../../../../endpoint/sts/sts_errors').StsError;
-const http_utils = require('../../../../util/http_utils');
 const dbg = require('../../../../util/debug_module')(__filename);
 const cloud_utils = require('../../../../util/cloud_utils');
 const jwt_utils = require('../../../../util/jwt_utils');
 const config = require('../../../../../config');
 const ldap_client = require('../../../../util/ldap_client');
 const { S3Error } = require('../../../../endpoint/s3/s3_errors');
-const { CreateRoleCommand, DeleteRoleCommand, PutRolePolicyCommand, UpdateAssumeRolePolicyCommand } = require('@aws-sdk/client-iam');
+const { CreateRoleCommand, DeleteRoleCommand, DeleteRolePolicyCommand,
+    PutRolePolicyCommand, UpdateAssumeRolePolicyCommand } = require('@aws-sdk/client-iam');
+const { AssumeRoleCommand, AssumeRoleWithWebIdentityCommand } = require('@aws-sdk/client-sts');
 const defualt_expiry_seconds = Math.ceil(config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS / 1000);
 
 const errors = {
@@ -100,7 +102,6 @@ mocha.describe('STS tests', function() {
     let admin_keys;
     let user_b_key;
     const role_b = 'RoleB';
-    let sts_creds;
     let accounts = [];
 
     let user_b_id = '';
@@ -113,16 +114,6 @@ mocha.describe('STS tests', function() {
     mocha.before(async function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
-        sts_creds = {
-            endpoint: coretest.get_https_address_sts(),
-            region: 'us-east-1',
-            sslEnabled: true,
-            computeChecksums: true,
-            httpOptions: { agent: new https.Agent({ keepAlive: false, rejectUnauthorized: false }) },
-            s3ForcePathStyle: true,
-            signatureVersion: 'v4',
-            s3DisableBodySigning: false,
-        };
         const account = { has_login: false, s3_access: true };
         if (is_nc_coretest) {
             account.nsfs_account_config = {
@@ -132,11 +123,10 @@ mocha.describe('STS tests', function() {
             };
         }
         admin_keys = (await rpc_client.account.read_account({ email: EMAIL })).access_keys;
-        sts_admin = new AWS.STS({
-            ...sts_creds,
-            accessKeyId: admin_keys[0].access_key.unwrap(),
-            secretAccessKey: admin_keys[0].secret_key.unwrap()
-        });
+        sts_admin = generate_sts_client(
+            admin_keys[0].access_key.unwrap(),
+            admin_keys[0].secret_key.unwrap(),
+            coretest.get_https_address_sts());
         account.name = user_a;
         account.email = user_a;
         // In NC mode, the system owner bypass in sts_rest.js is skipped (no system_store).
@@ -200,22 +190,19 @@ mocha.describe('STS tests', function() {
             }]
         };
 
-        sts = new AWS.STS({
-            ...sts_creds,
-            accessKeyId: user_a_keys[0].access_key.unwrap(),
-            secretAccessKey: user_a_keys[0].secret_key.unwrap()
-        });
-        sts_c = new AWS.STS({
-            ...sts_creds,
-            accessKeyId: user_c_keys[0].access_key.unwrap(),
-            secretAccessKey: user_c_keys[0].secret_key.unwrap()
-        });
+        sts = generate_sts_client(
+            user_a_keys[0].access_key.unwrap(),
+            user_a_keys[0].secret_key.unwrap(),
+            coretest.get_https_address_sts());
+        sts_c = generate_sts_client(
+            user_c_keys[0].access_key.unwrap(),
+            user_c_keys[0].secret_key.unwrap(),
+            coretest.get_https_address_sts());
         const random_access_keys = cloud_utils.generate_access_keys();
-        anon_sts = new AWS.STS({
-            ...sts_creds,
-            accessKeyId: random_access_keys.access_key.unwrap(),
-            secretAccessKey: random_access_keys.secret_key.unwrap()
-        });
+        anon_sts = generate_sts_client(
+            random_access_keys.access_key.unwrap(),
+            random_access_keys.secret_key.unwrap(),
+            coretest.get_https_address_sts());
         accounts = accounts.concat([user_a, user_b, user_c]);
 
         // Allow all of the accounts full access over 'first.bucket'
@@ -238,10 +225,10 @@ mocha.describe('STS tests', function() {
     });
 
     mocha.it('user a assume role of admin - should be rejected', async function() {
-        await assert_throws_async(sts.assumeRole({
+        await assert_throws_async(sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${'dummy_role'}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('admin assume role of user b - should be allowed', async function() {
@@ -249,30 +236,30 @@ mocha.describe('STS tests', function() {
             RoleArn: `arn:aws:sts::${user_b_id}:assumed-role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
-        const json = await assume_role_and_parse_xml(sts_admin, params);
+        const json = await sts_admin.send(new AssumeRoleCommand(params));
         validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
 
     mocha.it('admin assume non existing role of user b - should be rejected', async function() {
-        await assert_throws_async(sts_admin.assumeRole({
+        await assert_throws_async(sts_admin.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${'dummy_role2'}`,
             RoleSessionName: 'just_a_dummy_session_name1'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('admin assume non existing role of non existing user - should be rejected', async function() {
-        await assert_throws_async(sts_admin.assumeRole({
+        await assert_throws_async(sts_admin.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${12345}:role/${'dummy_role3'}`,
             RoleSessionName: 'just_a_dummy_session_name2'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('anonymous user a assume role of user b - should be rejected', async function() {
-        await assert_throws_async(anon_sts.assumeRole({
+        await assert_throws_async(anon_sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be allowed', async function() {
@@ -280,28 +267,24 @@ mocha.describe('STS tests', function() {
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
-        const json = await assume_role_and_parse_xml(sts_c, params);
+        const json = await sts_c.send(new AssumeRoleCommand(params));
         validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
 
         const temp_creds = validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
-        const s3 = new AWS.S3({
-            ...sts_creds,
-            accessKeyId: temp_creds.access_key,
-            secretAccessKey: temp_creds.secret_key,
-            sessionToken: temp_creds.session_token,
-            endpoint: coretest.get_https_address(),
-        });
-        const list_objects_res = await s3.listObjects({ Bucket: 'first.bucket' }).promise();
+        const s3 = generate_s3_client(
+            temp_creds.access_key, temp_creds.secret_key,
+            coretest.get_http_address(), temp_creds.session_token);
+        const list_objects_res = await s3.listObjects({ Bucket: 'first.bucket' });
         assert.ok(list_objects_res);
     });
 
     mocha.it('user a assume role of user b - should be rejected', async function() {
-        await assert_throws_async(sts.assumeRole({
+        await assert_throws_async(sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('update assume role policy of user b to allow user a', async function() {
@@ -326,7 +309,7 @@ mocha.describe('STS tests', function() {
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
-        const json = await assume_role_and_parse_xml(sts, params);
+        const json = await sts.send(new AssumeRoleCommand(params));
         validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
@@ -353,10 +336,10 @@ mocha.describe('STS tests', function() {
     });
 
     mocha.it('user a assume role of user b - should be rejected', async function() {
-        await assert_throws_async(sts.assumeRole({
+        await assert_throws_async(sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be allowed', async function() {
@@ -364,7 +347,7 @@ mocha.describe('STS tests', function() {
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
-        const json = await assume_role_and_parse_xml(sts_c, params);
+        const json = await sts_c.send(new AssumeRoleCommand(params));
         validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
@@ -392,10 +375,10 @@ mocha.describe('STS tests', function() {
     });
 
     mocha.it('user a assume role of user b - should be rejected sts:*', async function() {
-        await assert_throws_async(sts.assumeRole({
+        await assert_throws_async(sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_key}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be allowed sts:*', async function() {
@@ -403,7 +386,7 @@ mocha.describe('STS tests', function() {
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
         };
-        const json = await assume_role_and_parse_xml(sts_c, params);
+        const json = await sts_c.send(new AssumeRoleCommand(params));
         validate_assume_role_response(json, `arn:aws:sts::${user_b_id}:assumed-role/${role_b}/${params.RoleSessionName}`,
             `${user_b_id}:${params.RoleSessionName}`, user_b_key, defualt_expiry_seconds);
     });
@@ -424,57 +407,39 @@ mocha.describe('STS tests', function() {
     });
 
     mocha.it('user a assume role of user b - should be rejected *', async function() {
-        await assert_throws_async(sts.assumeRole({
+        await assert_throws_async(sts.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 
     mocha.it('user c assume role of user b - should be rejected *', async function() {
-        await assert_throws_async(sts_c.assumeRole({
+        await assert_throws_async(sts_c.send(new AssumeRoleCommand({
             RoleArn: `arn:aws:sts::${user_b_id}:role/${role_b}`,
             RoleSessionName: 'just_a_dummy_session_name'
-        }).promise(), errors.access_denied.code, errors.access_denied.message);
+        })), errors.access_denied.code, errors.access_denied.message);
     });
 });
 
-async function assume_role_and_parse_xml(sts, params) {
-    const req = sts.assumeRole(params);
-    let json;
-    req.on('complete', async function(resp) {
-        json = await http_utils.parse_xml_to_js(resp.httpResponse.body);
-    });
-    await req.promise();
-    return json;
-}
-
-function validate_assume_role_response(json, expected_arn, expected_role_id, assumed_access_key, duration_seconds) {
-    dbg.log0('test.sts.validate_assume_role_response: ', json);
-    assert.ok(json && json.AssumeRoleResponse && json.AssumeRoleResponse.AssumeRoleResult);
-    const result = json.AssumeRoleResponse.AssumeRoleResult[0];
-    assert.ok(result);
-
-    // validate credentials
-    const credentials = result.Credentials[0];
-    assert.ok(credentials && credentials.AccessKeyId[0] && credentials.SecretAccessKey[0]);
+function validate_assume_role_response(response, expected_arn, expected_role_id, assumed_access_key, duration_seconds) {
+    dbg.log0('test.sts.validate_assume_role_response: ', response);
+    assert.ok(response && response.Credentials && response.AssumedRoleUser);
+    const credentials = response.Credentials;
+    assert.ok(credentials.AccessKeyId && credentials.SecretAccessKey);
     const duration_ms = duration_seconds ? duration_seconds * 1000 : config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS;
-    const creds_generation_time_ms = new Date(credentials.Expiration[0]).getTime() - duration_ms;
+    const creds_generation_time_ms = new Date(credentials.Expiration).getTime() - duration_ms;
     assert(creds_generation_time_ms < Date.now());
     if (config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS !== 0) {
-        verify_session_token(credentials.SessionToken[0], credentials.AccessKeyId[0],
-            credentials.SecretAccessKey[0], assumed_access_key);
+        verify_session_token(credentials.SessionToken, credentials.AccessKeyId,
+            credentials.SecretAccessKey, assumed_access_key);
     }
-
-    // validate assumed role user
-    const assumed_role_user = result.AssumedRoleUser[0];
-    assert.equal(assumed_role_user.Arn[0], expected_arn);
-    assert.equal(assumed_role_user.AssumedRoleId[0], expected_role_id);
-
-    assert.equal(result.PackedPolicySize[0], '0');
+    assert.equal(response.AssumedRoleUser.Arn, expected_arn);
+    assert.equal(response.AssumedRoleUser.AssumedRoleId, expected_role_id);
+    assert.equal(Number(response.PackedPolicySize || 0), 0);
     return {
-        access_key: credentials && credentials.AccessKeyId[0],
-        secret_key: credentials && credentials.SecretAccessKey[0],
-        session_token: credentials.SessionToken[0]
+        access_key: credentials.AccessKeyId,
+        secret_key: credentials.SecretAccessKey,
+        session_token: credentials.SessionToken
     };
 }
 
@@ -489,7 +454,7 @@ async function assert_throws_async(promise,
         dbg.log0('assert_throws_async err.message', err.message, expected_message, err.message !== expected_message);
         dbg.log0('assert_throws_async err.code', err.code, expected_code, err.code !== expected_code);
         dbg.log0('assert_throws_async err.code', err.rpc_code, expected_code, err.rpc_code !== expected_code);
-        const code_or_rpc_code = err.code || err.rpc_code;
+        const code_or_rpc_code = err.code || err.rpc_code || err.Code || err.name;
         if (err.message !== expected_message || code_or_rpc_code !== expected_code) throw err;
     }
 }
@@ -512,6 +477,11 @@ mocha.describe('Session token tests', function() {
     let sts_creds;
     const role_alice = 'role_alice';
     let account_info_alice;
+    const original_sts_expiry_ms = config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS;
+
+    mocha.afterEach(function() {
+        config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS = original_sts_expiry_ms;
+    });
 
     mocha.after(async function() {
         const self = this; // eslint-disable-line no-invalid-this
@@ -552,11 +522,10 @@ mocha.describe('Session token tests', function() {
                 email: account.email
             })).access_keys;
 
-            account.sts = new AWS.STS({
-                ...sts_creds,
-                accessKeyId: account.access_keys[0].access_key.unwrap(),
-                secretAccessKey: account.access_keys[0].secret_key.unwrap()
-            });
+            account.sts = generate_sts_client(
+                account.access_keys[0].access_key.unwrap(),
+                account.access_keys[0].secret_key.unwrap(),
+                coretest.get_https_address_sts());
 
             account.s3 = new AWS.S3({
                 ...sts_creds,
@@ -632,7 +601,7 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -658,7 +627,7 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, duration_seconds);
 
@@ -685,7 +654,7 @@ mocha.describe('Session token tests', function() {
         const expected_error_message = `Value 43201 for durationSeconds failed to satisfy constraint:
             Member must have value less than or equal to 43200`;
         assert_throws_async(
-            assume_role_and_parse_xml(accounts[0].sts, params),
+            accounts[0].sts.send(new AssumeRoleCommand(params)),
             errors.validation_error.code,
             expected_error_message
         );
@@ -699,7 +668,7 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -722,11 +691,11 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json1 = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json1 = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj1 = validate_assume_role_response(json1, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const json2 = await assume_role_and_parse_xml(accounts[2].sts, params);
+        const json2 = await accounts[2].sts.send(new AssumeRoleCommand(params));
         const result_obj2 = validate_assume_role_response(json2, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -751,7 +720,7 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -775,7 +744,7 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -800,19 +769,17 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_sts_with_session_token = new AWS.STS({
-            ...sts_creds,
-            endpoint: coretest.get_https_address_sts(),
-            accessKeyId: user_a_key,
-            secretAccessKey: user_a_secret,
-            sessionToken: result_obj.session_token
-        });
+        const temp_sts_with_session_token = generate_sts_client(
+            user_a_key,
+            user_a_secret,
+            coretest.get_https_address_sts(),
+            result_obj.session_token);
 
-        await assert_throws_async(temp_sts_with_session_token.assumeRole(params).promise(),
+        await assert_throws_async(temp_sts_with_session_token.send(new AssumeRoleCommand(params)),
             errors.access_denied.code, errors.access_denied.message);
     });
 
@@ -824,19 +791,17 @@ mocha.describe('Session token tests', function() {
             RoleSessionName: 'just_a_dummy_session_name'
         };
 
-        const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+        const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_sts_with_session_token = new AWS.STS({
-            ...sts_creds,
-            endpoint: coretest.get_https_address_sts(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token + 'dummy'
-        });
+        const temp_sts_with_session_token = generate_sts_client(
+            result_obj.access_key,
+            result_obj.secret_key,
+            coretest.get_https_address_sts(),
+            result_obj.session_token + 'dummy');
 
-        await assert_throws_async(temp_sts_with_session_token.assumeRole(params).promise(),
+        await assert_throws_async(temp_sts_with_session_token.send(new AssumeRoleCommand(params)),
             errors.invalid_token.code, errors.invalid_token.message);
     });
 
@@ -851,7 +816,7 @@ mocha.describe('Session token tests', function() {
                 RoleSessionName: 'just_a_dummy_session_name'
             };
 
-            const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+            const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
             const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
                 `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
@@ -877,19 +842,17 @@ mocha.describe('Session token tests', function() {
                 RoleSessionName: 'just_a_dummy_session_name'
             };
 
-            const json = await assume_role_and_parse_xml(accounts[1].sts, params);
+            const json = await accounts[1].sts.send(new AssumeRoleCommand(params));
             const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
                 `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-            const temp_sts_with_session_token = new AWS.STS({
-                ...sts_creds,
-                endpoint: coretest.get_https_address_sts(),
-                accessKeyId: result_obj.access_key,
-                secretAccessKey: result_obj.secret_key,
-                sessionToken: result_obj.session_token
-            });
+            const temp_sts_with_session_token = generate_sts_client(
+                result_obj.access_key,
+                result_obj.secret_key,
+                coretest.get_https_address_sts(),
+                result_obj.session_token);
 
-            await assert_throws_async(temp_sts_with_session_token.assumeRole(params).promise(),
+            await assert_throws_async(temp_sts_with_session_token.send(new AssumeRoleCommand(params)),
                 errors.expired_token.code, errors.expired_token.message);
         });
     }
@@ -898,23 +861,14 @@ mocha.describe('Session token tests', function() {
 mocha.describe('Assume role with web indentity tests', function() {
     const user_a = 'alice1';
 
-    /** @type {AWS.STS} */
+    /** @type {import("@aws-sdk/client-sts").STSClient} */
     let anon_sts;
     mocha.before(async function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
 
-        // const random_access_keys = cloud_utils.generate_access_keys();
-        anon_sts = new AWS.STS({
-            endpoint: coretest.get_https_address_sts(),
-            region: 'us-east-1',
-            sslEnabled: true,
-            computeChecksums: true,
-            httpOptions: { agent: new https.Agent({ keepAlive: false, rejectUnauthorized: false }) },
-            s3ForcePathStyle: true,
-            signatureVersion: 'v4',
-            s3DisableBodySigning: false,
-        });
+        anon_sts = generate_sts_client(
+            '', '', coretest.get_https_address_sts());
         if (is_nc_coretest) {
             // nsfs.js is a separate process — inject jwt_secret via the LDAP config file
             // so the server's ldap_client picks it up via fs.watchFile reload.
@@ -936,38 +890,166 @@ mocha.describe('Assume role with web indentity tests', function() {
     });
 
     mocha.it('anonymous user a with bad jwt - should be rejected', async function() {
-        await assert_throws_async(anon_sts.assumeRoleWithWebIdentity({
+        await assert_throws_async(anon_sts.send(new AssumeRoleWithWebIdentityCommand({
             RoleArn: `arn:aws:sts::ldap:role/${user_a}`,
             RoleSessionName: 'just_a_dummy_session_name',
             WebIdentityToken: 'just_a_dummy_wit'
-        }).promise(), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
+        })), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
     });
 
     mocha.it('anonymous user a with invalid signature - should be rejected', async function() {
         const bad_signed_wit = jwt.sign({ user: user_a, password: 'dummy_password' }, 'invalid signature');
-        await assert_throws_async(anon_sts.assumeRoleWithWebIdentity({
+        await assert_throws_async(anon_sts.send(new AssumeRoleWithWebIdentityCommand({
             RoleArn: `arn:aws:sts::ldap:role/${user_a}`,
             RoleSessionName: 'just_a_dummy_session_name',
             WebIdentityToken: bad_signed_wit
-        }).promise(), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
+        })), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
     });
 
     mocha.it('anonymous user a with missing password - should be rejected', async function() {
         const missing_pwd_wit = jwt.sign({ user: user_a }, ldap_client.instance().ldap_params.jwt_secret);
-        await assert_throws_async(anon_sts.assumeRoleWithWebIdentity({
+        await assert_throws_async(anon_sts.send(new AssumeRoleWithWebIdentityCommand({
             RoleArn: `arn:aws:sts::ldap:role/${user_a}`,
             RoleSessionName: 'just_a_dummy_session_name',
             WebIdentityToken: missing_pwd_wit
-        }).promise(), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
+        })), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
     });
 
     mocha.it('anonymous user a with missing user name - should be rejected', async function() {
         // TODO: Need to update when authorize flow check for user and password based authentication
         const missing_usr_wit = jwt.sign({ password: 'password' }, ldap_client.instance().ldap_params.jwt_secret);
-        await assert_throws_async(anon_sts.assumeRoleWithWebIdentity({
+        await assert_throws_async(anon_sts.send(new AssumeRoleWithWebIdentityCommand({
             RoleArn: `arn:aws:sts::ldap:role/${user_a}`,
             RoleSessionName: 'just_a_dummy_session_name',
             WebIdentityToken: missing_usr_wit
-        }).promise(), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
+        })), stsErr.AccessDeniedException.code, stsErr.AccessDeniedException.message);
+    });
+});
+
+mocha.describe('STS assumed-role IAM policy authorization tests', function() {
+    if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+
+    const { rpc_client } = coretest;
+    const owner_email = 'role-authz-owner';
+    const assumer_email = 'role-authz-assumer';
+    const role_name = 'role_authz_restrictive';
+    const policy_name = 'Role_Authz_S3Access';
+    const owner = { email: owner_email };
+    const assumer = { email: assumer_email };
+    const accounts = [owner, assumer];
+    let owner_account_info;
+    let assumer_account_info;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        for (const account of accounts) {
+            account.access_keys = (await rpc_client.account.create_account({
+                has_login: false,
+                s3_access: true,
+                name: account.email,
+                email: account.email,
+            })).access_keys;
+            const access_key = account.access_keys[0].access_key.unwrap();
+            const secret_key = account.access_keys[0].secret_key.unwrap();
+            account.sts_client = generate_sts_client(access_key, secret_key, coretest.get_https_address_sts());
+            account.iam_client = generate_iam_client(access_key, secret_key, coretest.get_https_address_iam());
+        }
+
+        // emails are only for create_account/read_account RPC
+        // trust Principal uses the assumer's account id ARN
+        owner_account_info = await rpc_client.account.read_account({ email: owner_email });
+        assumer_account_info = await rpc_client.account.read_account({ email: assumer_email });
+        const assumer_account_id = assumer_account_info._id.toString();
+        await owner.iam_client.send(new CreateRoleCommand({
+            RoleName: role_name,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { AWS: [`arn:aws:iam::${assumer_account_id}:root`] },
+                    Action: ['sts:AssumeRole'],
+                }],
+            }),
+            MaxSessionDuration: config.STS_MAX_DURATION_SECONDS,
+        }));
+        await owner.iam_client.send(new PutRolePolicyCommand({
+            RoleName: role_name,
+            PolicyName: policy_name,
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:GetObject'],
+                    Resource: ['arn:aws:s3:::no-such-bucket/*'],
+                }],
+            }),
+        }));
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await owner.iam_client.send(new DeleteRolePolicyCommand({
+            RoleName: role_name, PolicyName: policy_name,
+        }));
+        await owner.iam_client.send(new DeleteRoleCommand({ RoleName: role_name }));
+        for (const account of accounts) {
+            await rpc_client.account.delete_account({ email: account.email });
+        }
+    });
+
+    mocha.it('assumer listBuckets with GetObject-only role policy - should fail', async function() {
+        const owner_id = owner_account_info._id.toString();
+        const owner_key = owner.access_keys[0].access_key.unwrap();
+        const session = 'restrictive_policy_session';
+        const json = await assumer.sts_client.send(new AssumeRoleCommand({
+            RoleArn: `arn:aws:sts::${owner_id}:role/${role_name}`,
+            RoleSessionName: session,
+        }));
+        const creds = validate_assume_role_response(json,
+            `arn:aws:sts::${owner_id}:assumed-role/${role_name}/${session}`,
+            `${owner_id}:${session}`, owner_key, defualt_expiry_seconds);
+        const s3_client = generate_s3_client(
+            creds.access_key, creds.secret_key, coretest.get_http_address(), creds.session_token);
+        try {
+            await s3_client.listBuckets({});
+            assert.fail('assumer listBuckets with GetObject-only role policy - should throw an error');
+        } catch (err) {
+            assert.equal(err_code(err), errors.s3_access_denied.code);
+        }
+    });
+
+    mocha.it('assumer listBuckets with ListAllMyBuckets-only role policy', async function() {
+        const input = {
+            RoleName: role_name,
+            PolicyName: policy_name,
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:ListAllMyBuckets'],
+                    Resource: ['*'],
+                }],
+            }),
+        };
+        const command = new PutRolePolicyCommand(input);
+        await owner.iam_client.send(command);
+
+        const owner_id = owner_account_info._id.toString();
+        const owner_key = owner.access_keys[0].access_key.unwrap();
+        const session = 'list_buckets_policy_session';
+        const json = await assumer.sts_client.send(new AssumeRoleCommand({
+            RoleArn: `arn:aws:sts::${owner_id}:role/${role_name}`,
+            RoleSessionName: session,
+        }));
+        const creds = validate_assume_role_response(json,
+            `arn:aws:sts::${owner_id}:assumed-role/${role_name}/${session}`,
+            `${owner_id}:${session}`, owner_key, defualt_expiry_seconds);
+        const s3_client = generate_s3_client(
+            creds.access_key, creds.secret_key, coretest.get_http_address(), creds.session_token);
+        const response = await s3_client.listBuckets({});
+        assert.equal(response.$metadata.httpStatusCode, 200);
     });
 });

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -10,6 +10,7 @@ const P = require('../../util/promise');
 const config = require('../../../config');
 const { S3 } = require('@aws-sdk/client-s3');
 const { IAMClient } = require('@aws-sdk/client-iam');
+const { STSClient } = require('@aws-sdk/client-sts');
 const os_utils = require('../../util/os_utils');
 const fs_utils = require('../../util/fs_utils');
 const nb_native = require('../../util/nb_native');
@@ -462,7 +463,7 @@ function generate_anon_s3_client(endpoint) {
     });
 }
 
-function generate_s3_client(access_key, secret_key, endpoint) {
+function generate_s3_client(access_key, secret_key, endpoint, session_token) {
     return new S3({
         forcePathStyle: true,
         region: config.DEFAULT_REGION,
@@ -472,6 +473,7 @@ function generate_s3_client(access_key, secret_key, endpoint) {
         credentials: {
             accessKeyId: access_key,
             secretAccessKey: secret_key,
+            ...(session_token && { sessionToken: session_token }),
         },
         endpoint
     });
@@ -486,6 +488,20 @@ function generate_iam_client(access_key, secret_key, endpoint) {
             secretAccessKey: secret_key,
         },
         endpoint,
+        requestHandler: new NodeHttpHandler({ httpsAgent }),
+    });
+}
+
+function generate_sts_client(access_key, secret_key, endpoint, session_token) {
+    const httpsAgent = new https.Agent({ keepAlive: false, rejectUnauthorized: false });
+    return new STSClient({
+        region: config.DEFAULT_REGION,
+        endpoint,
+        credentials: {
+            accessKeyId: access_key,
+            secretAccessKey: secret_key,
+            ...(session_token && { sessionToken: session_token }),
+        },
         requestHandler: new NodeHttpHandler({ httpsAgent }),
     });
 }
@@ -950,6 +966,13 @@ async function get_object(s3_client, bucket_name, key) {
     }
 }
 
+/**
+ * @param {Error & { Code?: string, code?: string, name?: string }} err
+ * @returns {string}
+ */
+function err_code(err) {
+    return err.Code || err.code || err.name;
+}
 
 exports.update_file_mtime = update_file_mtime;
 exports.generate_lifecycle_rule = generate_lifecycle_rule;
@@ -963,6 +986,7 @@ exports.disable_accounts_s3_access = disable_accounts_s3_access;
 exports.generate_s3_policy = generate_s3_policy;
 exports.generate_s3_client = generate_s3_client;
 exports.generate_iam_client = generate_iam_client;
+exports.generate_sts_client = generate_sts_client;
 exports.invalid_nsfs_root_permissions = invalid_nsfs_root_permissions;
 exports.require_coretest = require_coretest;
 exports.exec_manage_cli = exec_manage_cli;
@@ -996,4 +1020,5 @@ exports.clean_config_dir = clean_config_dir;
 exports.CLI_UNSET_EMPTY_STRING = CLI_UNSET_EMPTY_STRING;
 exports.set_health_mock_functions = set_health_mock_functions;
 exports.get_object = get_object;
+exports.err_code = err_code;
 exports.generate_vectors_client = generate_vectors_client;

--- a/src/test/unit_tests/api/iam/test_iam_ops_input_validation.test.js
+++ b/src/test/unit_tests/api/iam/test_iam_ops_input_validation.test.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2024 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
 const { IamError } = require('../../../../endpoint/iam/iam_errors');
@@ -12,7 +13,11 @@ const iam_get_access_key_last_used_op = require('../../../../endpoint/iam/ops/ia
 const iam_update_access_key_op = require('../../../../endpoint/iam/ops/iam_update_access_key');
 const iam_delete_access_key_op = require('../../../../endpoint/iam/ops/iam_delete_access_key');
 const iam_list_access_keys_op = require('../../../../endpoint/iam/ops/iam_list_access_keys');
-
+const iam_create_role_op = require('../../../../endpoint/iam/ops/iam_create_role');
+const iam_get_role_op = require('../../../../endpoint/iam/ops/iam_get_role');
+const iam_update_role_op = require('../../../../endpoint/iam/ops/iam_update_role');
+const iam_delete_role_op = require('../../../../endpoint/iam/ops/iam_delete_role');
+const iam_list_roles_op = require('../../../../endpoint/iam/ops/iam_list_roles');
 
 class NoErrorThrownError extends Error {}
 
@@ -542,4 +547,232 @@ describe('input validation flow in IAM ops - IAM ACCESS KEY API', () => {
     });
 });
 
+describe('input validation flow in IAM ops - IAM ROLES API', () => {
+
+    describe('iam_create_role', () => {
+        let res;
+        const role_name = 'TestRole';
+        // AWS-shaped trust policy example (account root principal)
+        const assume_role_policy = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111122223333:root"},"Action":"sts:AssumeRole"}]}';
+
+        it('iam_create_role without required parameters (role_name) should throw error', async () => {
+            try {
+                const req = {
+                    body: {
+                        // role_name is required
+                        assume_role_policy_document: assume_role_policy,
+                    }
+                };
+                await iam_create_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/required/i);
+            }
+        });
+
+        it('iam_create_role with invalid role_name (below min length) should throw error', async () => {
+            try {
+                const invalid_role_name = ''; // below min length (1)
+                const req = {
+                    body: {
+                        role_name: invalid_role_name,
+                        assume_role_policy_document: assume_role_policy,
+                    }
+                };
+                await iam_create_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/length/i);
+            }
+        });
+
+        it('iam_create_role with invalid path (without / at the beginning and the end) should throw error', async () => {
+            try {
+                const invalid_iam_path = 'abc'; // missing leading and trailing /
+                const req = {
+                    body: {
+                        role_name,
+                        path: invalid_iam_path,
+                        assume_role_policy_document: assume_role_policy,
+                    }
+                };
+                await iam_create_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/path/i);
+            }
+        });
+    });
+
+    describe('iam_get_role', () => {
+        let res;
+
+        it('iam_get_role with invalid role_name (below min length) should throw error', async () => {
+            try {
+                const invalid_role_name = ''; // below min length (1)
+                const req = {
+                    body: {
+                        role_name: invalid_role_name,
+                    }
+                };
+                await iam_get_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/length/i);
+            }
+        });
+    });
+
+    describe('iam_update_role', () => {
+        const role_name = 'TestRole';
+        let res;
+
+        it('iam_update_role without required parameters (role_name) should throw error', async () => {
+            try {
+                const req = {
+                    body: {
+                        // role_name is required
+                        description: 'updated',
+                    }
+                };
+                await iam_update_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/required/i);
+            }
+        });
+
+        it('iam_update_role with invalid max_session_duration should throw error', async () => {
+            try {
+                const invalid_max_session_duration = '100'; // below AWS min (3600)
+                const req = {
+                    body: {
+                        role_name,
+                        max_session_duration: invalid_max_session_duration,
+                    }
+                };
+                await iam_update_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/3600|43200|constraint/i);
+            }
+        });
+    });
+
+    describe('iam_delete_role', () => {
+        let res;
+
+        it('iam_delete_role without required parameters (role_name) should throw error', async () => {
+            try {
+                const req = {
+                    body: {
+                        // role_name is required
+                    }
+                };
+                await iam_delete_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/required/i);
+            }
+        });
+
+        it('iam_delete_role with invalid role_name (more than max length) should throw error', async () => {
+            try {
+                const max_length = 64;
+                const invalid_role_name = 'A'.repeat(max_length + 1); // above max length (64)
+                const req = {
+                    body: {
+                        role_name: invalid_role_name,
+                    }
+                };
+                await iam_delete_role_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/length/i);
+            }
+        });
+    });
+
+    describe('iam_list_roles', () => {
+        let res;
+
+        it('iam_list_roles with invalid iam_path_prefix (without / at the beginning and the end) should throw error', async () => {
+            try {
+                const invalid_iam_path_prefix = 'abc/def'; // missing leading and trailing /
+                const req = {
+                    body: {
+                        path_prefix: invalid_iam_path_prefix,
+                    }
+                };
+                await iam_list_roles_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/invalid/i);
+            }
+        });
+
+        it('iam_list_roles with invalid max_items (less than min value) should throw error', async () => {
+            try {
+                const invalid_nax_items = 0; // below min value (1)
+                const req = {
+                    body: {
+                        max_items: invalid_nax_items,
+                    }
+                };
+                await iam_list_roles_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/invalid/i);
+            }
+        });
+
+        it('iam_list_roles with invalid marker (below min length) should throw error', async () => {
+            try {
+                const invalid_marker = ''; // below min length (1)
+                const req = {
+                    body: {
+                        marker: invalid_marker,
+                    }
+                };
+                await iam_list_roles_op.handler(req, res);
+                throw new NoErrorThrownError();
+            } catch (err) {
+                expect(err).toBeInstanceOf(IamError);
+                expect(err).toHaveProperty('code', IamError.ValidationError.code);
+                expect(err).toHaveProperty('message');
+                expect(err.message).toMatch(/length greater than/i);
+            }
+        });
+    });
+});
 

--- a/src/test/unit_tests/api/iam/test_iam_utils.test.js
+++ b/src/test/unit_tests/api/iam/test_iam_utils.test.js
@@ -56,6 +56,48 @@ describe('create_arn_for_root', () => {
     });
 });
 
+describe('create_arn_for_role', () => {
+    const dummy_account_id = '12345678012';
+    const dummy_role_name = 'TestRole';
+    const dummy_iam_path = '/division_abc/subdivision_xyz/';
+    const arn_prefix = 'arn:aws:iam::';
+
+    it('create_arn_for_role without role_name should return basic structure', () => {
+        const res = iam_utils.create_arn_for_role(dummy_account_id, undefined, undefined);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:role/`);
+    });
+
+    it('create_arn_for_role with role_name and no iam_path should return only role_name in arn', () => {
+        const res = iam_utils.create_arn_for_role(dummy_account_id, dummy_role_name, undefined);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:role/${dummy_role_name}`);
+    });
+
+    it('create_arn_for_role with role_name and IAM_DEFAULT_PATH should return only role_name in arn', () => {
+        const res = iam_utils.create_arn_for_role(dummy_account_id, dummy_role_name, iam_constants.IAM_DEFAULT_PATH);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:role/${dummy_role_name}`);
+    });
+
+    it('create_arn_for_role with role_name and iam_path should return them in arn', () => {
+        const res = iam_utils.create_arn_for_role(dummy_account_id, dummy_role_name, dummy_iam_path);
+        expect(res).toBe(`${arn_prefix}${dummy_account_id}:role${dummy_iam_path}${dummy_role_name}`);
+    });
+});
+
+describe('parse_role_arn', () => {
+    it('should parse account_id and role_name from a valid role ARN', () => {
+        const res = iam_utils.parse_role_arn('arn:aws:iam::123456789012:role/TestRole');
+        expect(res).toEqual({ account_id: '123456789012', role_name: 'TestRole' });
+    });
+
+    it('should throw MISSING_ROLE_ARN error when role_arn is empty', () => {
+        expect(iam_utils.parse_role_arn('')).toEqual({ error: 'MISSING_ROLE_ARN' });
+    });
+
+    it('should throw INVALID_ROLE_ARN error when role_arn is malformed', () => {
+        expect(iam_utils.parse_role_arn('not-an-arn')).toEqual({ error: 'INVALID_ROLE_ARN' });
+    });
+});
+
 describe('get_action_message_title', () => {
     it('create_user', () => {
         const action = 'create_user';
@@ -115,6 +157,18 @@ describe('get_action_message_title', () => {
         const action = 'list_access_keys';
         const res = iam_utils.get_action_message_title(action);
         expect(res).toBe(`iam:ListAccessKeys`);
+    });
+
+    it('create_role', () => {
+        const action = 'create_role';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:CreateRole`);
+    });
+
+    it('put_role_policy', () => {
+        const action = 'put_role_policy';
+        const res = iam_utils.get_action_message_title(action);
+        expect(res).toBe(`iam:PutRolePolicy`);
     });
 });
 


### PR DESCRIPTION
### Describe the Problem
Currently, no tests implemented for IAM Roles.

### Explain the Changes
1. Jest: Role input-validation cases in existing ops validation file (no separate roles unit file / no mocked success-path ops). Utils coverage for create_arn_for_role, parse_role_arn, and role action message titles.
2. Mocha IAM: Role + role-policy happy path and negatives (duplicate, AccessDenied, NoSuchEntity, DeleteConflict, PathPrefix), aligned with user-API style; NC skip.
3. Mocha STS: Assumed-role suite for restrictive role policy → listBuckets AccessDenied, and ListAllMyBuckets policy → success (NC skip). Shared generate_sts_client (SDK v3) + generate_s3_client session-token/HTTPS support for reuse.

### Issues: Fixed #xxx / Gap #xxx
1. EPIC: https://redhat.atlassian.net/browse/MCGI-330

### Testing Instructions:
1.  From `noobaa-core` dir (run the below commands):
`$ make run-single-test testpath=integration_tests/api/iam/test_iam_basic_integration.js`
`$ make run-single-test testpath=integration_tests/api/sts/test_sts.js`

(jest tests)
`$ npx jest   src/test/unit_tests/api/iam/test_iam_utils.test.js \ src/test/unit_tests/api/iam/test_iam_ops_input_validation.test.js   --no-coverage`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded IAM integration coverage to include role and inline role policy flows (create/list/get/update/delete), including path filtering, conflict handling, and missing-resource/authorization failures.
  * Expanded IAM unit tests for role ARN helpers and IAM role handler input validation (names, path format, pagination, and session duration constraints).
  * Updated STS integration tests to use SDK v3 command-based flows, improved response/error assertions, and added assumed-role authorization scenarios for S3 access.
  * Enhanced test utilities to support optional session tokens for both S3 and STS clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->