### PR TITLE
map PutObjectLegalHold to the correct bucket policy action

### DIFF
--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -253,34 +253,57 @@ mocha.describe('s3_bucket_policy', function() {
     });
 
     // put_object_legal_hold was incorrectly mapped to GetObjectLegalHold, so
-    // PutBucketPolicy rejected s3:PutObjectLegalHold as an invalid action.
-    mocha.it('should accept PutObjectLegalHold in bucket policy', async function() {
+    // PutBucketPolicy rejected s3:PutObjectLegalHold and runtime auth checked the
+    // wrong permission. Grant only PutObjectLegalHold and exercise the op.
+    mocha.it('should allow PutObjectLegalHold when granted by bucket policy', async function() {
+        const LOCK_BKT = 'test2-bucket-policy-legal-hold';
+        const LOCK_KEY = 'legal-hold-obj';
+        await s3_owner.createBucket({
+            Bucket: LOCK_BKT,
+            ObjectLockEnabledForBucket: true,
+        });
+        await s3_owner.putObject({
+            Bucket: LOCK_BKT,
+            Key: LOCK_KEY,
+            Body: BODY,
+        });
+
         const policy = {
             Version: '2012-10-17',
             Statement: [{
                 Sid: 'id-put-object-legal-hold',
                 Effect: 'Allow',
                 Principal: { AWS: a_principal },
-                Action: [
-                    's3:PutObjectLegalHold',
-                    's3:GetObjectLegalHold',
-                ],
+                Action: ['s3:PutObjectLegalHold'],
                 Resource: [
-                    `arn:aws:s3:::${BKT}`,
-                    `arn:aws:s3:::${BKT}/*`,
+                    `arn:aws:s3:::${LOCK_BKT}`,
+                    `arn:aws:s3:::${LOCK_BKT}/*`,
                 ]
             }]
         };
         await s3_owner.putBucketPolicy({
-            Bucket: BKT,
+            Bucket: LOCK_BKT,
             Policy: JSON.stringify(policy)
         });
-        const res = await s3_owner.getBucketPolicy({ Bucket: BKT });
-        const stored = JSON.parse(res.Policy);
-        assert.deepStrictEqual(
-            stored.Statement[0].Action,
-            policy.Statement[0].Action
-        );
+
+        // Succeeds only if put_object_legal_hold maps to s3:PutObjectLegalHold.
+        // Wrong mapping to GetObjectLegalHold would AccessDeny with this policy.
+        await s3_a.putObjectLegalHold({
+            Bucket: LOCK_BKT,
+            Key: LOCK_KEY,
+            LegalHold: { Status: 'ON' },
+        });
+        const hold = await s3_owner.getObjectLegalHold({
+            Bucket: LOCK_BKT,
+            Key: LOCK_KEY,
+        });
+        assert.equal(hold.LegalHold.Status, 'ON');
+
+        await assert_throws_async(s3_b.putObjectLegalHold({
+            Bucket: LOCK_BKT,
+            Key: LOCK_KEY,
+            LegalHold: { Status: 'OFF' },
+        }));
     });
 
     mocha.it('should only read bucket policy when have permission to', async function() {

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy.js
@@ -252,6 +252,37 @@ mocha.describe('s3_bucket_policy', function() {
         }), 'Policy has invalid action');
     });
 
+    // put_object_legal_hold was incorrectly mapped to GetObjectLegalHold, so
+    // PutBucketPolicy rejected s3:PutObjectLegalHold as an invalid action.
+    mocha.it('should accept PutObjectLegalHold in bucket policy', async function() {
+        const policy = {
+            Version: '2012-10-17',
+            Statement: [{
+                Sid: 'id-put-object-legal-hold',
+                Effect: 'Allow',
+                Principal: { AWS: a_principal },
+                Action: [
+                    's3:PutObjectLegalHold',
+                    's3:GetObjectLegalHold',
+                ],
+                Resource: [
+                    `arn:aws:s3:::${BKT}`,
+                    `arn:aws:s3:::${BKT}/*`,
+                ]
+            }]
+        };
+        await s3_owner.putBucketPolicy({
+            Bucket: BKT,
+            Policy: JSON.stringify(policy)
+        });
+        const res = await s3_owner.getBucketPolicy({ Bucket: BKT });
+        const stored = JSON.parse(res.Policy);
+        assert.deepStrictEqual(
+            stored.Statement[0].Action,
+            policy.Statement[0].Action
+        );
+    });
+
     mocha.it('should only read bucket policy when have permission to', async function() {
         const policy = {
             Statement: [{

--- a/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
@@ -74,6 +74,24 @@ describe('access_policy_utils', () => {
                 ).resolves.toBeUndefined();
             });
 
+            it('should accept s3:PutObjectLegalHold and s3:BypassGovernanceRetention', async () => {
+                const policy = make_policy({
+                    action: [
+                        's3:PutObjectLegalHold',
+                        's3:GetObjectLegalHold',
+                        's3:PutObjectRetention',
+                        's3:BypassGovernanceRetention',
+                    ],
+                    resource: [
+                        `arn:aws:s3:::${BUCKET_NAME}`,
+                        `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    ],
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
             it('should accept a Deny statement with NotPrincipal', async () => {
                 const policy = make_policy({
                     effect: 'Deny',

--- a/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
@@ -74,13 +74,11 @@ describe('access_policy_utils', () => {
                 ).resolves.toBeUndefined();
             });
 
-            it('should accept s3:PutObjectLegalHold and s3:BypassGovernanceRetention', async () => {
+            it('should accept s3:PutObjectLegalHold', async () => {
                 const policy = make_policy({
                     action: [
                         's3:PutObjectLegalHold',
                         's3:GetObjectLegalHold',
-                        's3:PutObjectRetention',
-                        's3:BypassGovernanceRetention',
                     ],
                     resource: [
                         `arn:aws:s3:::${BUCKET_NAME}`,

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -94,16 +94,6 @@ const OP_NAME_TO_ACTION = Object.freeze({
     put_object: { regular: "s3:PutObject" },
 });
 
-/**
- * Extra s3 actions accepted in bucket policies that are not mapped 1:1 to an S3 op.
- * BypassGovernanceRetention is an additional permission required when using
- * x-amz-bypass-governance-retention (see AWS S3 Object Lock docs).
- */
-const BYPASS_GOVERNANCE_RETENTION_ACTION = 's3:BypassGovernanceRetention';
-const ADDITIONAL_BUCKET_POLICY_ACTIONS = Object.freeze([
-    BYPASS_GOVERNANCE_RETENTION_ACTION,
-]);
-
 const qm_regex = /\?/g;
 const ar_regex = /\*/g;
 const IAM_DEFAULT_PATH = '/';
@@ -650,10 +640,16 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
 
 async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
     const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
+    // valid_actions = Action strings allowed in PutBucketPolicy.
+    // Include Object Lock permissions that are not mapped 1:1 from an S3 op name
+    // (e.g. BypassGovernanceRetention is an extra permission for the bypass header).
+    const allowed_policy_actions = all_op_names.concat([
+        's3:BypassGovernanceRetention',
+    ]);
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3:::',
         action_wildcard: 's3:*',
-        valid_actions: all_op_names.concat(ADDITIONAL_BUCKET_POLICY_ACTIONS),
+        valid_actions: allowed_policy_actions,
         supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
         split_condition_key: true,
     });
@@ -1057,8 +1053,6 @@ function fetch_web_identity_info(req) {
 
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.VECTOR_OP_NAME_TO_ACTION = VECTOR_OP_NAME_TO_ACTION;
-exports.BYPASS_GOVERNANCE_RETENTION_ACTION = BYPASS_GOVERNANCE_RETENTION_ACTION;
-exports.ADDITIONAL_BUCKET_POLICY_ACTIONS = ADDITIONAL_BUCKET_POLICY_ACTIONS;
 exports.has_access_policy_permission = has_access_policy_permission;
 exports.validate_bucket_policy = validate_bucket_policy;
 exports.validate_vector_bucket_policy = validate_vector_bucket_policy;

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -575,12 +575,12 @@ function _validate_ip_condition_values(condition_value) {
  * @param {Object} options
  * @param {string} options.resource_arn_prefix - ARN prefix for resource validation (e.g. 'arn:aws:s3:::' or 'arn:aws:s3vectors:::')
  * @param {string} options.action_wildcard - wildcard action string (e.g. 's3:*' or 's3vectors:*')
- * @param {readonly string[]} options.allowed_policy_actions - Action / permission strings allowed in the policy
+ * @param {readonly string[]} options.valid_actions - list of valid action strings
  * @param {readonly string[]} options.supported_condition_keys - list of supported condition key prefixes
  * @param {boolean} [options.split_condition_key=false] - whether to split condition keys on '/' before matching
  */
 async function _validate_policy(policy, bucket_name, get_account_handler, options) {
-    const { resource_arn_prefix, action_wildcard, allowed_policy_actions, supported_condition_keys,
+    const { resource_arn_prefix, action_wildcard, valid_actions, supported_condition_keys,
         split_condition_key = false } = options;
     for (const statement of policy.Statement) {
         if (statement.NotPrincipal && statement.Effect !== 'Deny') {
@@ -618,7 +618,7 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
             }
         }
         for (const action of _.flatten([statement.Action || statement.NotAction])) {
-            if (action !== action_wildcard && !allowed_policy_actions.includes(action)) {
+            if (action !== action_wildcard && !valid_actions.includes(action)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid action', { detail: action });
             }
         }
@@ -643,7 +643,7 @@ async function validate_bucket_policy(policy, bucket_name, get_account_handler) 
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3:::',
         action_wildcard: 's3:*',
-        allowed_policy_actions: all_op_names,
+        valid_actions: all_op_names,
         supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
         split_condition_key: true,
     });
@@ -764,7 +764,7 @@ async function validate_vector_bucket_policy(policy, bucket_name, get_account_ha
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3vectors:::',
         action_wildcard: 's3vectors:*',
-        allowed_policy_actions: VECTOR_BUCKET_POLICY_ACTIONS,
+        valid_actions: VECTOR_BUCKET_POLICY_ACTIONS,
         supported_condition_keys: SUPPORTED_VECTOR_BUCKET_POLICY_CONDITIONS,
     });
 }

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -90,9 +90,19 @@ const OP_NAME_TO_ACTION = Object.freeze({
     put_object_tagging: { regular: "s3:PutObjectTagging", versioned: "s3:PutObjectVersionTagging" },
     put_object_uploadId: { regular: "s3:PutObject" },
     put_object_retention: { regular: "s3:PutObjectRetention" },
-    put_object_legal_hold: { regular: "s3:GetObjectLegalHold"},
+    put_object_legal_hold: { regular: "s3:PutObjectLegalHold" },
     put_object: { regular: "s3:PutObject" },
 });
+
+/**
+ * Extra s3 actions accepted in bucket policies that are not mapped 1:1 to an S3 op.
+ * BypassGovernanceRetention is an additional permission required when using
+ * x-amz-bypass-governance-retention (see AWS S3 Object Lock docs).
+ */
+const BYPASS_GOVERNANCE_RETENTION_ACTION = 's3:BypassGovernanceRetention';
+const ADDITIONAL_BUCKET_POLICY_ACTIONS = Object.freeze([
+    BYPASS_GOVERNANCE_RETENTION_ACTION,
+]);
 
 const qm_regex = /\?/g;
 const ar_regex = /\*/g;
@@ -643,7 +653,7 @@ async function validate_bucket_policy(policy, bucket_name, get_account_handler) 
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3:::',
         action_wildcard: 's3:*',
-        valid_actions: all_op_names,
+        valid_actions: all_op_names.concat(ADDITIONAL_BUCKET_POLICY_ACTIONS),
         supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
         split_condition_key: true,
     });
@@ -1047,6 +1057,8 @@ function fetch_web_identity_info(req) {
 
 exports.OP_NAME_TO_ACTION = OP_NAME_TO_ACTION;
 exports.VECTOR_OP_NAME_TO_ACTION = VECTOR_OP_NAME_TO_ACTION;
+exports.BYPASS_GOVERNANCE_RETENTION_ACTION = BYPASS_GOVERNANCE_RETENTION_ACTION;
+exports.ADDITIONAL_BUCKET_POLICY_ACTIONS = ADDITIONAL_BUCKET_POLICY_ACTIONS;
 exports.has_access_policy_permission = has_access_policy_permission;
 exports.validate_bucket_policy = validate_bucket_policy;
 exports.validate_vector_bucket_policy = validate_vector_bucket_policy;

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -575,12 +575,12 @@ function _validate_ip_condition_values(condition_value) {
  * @param {Object} options
  * @param {string} options.resource_arn_prefix - ARN prefix for resource validation (e.g. 'arn:aws:s3:::' or 'arn:aws:s3vectors:::')
  * @param {string} options.action_wildcard - wildcard action string (e.g. 's3:*' or 's3vectors:*')
- * @param {readonly string[]} options.valid_actions - list of valid action strings
+ * @param {readonly string[]} options.allowed_policy_actions - Action / permission strings allowed in the policy
  * @param {readonly string[]} options.supported_condition_keys - list of supported condition key prefixes
  * @param {boolean} [options.split_condition_key=false] - whether to split condition keys on '/' before matching
  */
 async function _validate_policy(policy, bucket_name, get_account_handler, options) {
-    const { resource_arn_prefix, action_wildcard, valid_actions, supported_condition_keys,
+    const { resource_arn_prefix, action_wildcard, allowed_policy_actions, supported_condition_keys,
         split_condition_key = false } = options;
     for (const statement of policy.Statement) {
         if (statement.NotPrincipal && statement.Effect !== 'Deny') {
@@ -618,7 +618,7 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
             }
         }
         for (const action of _.flatten([statement.Action || statement.NotAction])) {
-            if (action !== action_wildcard && !valid_actions.includes(action)) {
+            if (action !== action_wildcard && !allowed_policy_actions.includes(action)) {
                 throw new RpcError('MALFORMED_POLICY', 'Policy has invalid action', { detail: action });
             }
         }
@@ -640,16 +640,14 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
 
 async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
     const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
-    // valid_actions = Action strings allowed in PutBucketPolicy.
-    // Include Object Lock permissions that are not mapped 1:1 from an S3 op name
-    // (e.g. BypassGovernanceRetention is an extra permission for the bypass header).
-    const allowed_policy_actions = all_op_names.concat([
-        's3:BypassGovernanceRetention',
-    ]);
+    // Include Object Lock permissions that are not mapped 1:1 from an S3 op
+    // (BypassGovernanceRetention is required with the bypass header).
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3:::',
         action_wildcard: 's3:*',
-        valid_actions: allowed_policy_actions,
+        allowed_policy_actions: all_op_names.concat([
+            's3:BypassGovernanceRetention',
+        ]),
         supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
         split_condition_key: true,
     });
@@ -770,7 +768,7 @@ async function validate_vector_bucket_policy(policy, bucket_name, get_account_ha
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3vectors:::',
         action_wildcard: 's3vectors:*',
-        valid_actions: VECTOR_BUCKET_POLICY_ACTIONS,
+        allowed_policy_actions: VECTOR_BUCKET_POLICY_ACTIONS,
         supported_condition_keys: SUPPORTED_VECTOR_BUCKET_POLICY_CONDITIONS,
     });
 }

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -640,14 +640,10 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
 
 async function validate_bucket_policy(policy, bucket_name, get_account_handler) {
     const all_op_names = _.flatten(_.compact(_.flatMap(OP_NAME_TO_ACTION, action => [action.regular, action.versioned])));
-    // Include Object Lock permissions that are not mapped 1:1 from an S3 op
-    // (BypassGovernanceRetention is required with the bypass header).
     return _validate_policy(policy, bucket_name, get_account_handler, {
         resource_arn_prefix: 'arn:aws:s3:::',
         action_wildcard: 's3:*',
-        allowed_policy_actions: all_op_names.concat([
-            's3:BypassGovernanceRetention',
-        ]),
+        allowed_policy_actions: all_op_names,
         supported_condition_keys: SUPPORTED_BUCKET_POLICY_CONDITIONS,
         split_condition_key: true,
     });


### PR DESCRIPTION
## Summary
- Map `put_object_legal_hold` to `s3:PutObjectLegalHold` (was incorrectly mapped to `s3:GetObjectLegalHold`).
- This allows PutBucketPolicy to accept `s3:PutObjectLegalHold` and makes runtime PutObjectLegalHold authorization check the correct permission.

`s3:BypassGovernanceRetention` PutBucketPolicy acceptance and runtime Bypass authorization will be handled together in a follow-up PR.

Fixes: [DFBUGS-8950](https://redhat.atlassian.net/browse/DFBUGS-8950)

## Test plan
- [x] PutBucketPolicy with `s3:PutObjectLegalHold` succeeds (no MalformedPolicy)
- [x] Unit: `test_access_policy_utils.test.js` accepts `s3:PutObjectLegalHold`
- [x] Integration: `test_s3_bucket_policy.js` — principal with only `s3:PutObjectLegalHold` can put legal hold; other principal is denied