### PR TITLE
NC | Fixing md conditions for delete object/s

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -684,6 +684,7 @@ module.exports = {
                             properties: {
                                 key: { type: 'string' },
                                 version_id: { type: 'string' },
+                                md_conditions: { $ref: '#/definitions/md_conditions' },
                             }
                         }
                     }
@@ -699,10 +700,7 @@ module.exports = {
                         created_version_id: { type: 'string' },
                         created_delete_marker: { type: 'boolean' },
                         seq: { type: 'integer' },
-                        err_code: {
-                            type: 'string',
-                            enum: ['AccessDenied', 'InternalError']
-                        },
+                        err_code: { type: 'string' },
                         err_message: { type: 'string' }
                     }
                 }

--- a/src/endpoint/s3/ops/s3_get_object_attributes.js
+++ b/src/endpoint/s3/ops/s3_get_object_attributes.js
@@ -19,7 +19,7 @@ async function get_object_attributes(req, res) {
         key: req.params.key,
         version_id: version_id,
         encryption: encryption, // GAP - we don't use it currently
-        md_conditions: http_utils.get_md_conditions(req), // GAP - we don't use it currently in all namespaces (for example - not in NSFS)
+        md_conditions: http_utils.get_md_conditions(req),
         attributes: attributes,
     };
     dbg.log2('params after parsing', params);

--- a/src/endpoint/s3/ops/s3_post_bucket_delete.js
+++ b/src/endpoint/s3/ops/s3_post_bucket_delete.js
@@ -30,8 +30,12 @@ async function post_bucket_delete(req) {
     for (const item of delete_list) {
         const key = item.Key?.[0];
         const version_id = item.VersionId?.[0];
-        const key_version = (key || '') + '\0' + (version_id || ''); // using null char (\x00) as separator
-        uniq_map.set(key_version, { key, version_id });
+        const etag = item.ETag?.[0];
+        const md_conditions = etag ? { if_match_etag: etag } : undefined;
+        const key_version = (key || '') + '\0' + (version_id || '') + '\0' + (etag || ''); // using null char (\x00) as separator
+        const obj = { key, version_id };
+        if (md_conditions) obj.md_conditions = md_conditions;
+        uniq_map.set(key_version, obj);
     }
     const objects = Array.from(uniq_map.values());
     dbg.log3('post_bucket_delete: objects without duplications', objects);
@@ -47,11 +51,12 @@ async function post_bucket_delete(req) {
         const req_obj = objects[i];
         const res_obj = reply[i];
         if (res_obj.err_code && !quiet) {
+            const mapped = S3Error.RPC_ERRORS_TO_S3[res_obj.err_code];
             results[i] = {
                 Error: {
                     Key: req_obj.key,
                     VersionId: req_obj.version_id,
-                    Code: res_obj.err_code,
+                    Code: mapped ? mapped.code : res_obj.err_code,
                     Message: res_obj.err_message,
                 }
             };

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1005,15 +1005,7 @@ class NamespaceFS {
                     stat = await nb_native().fs.stat(fs_context, file_path);
                     isDir = native_fs_utils.isDirectory(stat);
                     if (isDir) {
-                        if (!stat.xattr?.[XATTR_DIR_CONTENT] || !params.key.endsWith('/')) {
-                            throw error_utils.new_error_code('ENOENT', 'NoSuchKey');
-                        } else if (stat.xattr?.[XATTR_DIR_CONTENT] !== '0') {
-                            // find dir object content file path  and return its stat + xattr of its parent directory
-                            const dir_content_path = await this._find_version_path(fs_context, params);
-                            const dir_content_path_stat = await nb_native().fs.stat(fs_context, dir_content_path);
-                            const xattr = stat.xattr;
-                            stat = { ...dir_content_path_stat, xattr };
-                        }
+                        stat = await this._resolve_directory_object_stat(fs_context, params, stat);
                     }
                     if (this._is_mismatch_version_id(stat, params.version_id)) {
                         dbg.warn('NamespaceFS.read_object_md mismatch version_id', file_path, params.version_id, this._get_version_id_by_xattr(stat));
@@ -2095,6 +2087,7 @@ class NamespaceFS {
             await this._load_bucket(params, fs_context);
             const file_path = await this._find_version_path(fs_context, params);
             await this._check_path_in_bucket_boundaries(fs_context, file_path);
+            await this._check_md_conditions_delete(params.md_conditions, fs_context, params);
             dbg.log0('NamespaceFS: delete_object', file_path);
             let res;
             const is_key_dir_path = await this._is_key_dir_path(fs_context, params.key);
@@ -2122,27 +2115,29 @@ class NamespaceFS {
             await this._load_bucket(params, fs_context);
             let res = [];
             if (this._is_versioning_disabled()) {
-                for (const { key, version } of params.objects) {
-                    if (version) {
+                for (const { key, version_id, md_conditions } of params.objects) {
+                    if (version_id && version_id !== NULL_VERSION_ID) {
                         res.push({});
                         continue;
                     }
                     try {
                         const file_path = this._get_file_path({ key });
                         await this._check_path_in_bucket_boundaries(fs_context, file_path);
+                        await this._check_md_conditions_delete(md_conditions, fs_context, { key });
                         dbg.log1('NamespaceFS: delete_multiple_objects', file_path);
                         await this._delete_single_object(fs_context, file_path, { key, filter_func: params.filter_func });
                         res.push({ key });
                     } catch (err) {
-                        res.push({ err_code: err.code, err_message: err.message });
+                        res.push({ err_code: err.rpc_code || err.code, err_message: err.message });
                     }
                 }
             } else {
                 // [{key: a, version: 1}, {key: a, version: 2}, {key:b, version: 1}] => {'a': [1, 2], 'b': [1]}
                 const versions_by_key_map = {};
-                for (const { key, version_id } of params.objects) {
-                    if (versions_by_key_map[key]) versions_by_key_map[key].push(version_id);
-                    else versions_by_key_map[key] = [version_id];
+                for (const { key, version_id, md_conditions } of params.objects) {
+                    const version_entry = { version_id, md_conditions };
+                    if (versions_by_key_map[key]) versions_by_key_map[key].push(version_entry);
+                    else versions_by_key_map[key] = [version_entry];
                 }
                 dbg.log3('NamespaceFS: versions_by_key_map', versions_by_key_map);
                 for (const key of Object.keys(versions_by_key_map)) {
@@ -2842,6 +2837,26 @@ class NamespaceFS {
     }
 
     /**
+     * Resolve stat for a directory object (call when {@link native_fs_utils.isDirectory} is true).
+     * For non-empty dir objects, metadata comes from the content file with directory xattrs preserved.
+     * @param {import('./nb').NativeFSContext} fs_context
+     * @param {{ key: string, version_id?: string }} params
+     * @param {nb.NativeFSStats} stat directory stat from _find_version_path(..., true)
+     * @returns {Promise<nb.NativeFSStats>}
+     */
+    async _resolve_directory_object_stat(fs_context, params, stat) {
+        if (!stat.xattr?.[XATTR_DIR_CONTENT] || !params.key.endsWith('/')) {
+            throw error_utils.new_error_code('ENOENT', 'NoSuchKey');
+        }
+        if (stat.xattr?.[XATTR_DIR_CONTENT] !== '0') {
+            const dir_content_path = await this._find_version_path(fs_context, params);
+            const dir_content_path_stat = await nb_native().fs.stat(fs_context, dir_content_path);
+            stat = { ...dir_content_path_stat, xattr: stat.xattr };
+        }
+        return stat;
+    }
+
+    /**
      * _is_disabled_content_dir returns true if the latest key is content directory of the disabled versioning format.
      * meaning xattr are on the directory itself and not on the .folder file. returns false otherwise
      * @param {nb.NativeFSContext} fs_context
@@ -3280,6 +3295,48 @@ class NamespaceFS {
         }
     }
 
+    /**
+     * Stat the object targeted by delete and evaluate md_conditions.
+     * Stat/version resolution mirrors {@link read_object_md}.
+     * Missing objects (ENOENT, or latest delete marker) yield undefined metadata so
+     * If-Match fails while unconditional deletes stay idempotent.
+     * @param {import('../util/http_utils').MDConditions} md_conditions
+     * @param {import('./nb').NativeFSContext} fs_context
+     * @param {{ bucket?: string, key: string, version_id?: string }} params
+     */
+    async _check_md_conditions_delete(md_conditions, fs_context, params) {
+        if (!http_utils.has_md_conditions(md_conditions)) return;
+        let obj_md;
+        try {
+            const md_path = await this._find_version_path(fs_context, params, true);
+            await this._check_path_in_bucket_boundaries(fs_context, md_path);
+            let stat = await nb_native().fs.stat(fs_context, md_path);
+            if (native_fs_utils.isDirectory(stat)) {
+                stat = await this._resolve_directory_object_stat(fs_context, params, stat);
+            }
+            if (this._is_mismatch_version_id(stat, params.version_id)) {
+                throw error_utils.new_error_code('MISMATCH_VERSION', 'file version does not match the version we asked for');
+            }
+            // latest delete marker counts as "object does not exist" for conditional delete
+            if (stat.xattr?.[XATTR_DELETE_MARKER] && !params.version_id) {
+                obj_md = undefined;
+            } else {
+                this._throw_if_delete_marker(stat, params);
+                obj_md = {
+                    etag: this._get_etag(stat),
+                    last_modified_time: stat.mtime,
+                };
+            }
+        } catch (err) {
+            if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+                obj_md = undefined;
+            } else {
+                throw err;
+            }
+        }
+        http_utils.check_md_conditions(md_conditions, obj_md);
+    }
+
     //////////////////////////
     //// VERSIONING UTILS ////
     //////////////////////////
@@ -3444,7 +3501,7 @@ class NamespaceFS {
     /**
      * _is_mismatch_version_id checks if the expected_version_id equals to the version_id_str received by version_info or by version_id xattr coming from stat
      * @param {nb.NativeFSStats} stat 
-     * @param {String} expected_version_id 
+     * @param {string} [expected_version_id]
      * @returns {Boolean}
      */
     _is_mismatch_version_id(stat, expected_version_id) {
@@ -3548,9 +3605,10 @@ class NamespaceFS {
         let latest_ver_info;
         const latest_version_path = this._get_file_path({ key });
         await this._check_path_in_bucket_boundaries(fs_context, latest_version_path);
-        for (const version_id of versions) {
+        for (const { version_id, md_conditions } of versions) {
             try {
                 if (version_id) {
+                    await this._check_md_conditions_delete(md_conditions, fs_context, { key, version_id });
                     const del_ver_info = await this._delete_single_object_versioned(fs_context, { key, version_id, filter_func });
                     if (!del_ver_info) {
                         res.push({});
@@ -3563,13 +3621,14 @@ class NamespaceFS {
                     }
                     res.push({ deleted_delete_marker: del_ver_info.delete_marker });
                 } else {
+                    await this._check_md_conditions_delete(md_conditions, fs_context, { key, version_id });
                     const version_res = await this._delete_latest_version(fs_context, latest_version_path,
                         { key, version_id, filter_func });
                     res.push(version_res);
                     delete_marker_created = true;
                 }
             } catch (err) {
-                res.push({ err_code: err.code, err_message: err.message });
+                res.push({ err_code: err.rpc_code || err.code, err_message: err.message });
             }
         }
         // we try promote only if the latest version was deleted or we deleted a delete marker

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1113,8 +1113,10 @@ async function delete_multiple_objects(req) {
     const results = [];
     results.length = objects.length;
 
+    const any_md_conditions = objects.some(obj => http_utils.has_md_conditions(obj.md_conditions));
+
     // if bucket versioning is disabled, optimize the DB operations
-    if (req.bucket.versioning === CONSTANTS.S3.VERSIONING.DISABLED) {
+    if (req.bucket.versioning === CONSTANTS.S3.VERSIONING.DISABLED && !any_md_conditions) {
         dbg.log1('Optimizing delete for non versioned bucket');
 
         const keys = [];
@@ -1197,14 +1199,14 @@ async function delete_multiple_objects(req) {
                             bucket: req.bucket.name,
                             key: obj.key,
                             version_id: obj.version_id,
+                            md_conditions: obj.md_conditions,
                         }
                     }, req)
                 );
             } catch (err) {
                 dbg.error('Multiple delete for obj', obj, 'failed with reason', err);
-                // for now we mapped all errors to internal error
                 res = {
-                    err_code: 'InternalError',
+                    err_code: err.rpc_code || 'InternalError',
                     err_message: err.message || 'InternalError'
                 };
 

--- a/src/test/unit_tests/nsfs/test_namespace_fs.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs.js
@@ -1,6 +1,6 @@
 /* Copyright (C) 2020 NooBaa */
-/*eslint max-lines-per-function: ["error", 1300]*/
-/*eslint max-lines: ["error", 2600]*/
+/*eslint max-lines-per-function: ["error", 1310]*/
+/*eslint max-lines: ["error", 3000]*/
 'use strict';
 
 const _ = require('lodash');
@@ -899,6 +899,275 @@ mocha.describe('namespace_fs', function() {
             } catch (err) {
                 assert.strictEqual(err.rpc_code, 'IF_NONE_MATCH_ETAG');
             }
+        });
+
+        const delete_key = 'delete_key_md_conditions';
+        const delete_key_missing = 'delete_key_md_conditions_missing';
+
+        mocha.it('delete_object with If-Match that passes', async function() {
+            const upload_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: delete_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: delete_key,
+                md_conditions: {
+                    if_match_etag: upload_res.etag,
+                },
+            }, dummy_object_sdk);
+
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: delete_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+        });
+
+        mocha.it('delete_object with If-Match that fails', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: delete_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            try {
+                await ns_tmp.delete_object({
+                    bucket: upload_bkt,
+                    key: delete_key,
+                    md_conditions: {
+                        if_match_etag: 'non-matching-etag',
+                    },
+                }, dummy_object_sdk);
+                assert.fail('delete_object should fail');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'IF_MATCH_ETAG');
+            }
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: delete_key,
+            }, dummy_object_sdk);
+            assert.ok(md.etag);
+        });
+
+        mocha.it('delete_object with If-Match on missing object', async function() {
+            try {
+                await ns_tmp.delete_object({
+                    bucket: upload_bkt,
+                    key: delete_key_missing,
+                    md_conditions: {
+                        if_match_etag: 'non-matching-etag',
+                    },
+                }, dummy_object_sdk);
+                assert.fail('delete_object should fail');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'IF_MATCH_ETAG');
+            }
+        });
+
+        mocha.it('delete_object without conditions on missing object', async function() {
+            await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: delete_key_missing,
+            }, dummy_object_sdk);
+        });
+
+        mocha.it('delete_object with If-Match * on missing object', async function() {
+            try {
+                await ns_tmp.delete_object({
+                    bucket: upload_bkt,
+                    key: delete_key_missing,
+                    md_conditions: {
+                        if_match_etag: '*',
+                    },
+                }, dummy_object_sdk);
+                assert.fail('delete_object should fail');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'IF_MATCH_ETAG');
+            }
+        });
+
+        mocha.it('delete_object with If-Match * on existing object', async function() {
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: delete_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: delete_key,
+                md_conditions: {
+                    if_match_etag: '*',
+                },
+            }, dummy_object_sdk);
+
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: delete_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+        });
+
+        mocha.it('delete_multiple_objects with matching If-Match ETag', async function() {
+            const batch_key_1 = 'delete_batch_md_conditions_1';
+            const batch_key_2 = 'delete_batch_md_conditions_2';
+            const upload_res_1 = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: batch_key_1,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+            const upload_res_2 = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: batch_key_2,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            const delete_res = await ns_tmp.delete_multiple_objects({
+                bucket: upload_bkt,
+                objects: [
+                    { key: batch_key_1, md_conditions: { if_match_etag: upload_res_1.etag } },
+                    { key: batch_key_2, md_conditions: { if_match_etag: upload_res_2.etag } },
+                ],
+            }, dummy_object_sdk);
+
+            assert.strictEqual(delete_res.length, 2);
+            assert.ok(!delete_res[0].err_code);
+            assert.ok(!delete_res[1].err_code);
+        });
+
+        mocha.it('delete_multiple_objects with mismatched If-Match ETag', async function() {
+            const batch_key = 'delete_batch_md_conditions_fail';
+            await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: batch_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            const delete_res = await ns_tmp.delete_multiple_objects({
+                bucket: upload_bkt,
+                objects: [
+                    { key: batch_key, md_conditions: { if_match_etag: 'non-matching-etag' } },
+                ],
+            }, dummy_object_sdk);
+
+            assert.strictEqual(delete_res.length, 1);
+            assert.strictEqual(delete_res[0].err_code, 'IF_MATCH_ETAG');
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: batch_key,
+            }, dummy_object_sdk);
+            assert.ok(md.etag);
+        });
+
+        mocha.it('delete_object with If-Match on empty disabled directory object', async function() {
+            const dir_key = 'delete_dir_md_conditions_empty/';
+            const upload_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: dir_key,
+                size: 0,
+            }, dummy_object_sdk);
+
+            await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: dir_key,
+                md_conditions: {
+                    if_match_etag: upload_res.etag,
+                },
+            }, dummy_object_sdk);
+
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: dir_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+        });
+
+        mocha.it('delete_object with If-Match on non-empty disabled directory object', async function() {
+            const dir_key = 'delete_dir_md_conditions_nonempty/';
+            const upload_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: dir_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            await ns_tmp.delete_object({
+                bucket: upload_bkt,
+                key: dir_key,
+                md_conditions: {
+                    if_match_etag: upload_res.etag,
+                },
+            }, dummy_object_sdk);
+
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: dir_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+        });
+
+        mocha.it('delete_multiple_objects with If-Match on disabled directory objects', async function() {
+            const empty_dir_key = 'delete_batch_dir_empty/';
+            const nonempty_dir_key = 'delete_batch_dir_nonempty/';
+            const empty_upload = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: empty_dir_key,
+                size: 0,
+            }, dummy_object_sdk);
+            const nonempty_upload = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: nonempty_dir_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            const delete_res = await ns_tmp.delete_multiple_objects({
+                bucket: upload_bkt,
+                objects: [
+                    { key: empty_dir_key, md_conditions: { if_match_etag: empty_upload.etag } },
+                    { key: nonempty_dir_key, md_conditions: { if_match_etag: nonempty_upload.etag } },
+                ],
+            }, dummy_object_sdk);
+
+            assert.strictEqual(delete_res.length, 2);
+            assert.ok(!delete_res[0].err_code);
+            assert.ok(!delete_res[1].err_code);
+
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: empty_dir_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+            await assert.rejects(
+                () => ns_tmp.read_object_md({ bucket: upload_bkt, key: nonempty_dir_key }, dummy_object_sdk),
+                err => err.code === 'ENOENT' || err.rpc_code === 'NO_SUCH_OBJECT'
+            );
+        });
+
+        mocha.it('delete_multiple_objects skips non-null version_id on disabled bucket', async function() {
+            const batch_key = 'delete_batch_version_id_disabled';
+            const upload_res = await ns_tmp.upload_object({
+                bucket: upload_bkt,
+                key: batch_key,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            const delete_res = await ns_tmp.delete_multiple_objects({
+                bucket: upload_bkt,
+                objects: [{
+                    key: batch_key,
+                    version_id: 'mtime-fake-ino-fake',
+                    md_conditions: { if_match_etag: upload_res.etag },
+                }],
+            }, dummy_object_sdk);
+
+            assert.strictEqual(delete_res.length, 1);
+            assert.ok(!delete_res[0].err_code);
+            assert.ok(!delete_res[0].key);
+
+            const md = await ns_tmp.read_object_md({
+                bucket: upload_bkt,
+                key: batch_key,
+            }, dummy_object_sdk);
+            assert.ok(md.etag);
         });
     });
 


### PR DESCRIPTION
### Describe the Problem
We were missing support for md conditions in NC for delete operation to be better aligned with AWS: https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html 

### Explain the Changes
1. Adding support for single/multiple deletes, both versioned and none-versioned

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `If-Match` behavior for single-object and bulk deletes, including correct handling for missing objects and `If-Match: *`.
  * Added support for per-object `ETag` to strengthen conditional matching in bulk deletes.
  * Disabled bulk-delete optimizations when conditional requirements are present, and improved per-object error reporting to preserve upstream RPC error codes.
  * Enhanced conditional evaluation for directory objects to behave consistently across empty vs non-empty cases.
* **Tests**
  * Expanded unit tests to cover conditional delete scenarios for single and bulk operations, including directory and versioning edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->