### PR TITLE
DEEP_ARCHIVE | reclaim archived data via objects reclaimer BG worker

### DIFF
--- a/src/api/archive_api.js
+++ b/src/api/archive_api.js
@@ -35,6 +35,40 @@ module.exports = {
             auth: { system: 'admin' }
         },
 
+        delete_archive_objects: {
+            method: 'POST',
+            params: {
+                type: 'object',
+                required: ['bucket_id', 'objects'],
+                properties: {
+                    bucket_id: { objectid: true },
+                    objects: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            required: ['obj_id'],
+                            properties: {
+                                obj_id: { objectid: true },
+                                key: { type: 'string' },
+                            }
+                        }
+                    },
+                }
+            },
+            reply: {
+                type: 'object',
+                required: ['reclaimed_ids', 'has_errors'],
+                properties: {
+                    reclaimed_ids: {
+                        type: 'array',
+                        items: { objectid: true },
+                    },
+                    has_errors: { type: 'boolean' },
+                }
+            },
+            auth: { system: 'admin' }
+        },
+
     },
 
     definitions: {

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -8,7 +8,6 @@ const { get_archive_key, throw_if_restore_incomplete } = require('../util/deep_a
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { get_create_object_upload_params, get_complete_object_upload_params } = require('../util/object_utils');
 
-
 /**
  * NamespaceMultiStorageClass routes operations to different namespaces based on
  * the object's storage class — analogous to NamespaceMerge, but keyed by
@@ -266,10 +265,8 @@ class NamespaceMultiStorageClass {
     ///////////////////
 
     /**
-     * Deletes object metadata via the default (STANDARD) namespace only.
-     *
-     * For deep archive objects, a separate BG worker (similar to objects_reclaimer)
-     * will delete the actual archive data asynchronously.
+     * Deletes the object MD from the default namespace. Archive data cleanup
+     * (DEEP_ARCHIVE / GLACIER objects) is handled asynchronously by ObjectsReclaimer.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
@@ -279,10 +276,8 @@ class NamespaceMultiStorageClass {
     }
 
     /**
-     * Deletes object metadata via the default (STANDARD) namespace only.
-     *
-     * For deep archive objects, a separate BG worker (similar to objects_reclaimer)
-     * will delete the actual archive data asynchronously.
+     * Deletes object metadata from the default namespace. Archive data cleanup
+     * (DEEP_ARCHIVE / GLACIER objects) is handled asynchronously by ObjectsReclaimer.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object[]>}
@@ -441,8 +436,8 @@ class NamespaceMultiStorageClass {
      *
      * Failure cleanup: abort_object_upload only soft-deletes the NB MD
      * (sets `deleted`). It does not remove data already written to target_ns.
-     * A dedicated BG worker will delete archive objects for deleted object_mds
-     * (same path as user DeleteObject), using get_archive_key(bucket_id, obj_id).
+     * ObjectsReclaimer deletes archive objects for deleted object_mds,
+     * using get_archive_key(bucket_id, obj_id).
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @param {{ storage_class: string, target_ns: nb.Namespace }} options
@@ -496,6 +491,5 @@ class NamespaceMultiStorageClass {
         return this.namespace_by_storage_class[sc] || this.namespace_by_storage_class[this.default_storage_class];
     }
 }
-
 
 module.exports = NamespaceMultiStorageClass;

--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -1,7 +1,16 @@
 /* Copyright (C) 2026 NooBaa */
 'use strict';
 
+const config = require('../../../config');
 const dbg = require('../../util/debug_module')(__filename);
+const system_store = require('../system_services/system_store').get_instance();
+const pool_server = require('../system_services/pool_server');
+const NamespaceS3 = require('../../sdk/namespace_s3');
+const noobaa_s3_client = require('../../sdk/noobaa_s3_client/noobaa_s3_client');
+const { get_archive_key } = require('../../util/deep_archive_utils');
+
+// Max batch size for S3 DeleteObjects — AWS accepts at most 1000 keys per request.
+const S3_DELETE_OBJECTS_BATCH_SIZE = 1000;
 
 /* 
     This function will transition an object from Standard storage class to Deep Archive storage class.
@@ -12,4 +21,85 @@ async function archive_object(req) {
     throw new Error('archive_object not yet implemented');
 }
 
+/**
+ * Sets up a NamespaceS3 pointed at the bucket's archive endpoint.
+ * Uses get_namespace_resource_extended_info (same as read_bucket_sdk_info)
+ * so connection fields are flattened for NamespaceS3.
+ * Returns undefined if the bucket has no archive policy or resource.
+ * @param {string} bucket_id
+ * @returns {NamespaceS3 | undefined}
+ */
+function setup_archive_ns_for_bucket(bucket_id) {
+    const bucket = system_store.data.get_by_id(bucket_id);
+    const archive_resource = bucket?.archive_policy?.deep_archive_resource?.resource;
+    if (!archive_resource) return;
+
+    const ns_info = pool_server.get_namespace_resource_extended_info(archive_resource);
+    if (!ns_info?.endpoint) return;
+
+    return new NamespaceS3({
+        namespace_resource_id: ns_info.id,
+        bucket: ns_info.target_bucket,
+        s3_params: {
+            endpoint: ns_info.endpoint,
+            aws_sts_arn: ns_info.aws_sts_arn,
+            credentials: {
+                accessKeyId: ns_info.access_key.unwrap(),
+                secretAccessKey: ns_info.secret_key.unwrap(),
+            },
+            region: ns_info.region || config.DEFAULT_REGION,
+            forcePathStyle: true,
+            requestHandler: noobaa_s3_client.get_requestHandler_with_suitable_agent(ns_info.endpoint),
+            requestChecksumCalculation: 'WHEN_REQUIRED',
+            access_mode: ns_info.access_mode,
+        },
+    });
+}
+
+/**
+ * Deletes remote archive keys for objects of one bucket.
+ * Archive keys are unique per object target_bucket/noobaa_storage/bucket_id/obj_id
+ * therefore, no need to specify a specific version).
+ * @param {*} req
+ * @returns {Promise<{ reclaimed_ids: object[], has_errors: boolean }>}
+ */
+async function delete_archive_objects(req) {
+    const { bucket_id, objects } = req.rpc_params;
+    const archive_ns = setup_archive_ns_for_bucket(bucket_id);
+    if (!archive_ns) {
+        dbg.error(`bucket ${bucket_id} has no archive namespace, skipping ${objects.length} objects`);
+        return { reclaimed_ids: [], has_errors: true };
+    }
+
+    const reclaimed_ids = [];
+    let has_errors = false;
+    const bucket = archive_ns.get_bucket();
+
+    for (let start = 0; start < objects.length; start += S3_DELETE_OBJECTS_BATCH_SIZE) {
+        const objects_batch = objects.slice(start, start + S3_DELETE_OBJECTS_BATCH_SIZE);
+        const archive_keys = objects_batch.map(obj => ({ key: get_archive_key(bucket_id, obj.obj_id) }));
+        try {
+            const results = await archive_ns.delete_multiple_objects({ bucket, objects: archive_keys }, null);
+            const failed = [];
+            for (const [i, result] of results.entries()) {
+                if (result?.err_code) {
+                    failed.push({ key: objects_batch[i].key, archive_key: archive_keys[i].key, ...result });
+                } else {
+                    reclaimed_ids.push(objects_batch[i].obj_id);
+                }
+            }
+            if (failed.length) {
+                has_errors = true;
+                dbg.error('failed to delete archive objects for bucket', bucket_id, failed);
+            }
+        } catch (err) {
+            dbg.error('delete_multiple_objects failed for bucket', bucket_id, err);
+            has_errors = true;
+        }
+    }
+
+    return { reclaimed_ids, has_errors };
+}
+
 exports.archive_object = archive_object;
+exports.delete_archive_objects = delete_archive_objects;

--- a/src/server/bg_services/objects_reclaimer.js
+++ b/src/server/bg_services/objects_reclaimer.js
@@ -7,6 +7,8 @@ const MDStore = require('../object_services/md_store').MDStore;
 const system_store = require('../system_services/system_store').get_instance();
 const system_utils = require('../utils/system_utils');
 const map_deleter = require('../object_services/map_deleter');
+const auth_server = require('../common_services/auth_server');
+const deep_archive_utils = require('../../util/deep_archive_utils');
 const P = require('../../util/promise');
 
 class ObjectsReclaimer {
@@ -16,6 +18,15 @@ class ObjectsReclaimer {
         this.client = client;
     }
 
+    /**
+     * Reclaim unreclaimed deleted objects:
+     * - STANDARD / tiering: map_deleter, then mark reclaimed.
+     * - Remote archive (archive SC + bucket archive_policy): map_deleter only if
+     *   restore_status is set, then delete remote keys and mark reclaimed.
+     *   map_deleter must succeed before the object is queued for remote delete;
+     *   if mapping cleanup throws, we skip enqueue so the object is not marked
+     *   reclaimed while restore copies may still remain.
+     */
     async run_batch() {
         if (!this._can_run()) return;
 
@@ -28,22 +39,41 @@ class ObjectsReclaimer {
         let has_errors = false;
         dbg.log0('object_reclaimer: starting batch work on objects: ', unreclaimed_objects.map(o => o.key).join(', '));
         const reclaimed_objects_ids = [];
+        /** @type {{ [bucket_id: string]: object[] }} */
+        const pending_archive_deletes_by_bucket = {};
+
         await P.all(unreclaimed_objects.map(async obj => {
             try {
-                await map_deleter.delete_object_mappings(obj);
+                const bucket = system_store.data.get_by_id(obj.bucket);
+                const is_remote_archive = deep_archive_utils.is_remote_archive_object(obj, bucket);
+                const should_delete_mappings = is_remote_archive ? Boolean(obj.restore_status) : true;
+                if (should_delete_mappings) {
+                    await map_deleter.delete_object_mappings(obj);
+                }
+                if (is_remote_archive) {
+                    const bucket_id = String(obj.bucket);
+                    (pending_archive_deletes_by_bucket[bucket_id] ??= []).push(obj);
+                    return;
+                }
                 reclaimed_objects_ids.push(obj._id);
             } catch (err) {
                 dbg.error(`got error when trying to delete object ${obj.key} mappings :`, err);
                 has_errors = true;
             }
         }));
+
+        if (Object.keys(pending_archive_deletes_by_bucket).length) {
+            const archive_result = await this._delete_archived_objects(pending_archive_deletes_by_bucket);
+            reclaimed_objects_ids.push(...archive_result.reclaimed_ids);
+            has_errors = has_errors || archive_result.has_errors;
+        }
+
         await MDStore.instance().update_objects_by_ids(reclaimed_objects_ids, { reclaimed: new Date() });
 
         if (has_errors) {
             return config.OBJECT_RECLAIMER_ERROR_DELAY;
         }
         return config.OBJECT_RECLAIMER_BATCH_DELAY;
-
     }
 
     _can_run() {
@@ -56,6 +86,40 @@ class ObjectsReclaimer {
         if (!system || system_utils.system_in_maintenance(system._id)) return false;
 
         return true;
+    }
+
+    ////////////////////////
+    // DEEP ARCHIVE UTILS //
+    ////////////////////////
+
+    /**
+     * Per bucket, deletes archive keys via archive_api.
+     * @param {{ [bucket_id: string]: object[] }} pending_archive_deletes_by_bucket
+     * @returns {Promise<{ reclaimed_ids: object[], has_errors: boolean }>}
+     */
+    async _delete_archived_objects(pending_archive_deletes_by_bucket) {
+        const system = system_store.data.systems[0];
+        const auth_token = auth_server.make_auth_token({
+            system_id: system._id,
+            account_id: system.owner._id,
+            role: 'admin',
+        });
+        const reclaimed_ids = [];
+        let has_errors = false;
+
+        await P.all(Object.entries(pending_archive_deletes_by_bucket).map(async ([bucket_id, objects]) => {
+            try {
+                const objects_to_delete = objects.map(obj => ({ obj_id: obj._id, key: obj.key }));
+                const result = await this.client.archive.delete_archive_objects({ bucket_id, objects: objects_to_delete }, { auth_token });
+                reclaimed_ids.push(...result.reclaimed_ids);
+                has_errors = has_errors || result.has_errors;
+            } catch (err) {
+                dbg.error(`failed deleting archived objects for bucket ${bucket_id}:`, err);
+                has_errors = true;
+            }
+        }));
+
+        return { reclaimed_ids, has_errors };
     }
 
 }

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -1,4 +1,6 @@
 /* Copyright (C) 2026 NooBaa */
+/* eslint-disable max-lines-per-function */
+
 'use strict';
 
 // setup coretest first to prepare the env
@@ -16,6 +18,13 @@ const http_utils = require('../../../../util/http_utils');
 const s3_utils = require('../../../../endpoint/s3/s3_utils');
 const { get_archive_key } = require('../../../../util/deep_archive_utils');
 const test_utils = require('../../../system_tests/test_utils');
+const { MDStore } = require('../../../../server/object_services/md_store');
+const db_client = require('../../../../util/db_client');
+const { ObjectsReclaimer } = require('../../../../server/bg_services/objects_reclaimer');
+const { BucketsReclaimer } = require('../../../../server/bg_services/buckets_reclaimer');
+const lifecycle = require('../../../../server/bg_services/lifecycle');
+const commonTests = require('../../../lifecycle/common');
+const system_store = require('../../../../server/system_services/system_store').get_instance();
 
 const { rpc_client, EMAIL } = coretest;
 
@@ -37,18 +46,117 @@ function err_code(err) {
 }
 
 /**
- * Asserts archived object MD and that payload lives under get_archive_key on the archive target.
- * @param {{ key: string, buf: Buffer, storage_class: string }} args
+ * @param {string} obj_id
+ * @returns {nb.ID}
+ */
+function parse_obj_id(obj_id) {
+    return db_client.instance().parse_object_id(obj_id);
+}
+
+/**
+ * @param {string} bid
+ * @param {string} obj_id
+ * @returns {Promise<Buffer>}
+ */
+async function get_archive_body(bid, obj_id) {
+    const archived = await s3.getObject({
+        Bucket: ARCHIVE_TARGET_BUCKET,
+        Key: get_archive_key(bid, obj_id),
+    });
+    return Buffer.from(await archived.Body.transformToByteArray());
+}
+
+/**
+ * @param {string} bid
+ * @param {string} obj_id
  * @returns {Promise<void>}
  */
-async function assert_archived_via_s3({ key, buf, storage_class }) {
-    const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+async function assert_archive_absent(bid, obj_id) {
+    await assert.rejects(
+        s3.headObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: get_archive_key(bid, obj_id) }),
+        err => err_code(err) === 'NotFound' || err_code(err) === 'NoSuchKey'
+    );
+}
+
+/**
+ * @param {string} bucket
+ * @param {string} key
+ * @returns {Promise<void>}
+ */
+async function assert_md_absent(bucket, key) {
+    await assert.rejects(
+        rpc_client.object.read_object_md({ bucket, key }),
+        err => err.rpc_code === 'NO_SUCH_OBJECT'
+    );
+}
+
+/**
+ * @param {string} obj_id
+ * @returns {Promise<boolean>}
+ */
+async function object_has_parts(obj_id) {
+    return MDStore.instance().has_any_parts_for_object({ _id: parse_obj_id(obj_id) });
+}
+
+/**
+ * Soft-deleted MD still exists and is not yet marked reclaimed.
+ * Check by id — find_unreclaimed_objects(limit) can miss the object under a
+ * shared coretest DB where unreclaimed leftovers fill the limited batch.
+ * @param {string} obj_id
+ * @returns {Promise<void>}
+ */
+async function assert_object_unreclaimed(obj_id) {
+    const obj = await MDStore.instance().find_object_by_id(parse_obj_id(obj_id));
+    assert.ok(obj?.deleted && !obj.reclaimed, 'expected deleted archive object to be unreclaimed');
+}
+
+/**
+ * @param {string} obj_id
+ * @returns {Promise<void>}
+ */
+async function assert_object_reclaimed(obj_id) {
+    const obj = await MDStore.instance().find_object_by_id(parse_obj_id(obj_id));
+    assert.ok(obj?.reclaimed, 'expected archive object to be marked reclaimed');
+}
+
+/**
+ * Drain ObjectsReclaimer until every given object is marked reclaimed.
+ * find_unreclaimed_objects is hard-capped at 1000, so one batch is not enough
+ * when earlier suites leave a large unreclaimed backlog.
+ * @param {...string} obj_ids
+ * @returns {Promise<void>}
+ */
+async function run_objects_reclaimer(...obj_ids) {
+    assert.ok(obj_ids.length, 'run_objects_reclaimer requires at least one obj_id');
+    const ids = obj_ids.map(parse_obj_id);
+    const reclaimer = new ObjectsReclaimer({ name: 'test_object_reclaimer', client: rpc_client });
+
+    for (let i = 0; i < 1000; i++) {
+        const objs = await MDStore.instance().find_objects_by_id(ids);
+        if (objs.length === ids.length && objs.every(o => o.reclaimed)) return;
+
+        const delay = await reclaimer.run_batch();
+        if (delay === config.OBJECT_RECLAIMER_EMPTY_DELAY) break;
+    }
+
+    const objs = await MDStore.instance().find_objects_by_id(ids);
+    assert.ok(
+        objs.length === ids.length && objs.every(o => o.reclaimed),
+        `objects not reclaimed: ${obj_ids.join(', ')}`
+    );
+}
+
+/**
+ * Asserts archived object MD and that payload lives under get_archive_key on the archive target.
+ * @param {{ key: string, buf: Buffer, storage_class: string, bucket?: string, bid?: string }} args
+ * @returns {Promise<void>}
+ */
+async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET, bid = bucket_id }) {
+    const md = await rpc_client.object.read_object_md({ bucket, key });
     assert.strictEqual(md.storage_class, storage_class);
     assert.strictEqual(md.size, buf.length);
 
-    const archive_key = get_archive_key(bucket_id, md.obj_id);
-    const archived = await s3.getObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: archive_key });
-    const archived_body = Buffer.from(await archived.Body.transformToByteArray());
+    const archived_body = await get_archive_body(bid, md.obj_id);
     assert.strictEqual(Buffer.compare(archived_body, buf), 0);
 
     await assert.rejects(
@@ -57,9 +165,132 @@ async function assert_archived_via_s3({ key, buf, storage_class }) {
     );
 
     await assert.rejects(
-        s3.getObject({ Bucket: BUCKET, Key: key }),
+        s3.getObject({ Bucket: bucket, Key: key }),
         err => err_code(err) === 'InvalidObjectState'
     );
+}
+
+/**
+ * Puts a DEEP_ARCHIVE object via S3 and returns its md.
+ * @param {{ bucket?: string, key: string, buf: Buffer }} args
+ * @returns {Promise<object>}
+ */
+async function put_deep_archive({ bucket = BUCKET, key, buf }) {
+    await s3.putObject({
+        Bucket: bucket,
+        Key: key,
+        Body: buf,
+        ContentType: 'application/octet-stream',
+        StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+    });
+    return rpc_client.object.read_object_md({ bucket, key });
+}
+
+/**
+ * Puts a STANDARD object via S3 and returns its md.
+ * @param {{ bucket?: string, key: string, buf: Buffer }} args
+ * @returns {Promise<object>}
+ */
+async function put_standard({ bucket = BUCKET, key, buf }) {
+    await s3.putObject({
+        Bucket: bucket,
+        Key: key,
+        Body: buf,
+        ContentType: 'application/octet-stream',
+        StorageClass: s3_utils.STORAGE_CLASS_STANDARD,
+    });
+    return rpc_client.object.read_object_md({ bucket, key });
+}
+
+/**
+ * Simulates an actively restored archive object:
+ * STANDARD upload (NB restore copy) + archive payload + MD marked DEEP_ARCHIVE with restore_status.
+ * RestoreObject is not implemented yet, so tests seed this state via MDStore.
+ * @param {{ bucket?: string, bid?: string, key: string, buf: Buffer }} args
+ * @returns {Promise<object>}
+ */
+async function simulate_put_restored_deep_archive({ bucket = BUCKET, bid = bucket_id, key, buf }) {
+    const md = await put_standard({ bucket, key, buf });
+    await s3.putObject({
+        Bucket: ARCHIVE_TARGET_BUCKET,
+        Key: get_archive_key(bid, md.obj_id),
+        Body: buf,
+        ContentType: 'application/octet-stream',
+    });
+    await MDStore.instance().update_object_by_id(parse_obj_id(md.obj_id), {
+        storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        restore_status: {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z'),
+        },
+    });
+    return rpc_client.object.read_object_md({ bucket, key });
+}
+
+/**
+ * Creates a dedicated archive-policy bucket for tests that destroy the bucket.
+ * @param {string} name
+ * @returns {Promise<string>} bucket id
+ */
+async function create_archive_bucket(name) {
+    await rpc_client.bucket.create_bucket({
+        name,
+        archive_policy: {
+            deep_archive_resource: { resource: ARCHIVE_NSR },
+        },
+    });
+    const info = await rpc_client.bucket.read_bucket_sdk_info({ name });
+    return String(info._id);
+}
+
+/**
+ * Soft-deletes all objects on a deleting bucket, runs ObjectsReclaimer while
+ * archive_policy is still available, then finishes BucketsReclaimer.
+ * @param {string} bid
+ * @param {...string} obj_ids
+ * @returns {Promise<void>}
+ */
+async function reclaim_deleting_bucket(bid, ...obj_ids) {
+    const deleting_bucket = system_store.data.buckets.find(
+        b => Boolean(b.deleting) && String(b._id) === String(bid)
+    );
+    assert.ok(deleting_bucket, 'expected bucket to be marked deleting');
+    const deleting_name = deleting_bucket.name.unwrap ?
+        deleting_bucket.name.unwrap() :
+        String(deleting_bucket.name);
+
+    // Soft-delete MD without removing the bucket yet (archive_policy still needed).
+    let is_empty = false;
+    while (!is_empty) {
+        const reply = await rpc_client.object.delete_multiple_objects_unordered({
+            bucket: deleting_name,
+            limit: config.BUCKET_RECLAIMER_BATCH_SIZE,
+        });
+        is_empty = reply.is_empty;
+    }
+
+    await run_objects_reclaimer(...obj_ids);
+
+    const buckets_reclaimer = new BucketsReclaimer({
+        name: 'test_bucket_reclaimer',
+        client: rpc_client,
+    });
+    await buckets_reclaimer.run_batch();
+
+    const bucket_still_present = system_store.data.buckets.some(b => String(b._id) === String(bid));
+    assert.ok(!bucket_still_present, 'expected bucket to be removed from system_store');
+}
+
+/**
+ * Backdates object create_time so an absolute Date lifecycle rule expires it.
+ * @param {string} obj_id
+ * @param {number} age_days
+ * @returns {Promise<void>}
+ */
+async function backdate_object(obj_id, age_days) {
+    const create_time = new Date();
+    create_time.setDate(create_time.getDate() - age_days);
+    await MDStore.instance().update_object_by_id(parse_obj_id(obj_id), { create_time });
 }
 
 mocha.describe('deep_archive_via_s3', function() {
@@ -323,6 +554,231 @@ mocha.describe('deep_archive_via_s3', function() {
     });
 
     }); // CopyObject
+
+    mocha.describe('DeleteObject', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        mocha.it('deleteObject on DEEP_ARCHIVE removes MD immediately but leaves archive data until reclaim', async function() {
+            const key = 's3-delete/deep-archive';
+            const buf = Buffer.from('delete-deep-archive-payload');
+            const md = await put_deep_archive({ key, buf });
+            const obj_id = md.obj_id;
+
+            await s3.deleteObject({ Bucket: BUCKET, Key: key });
+
+            await assert_md_absent(BUCKET, key);
+            const archived_body = await get_archive_body(bucket_id, obj_id);
+            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+            await assert_object_unreclaimed(obj_id);
+
+            await run_objects_reclaimer(obj_id);
+
+            await assert_archive_absent(bucket_id, obj_id);
+            await assert_object_reclaimed(obj_id);
+        });
+
+        mocha.it('deleteObject on restored DEEP_ARCHIVE cleans restore copy and archive on reclaim', async function() {
+            const key = 's3-delete/restored-deep-archive';
+            const buf = Buffer.from('delete-restored-archive-payload');
+            const md = await simulate_put_restored_deep_archive({ key, buf });
+            const obj_id = md.obj_id;
+            const has_parts_before = await object_has_parts(obj_id);
+            assert.ok(has_parts_before, 'expected restore copy parts before delete');
+
+            await s3.deleteObject({ Bucket: BUCKET, Key: key });
+
+            await assert_md_absent(BUCKET, key);
+            const has_parts_after_delete = await object_has_parts(obj_id);
+            assert.ok(has_parts_after_delete, 'restore copy parts remain until reclaim');
+            const archived_body = await get_archive_body(bucket_id, obj_id);
+            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+
+            await run_objects_reclaimer(obj_id);
+
+            await assert_archive_absent(bucket_id, obj_id);
+            const has_parts_after_reclaim = await object_has_parts(obj_id);
+            assert.ok(!has_parts_after_reclaim, 'expected restore copy parts deleted on reclaim');
+            await assert_object_reclaimed(obj_id);
+        });
+    });
+
+    mocha.describe('DeleteMultipleObjects', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        mocha.it('deleteObjects mixes STANDARD and DEEP_ARCHIVE; archive cleaned on reclaim', async function() {
+            const std_key = 's3-mdelete/standard';
+            const arch_key = 's3-mdelete/deep-archive';
+            const std_buf = Buffer.from('mdelete-standard');
+            const arch_buf = Buffer.from('mdelete-deep-archive');
+
+            const std_md = await put_standard({ key: std_key, buf: std_buf });
+            const arch_md = await put_deep_archive({ key: arch_key, buf: arch_buf });
+
+            const delete_res = await s3.deleteObjects({
+                Bucket: BUCKET,
+                Delete: {
+                    Objects: [{ Key: std_key }, { Key: arch_key }],
+                    Quiet: false,
+                },
+            });
+            assert.strictEqual((delete_res.Deleted || []).length, 2);
+            const delete_errors = delete_res.Errors || [];
+            assert.strictEqual(delete_errors.length, 0);
+
+            await assert_md_absent(BUCKET, std_key);
+            await assert_md_absent(BUCKET, arch_key);
+            const archived_body = await get_archive_body(bucket_id, arch_md.obj_id);
+            assert.strictEqual(Buffer.compare(archived_body, arch_buf), 0);
+
+            await run_objects_reclaimer(std_md.obj_id, arch_md.obj_id);
+
+            await assert_archive_absent(bucket_id, arch_md.obj_id);
+            await assert_object_reclaimed(std_md.obj_id);
+            await assert_object_reclaimed(arch_md.obj_id);
+        });
+
+        mocha.it('deleteObjects mixes STANDARD and restored DEEP_ARCHIVE; both copies cleaned on reclaim', async function() {
+            const std_key = 's3-mdelete/std-with-restored';
+            const arch_key = 's3-mdelete/restored-deep-archive';
+            const std_buf = Buffer.from('mdelete-std-restored-mix');
+            const arch_buf = Buffer.from('mdelete-restored-archive');
+
+            const std_md = await put_standard({ key: std_key, buf: std_buf });
+            const arch_md = await simulate_put_restored_deep_archive({ key: arch_key, buf: arch_buf });
+            const has_parts_before = await object_has_parts(arch_md.obj_id);
+            assert.ok(has_parts_before);
+
+            await s3.deleteObjects({
+                Bucket: BUCKET,
+                Delete: {
+                    Objects: [{ Key: std_key }, { Key: arch_key }],
+                    Quiet: true,
+                },
+            });
+
+            await assert_md_absent(BUCKET, std_key);
+            await assert_md_absent(BUCKET, arch_key);
+            const has_parts_after_delete = await object_has_parts(arch_md.obj_id);
+            assert.ok(has_parts_after_delete);
+            await get_archive_body(bucket_id, arch_md.obj_id);
+
+            await run_objects_reclaimer(std_md.obj_id, arch_md.obj_id);
+
+            await assert_archive_absent(bucket_id, arch_md.obj_id);
+            const arch_has_parts = await object_has_parts(arch_md.obj_id);
+            const std_has_parts = await object_has_parts(std_md.obj_id);
+            assert.ok(!arch_has_parts);
+            assert.ok(!std_has_parts);
+            await assert_object_reclaimed(std_md.obj_id);
+            await assert_object_reclaimed(arch_md.obj_id);
+        });
+    });
+
+    mocha.describe('Bucket reclaim', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        mocha.it('reclaims bucket with STANDARD and DEEP_ARCHIVE objects', async function() {
+            const name = `test-s3-bucket-reclaim-${Date.now()}`;
+            const bid = await create_archive_bucket(name);
+            const std_key = 'breclaim/standard';
+            const arch_key = 'breclaim/deep-archive';
+            const std_buf = Buffer.from('bucket-reclaim-standard');
+            const arch_buf = Buffer.from('bucket-reclaim-deep-archive');
+
+            const std_md = await put_standard({ bucket: name, key: std_key, buf: std_buf });
+            const arch_md = await put_deep_archive({ bucket: name, key: arch_key, buf: arch_buf });
+            await assert_archived_via_s3({
+                bucket: name,
+                bid,
+                key: arch_key,
+                buf: arch_buf,
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            });
+
+            await rpc_client.bucket.delete_bucket_and_objects({ name });
+            await reclaim_deleting_bucket(bid, std_md.obj_id, arch_md.obj_id);
+
+            await assert_archive_absent(bid, arch_md.obj_id);
+            await assert_object_reclaimed(std_md.obj_id);
+            await assert_object_reclaimed(arch_md.obj_id);
+        });
+
+        mocha.it('reclaims bucket with STANDARD and restored DEEP_ARCHIVE objects', async function() {
+            const name = `test-s3-bucket-reclaim-restored-${Date.now()}`;
+            const bid = await create_archive_bucket(name);
+            const std_key = 'breclaim/std';
+            const arch_key = 'breclaim/restored';
+            const std_buf = Buffer.from('bucket-reclaim-std-restored');
+            const arch_buf = Buffer.from('bucket-reclaim-restored-archive');
+
+            const std_md = await put_standard({ bucket: name, key: std_key, buf: std_buf });
+            const arch_md = await simulate_put_restored_deep_archive({ bucket: name, bid, key: arch_key, buf: arch_buf });
+            const has_parts_before = await object_has_parts(arch_md.obj_id);
+            assert.ok(has_parts_before);
+
+            await rpc_client.bucket.delete_bucket_and_objects({ name });
+            await reclaim_deleting_bucket(bid, std_md.obj_id, arch_md.obj_id);
+
+            await assert_archive_absent(bid, arch_md.obj_id);
+            const arch_has_parts = await object_has_parts(arch_md.obj_id);
+            const std_has_parts = await object_has_parts(std_md.obj_id);
+            assert.ok(!arch_has_parts);
+            assert.ok(!std_has_parts);
+            await assert_object_reclaimed(std_md.obj_id);
+            await assert_object_reclaimed(arch_md.obj_id);
+        });
+    });
+
+    mocha.describe('Lifecycle expiry', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        mocha.before(function() {
+            config.LIFECYCLE_SCHEDULE_MIN = 0;
+            config.LIFECYCLE_INTERVAL = 0;
+        });
+
+        mocha.it('lifecycle expiry soft-deletes DEEP_ARCHIVE; reclaim removes archive data', async function() {
+            const prefix = `s3-lifecycle/da-${Date.now()}`;
+            const key = `${prefix}/obj`;
+            const buf = Buffer.from('lifecycle-deep-archive');
+            const md = await put_deep_archive({ key, buf });
+            await backdate_object(md.obj_id, 17);
+
+            await s3.putBucketLifecycleConfiguration(commonTests.date_lifecycle_configuration(BUCKET, prefix));
+            await lifecycle.background_worker();
+
+            await assert_md_absent(BUCKET, key);
+            const archived_body = await get_archive_body(bucket_id, md.obj_id);
+            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+
+            await run_objects_reclaimer(md.obj_id);
+            await assert_archive_absent(bucket_id, md.obj_id);
+        });
+
+        mocha.it('lifecycle expiry on restored DEEP_ARCHIVE cleans restore copy and archive on reclaim', async function() {
+            const prefix = `s3-lifecycle/restored-${Date.now()}`;
+            const key = `${prefix}/obj`;
+            const buf = Buffer.from('lifecycle-restored-archive');
+            const md = await simulate_put_restored_deep_archive({ key, buf });
+            const has_parts_before = await object_has_parts(md.obj_id);
+            assert.ok(has_parts_before);
+            await backdate_object(md.obj_id, 17);
+
+            await s3.putBucketLifecycleConfiguration(commonTests.date_lifecycle_configuration(BUCKET, prefix));
+            await lifecycle.background_worker();
+
+            await assert_md_absent(BUCKET, key);
+            const has_parts_after_expiry = await object_has_parts(md.obj_id);
+            assert.ok(has_parts_after_expiry);
+            await get_archive_body(bucket_id, md.obj_id);
+
+            await run_objects_reclaimer(md.obj_id);
+
+            await assert_archive_absent(bucket_id, md.obj_id);
+            const has_parts_after_reclaim = await object_has_parts(md.obj_id);
+            assert.ok(!has_parts_after_reclaim);
+        });
+    });
 
     // TODO: add GetObject tests (STANDARD read, unrestored / ongoing / expired restore →
     // InvalidObjectState, restored archive read) once RestoreObject is implemented.

--- a/src/test/unit_tests/internal/test_deep_archive_s3.js
+++ b/src/test/unit_tests/internal/test_deep_archive_s3.js
@@ -9,6 +9,8 @@ const mocha = require('mocha');
 const assert = require('assert');
 const config = require('../../../../config');
 const pool_server = require('../../../server/system_services/pool_server');
+const s3_utils = require('../../../endpoint/s3/s3_utils');
+const { is_remote_archive_object } = require('../../../util/deep_archive_utils');
 
 const { rpc_client, EMAIL } = coretest;
 
@@ -213,5 +215,20 @@ mocha.describe('archive_policy', function() {
         });
         info = await rpc_client.bucket.read_bucket({ name: UPDATE_ARCHIVE_BUCKET });
         assert.ok(!info.archive_policy);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deep_archive_utils – pure helpers (no system mocks)
+// ---------------------------------------------------------------------------
+
+mocha.describe('deep_archive_utils', function() {
+    mocha.it('is_remote_archive_object requires glacier SC and bucket deep_archive_resource', function() {
+        const archive_bucket = { archive_policy: { deep_archive_resource: { resource: 'nsr' } } };
+        assert.strictEqual(is_remote_archive_object({ storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE }, archive_bucket), true);
+        assert.strictEqual(is_remote_archive_object({ storage_class: s3_utils.STORAGE_CLASS_GLACIER }, archive_bucket), true);
+        assert.strictEqual(is_remote_archive_object({ storage_class: s3_utils.STORAGE_CLASS_STANDARD }, archive_bucket), false);
+        assert.strictEqual(is_remote_archive_object({ storage_class: s3_utils.STORAGE_CLASS_GLACIER }, {}), false);
+        assert.strictEqual(is_remote_archive_object({ storage_class: s3_utils.STORAGE_CLASS_GLACIER_IR }, archive_bucket), false);
     });
 });

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
@@ -1,4 +1,5 @@
 /* Copyright (C) 2026 NooBaa */
+/* eslint-disable max-lines-per-function */
 'use strict';
 
 // setup coretest first to prepare the env
@@ -23,6 +24,9 @@ const { get_archive_key } = require('../../../util/deep_archive_utils');
 const endpoint_stats_collector = require('../../../sdk/endpoint_stats_collector');
 const S3Error = require('../../../endpoint/s3/s3_errors').S3Error;
 const test_utils = require('../../system_tests/test_utils');
+const { ObjectsReclaimer } = require('../../../server/bg_services/objects_reclaimer');
+const { MDStore } = require('../../../server/object_services/md_store');
+const db_client = require('../../../util/db_client');
 
 const { rpc_client, EMAIL } = coretest;
 
@@ -350,10 +354,9 @@ mocha.describe('NamespaceMultiStorageClass', function() {
             err => err.rpc_code === 'NO_SUCH_OBJECT' || err.rpc_code === 'NO_SUCH_UPLOAD'
         );
     });
+});
 
-    }); // upload_object
-
-    mocha.describe('CopyObject (stream fallback)', function() {
+mocha.describe('CopyObject (stream fallback)', function() {
 
     mocha.it('disables server-side copy so ObjectSDK uses the stream fallback', function() {
         const { msc } = get_new_multi_storage_class_namespace();
@@ -499,10 +502,9 @@ mocha.describe('NamespaceMultiStorageClass', function() {
             err => err.rpc_code === 'NO_SUCH_OBJECT'
         );
     });
+});
 
-    }); // CopyObject (stream fallback)
-
-    mocha.describe('read_object_stream', function() {
+mocha.describe('read_object_stream', function() {
 
     mocha.it('reads STANDARD objects from the metadata namespace', async function() {
         const { msc } = get_new_multi_storage_class_namespace();
@@ -580,7 +582,69 @@ mocha.describe('NamespaceMultiStorageClass', function() {
         const read_buf = await buffer_utils.read_stream_join(read_stream);
         assert.strictEqual(Buffer.compare(read_buf, buf), 0);
     });
+});
 
-    }); // read_object_stream
+mocha.describe('delete_object', function() {
 
-}); // NamespaceMultiStorageClass
+    mocha.it('delete_object removes MD immediately but leaves archive data until reclaim', async function() {
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const key = 'archive/delete-leaves-data';
+        const buf = Buffer.from('delete-leaves-archive-payload');
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE });
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        const archive_key = get_archive_key(bucket_id, md.obj_id);
+
+        await msc.delete_object({ bucket: BUCKET, key }, object_sdk);
+
+        await assert.rejects(
+            rpc_client.object.read_object_md({ bucket: BUCKET, key }),
+            err => err.rpc_code === 'NO_SUCH_OBJECT'
+        );
+
+        // Archive-side object is still present until ObjectsReclaimer runs
+        const archived_stream = await arch_ns.read_object_stream({
+            bucket: ARCHIVE_TARGET_BUCKET,
+            key: archive_key,
+        }, object_sdk);
+        const archived_buf = await buffer_utils.read_stream_join(archived_stream);
+        assert.strictEqual(Buffer.compare(archived_buf, buf), 0);
+    });
+
+    mocha.it('ObjectsReclaimer deletes archive-side data for unreclaimed DEEP_ARCHIVE objects', async function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+        const { msc, arch_ns } = get_new_multi_storage_class_namespace();
+        const key = 'archive/reclaim-cleans-data';
+        const buf = Buffer.from('reclaim-archive-payload');
+
+        await upload_buf(msc, object_sdk, { key, buf, storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE });
+        const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+        const archive_key = get_archive_key(bucket_id, md.obj_id);
+        const obj_id = db_client.instance().parse_object_id(md.obj_id);
+
+        await msc.delete_object({ bucket: BUCKET, key }, object_sdk);
+
+        // Soft-deleted MD is unreclaimed until ObjectsReclaimer runs (check by id —
+        // find_unreclaimed_objects(limit) can miss it under a shared coretest DB).
+        const deleted_obj = await MDStore.instance().find_object_by_id(obj_id);
+        assert.ok(deleted_obj?.deleted && !deleted_obj.reclaimed, 'expected deleted archive object to be unreclaimed');
+
+        // find_unreclaimed_objects is hard-capped at 1000 — drain until this object is reclaimed.
+        const reclaimer = new ObjectsReclaimer({ name: 'test_object_reclaimer', client: rpc_client });
+        for (let i = 0; i < 1000; i++) {
+            const obj = await MDStore.instance().find_object_by_id(obj_id);
+            if (obj.reclaimed) break;
+            const delay = await reclaimer.run_batch();
+            if (delay === config.OBJECT_RECLAIMER_EMPTY_DELAY) break;
+        }
+
+        await assert.rejects(
+            arch_ns.read_object_md({ bucket: ARCHIVE_TARGET_BUCKET, key: archive_key }, object_sdk),
+            err => err.rpc_code === 'NO_SUCH_OBJECT' || err.code === 'NoSuchKey' || err.name === 'NoSuchKey'
+        );
+
+        const reclaimed_obj = await MDStore.instance().find_object_by_id(obj_id);
+        assert.ok(reclaimed_obj?.reclaimed, 'expected archive object to be marked reclaimed');
+    });
+});
+});

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -21,6 +21,19 @@ function get_archive_key(bucket_id, obj_md_id) {
 }
 
 /**
+ * True when the object's data lives in a remote deep-archive namespace
+ * (GLACIER/DEEP_ARCHIVE storage class + bucket archive_policy).
+ * False for tiering GLACIER, where data lives in NB pools only.
+ * @param {{ storage_class?: string }} obj
+ * @param {{ archive_policy?: { deep_archive_resource?: object } }} [bucket]
+ * @returns {boolean}
+ */
+function is_remote_archive_object(obj, bucket) {
+    if (!GLACIER_STORAGE_CLASSES.includes(obj?.storage_class)) return false;
+    return Boolean(bucket?.archive_policy?.deep_archive_resource);
+}
+
+/**
  * For glacier/archive storage classes, throws InvalidObjectState when the object
  * is not restored yet (restore ongoing, missing expiry_time, or expiry in the past).
  * No-op otherwise.
@@ -29,14 +42,15 @@ function get_archive_key(bucket_id, obj_md_id) {
  */
 function throw_if_restore_incomplete(bucket_name, object_md) {
     if (!GLACIER_STORAGE_CLASSES.includes(object_md?.storage_class)) return;
-    const restore = object_md.restore_status;
+    const restore = object_md?.restore_status;
     const expiry_time = restore?.expiry_time && new Date(restore.expiry_time);
-    const is_restored = Boolean(expiry_time) && !restore.ongoing && expiry_time > new Date();
-    if (is_restored) return;
+    const has_active_restore = Boolean(expiry_time) && !restore.ongoing && expiry_time > new Date();
+    if (has_active_restore) return;
     // Don't try to read the object if it's not restored yet
     dbg.warn('Object is not restored yet', bucket_name, object_md.key, object_md.storage_class, restore);
     throw new S3Error(S3Error.InvalidObjectState);
 }
 
 exports.get_archive_key = get_archive_key;
+exports.is_remote_archive_object = is_remote_archive_object;
 exports.throw_if_restore_incomplete = throw_if_restore_incomplete;


### PR DESCRIPTION
### Describe the Problem
A few scenarios need async worker that will delete the data of archived objects - 
1. DeleteObject - when the object is on deep archive.
2. DeleteMultipleObjects - when some of the objects are on deep archive.
3. A lifecycle expiry rule configured on a bucket and objects that are on deep archive. 

### Explain the Changes
1. ObjectsReclaimer - add a flow that reclaims (deletes) the data of archived objects (Storage class is DEEP_ARCHIVE / GLACIER). 
Note - these objects can have restore copies, and their mapping and blocks should be reclaimed as well during the existing flow.
4. archive_server and archive_api - added setup_archive_ns_for_bucket() internal helper and delete_archive_objects_for_bucket() public RPC function.

### Issues: Fixed #xxx / Gap #xxx
 

### Testing Instructions:
Manual Tests (using first.bucket as the archive bucket) - 

Pre-requisites - 

Configure a bucket with archive policy -
```
>  k get secret noobaa-admin -o json | jq '.data | map_values(@base64d)'
>  k edit cm noobaa-config
>  k get secret noobaa-admin -o json | jq '.data | map_values(@base64d)'
>  nb namespacestore create s3-compatible ns1 --access-key=<access-key> --secret-key=<secret-key> --endpoint=https://s3.default.svc:443 --target-bucket=first.bucket --archive
> nb bucketclass create placement-bucketclass bc1 --backingstores=noobaa-default-backing-store --deep-archive-resource=ns1
> nb obc create obc1 --exact --bucketclass=bc1
>  alias s3='AWS_ACCESS_KEY_ID=<obc-access-key> AWS_SECRET_ACCESS_KEY=<obc-secret-key> aws s3 --no-verify-ssl --endpoint-url https://127.0.0.1:10443/'
> kubectl port-forward svc/s3 10443:443
```

1. Delete Object (storage class = DEEP_ARCHIVE / GLACIER ) -
```
Tab 2 - 
>  alias s3='AWS_ACCESS_KEY_ID=<obc-access-key> AWS_SECRET_ACCESS_KEY=<obc-secret-key> aws s3 --no-verify-ssl --endpoint-url https://127.0.0.1:10443/'
> echo "djaksnfksanflkmsalfmieojtoier" > obj1
>  s3 cp obj1 s3://obc1/obj1  --storage-class=DEEP_ARCHIVE
>  s3 rm s3://obc1/obj1

Tab 3 - 
> oc rsh noobaa-db-pg-cluster-1
> psql nbcore
nbcore=# select * from objects; 
// see that both object and object on archive were deleted
```

2. Delete Multiple Objects (Storage Class 
Similarly, we can run s3 delete multiple objects using s3api tool - 
```
>  alias s3api='AWS_ACCESS_KEY_ID=<obc-access-key> AWS_SECRET_ACCESS_KEY=<obc-secret-key> aws s3api --no-verify-ssl --endpoint-url https://127.0.0.1:10443/'
>  s3 cp obj1 s3://obc1/obj1  --storage-class=DEEP_ARCHIVE
>  s3 cp obj1 s3://obc1/obj2 --storage-class=GLACIER
>  s3 cp obj1 s3://obc1/obj3 
> s3api delete-objects --bucket obc1 --delete '{"Objects":[{"Key":"obj1"},{"Key":"obj2"},{"Key":"obj3"}]}'
 
and then again check in the db  they were deleted  
```

3. Expiry of objects that are on deep archive - 
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched deletion/reclamation for S3 deep-archive objects (up to 1000 keys per batch).
  * Added an admin-only archive deletion RPC that returns reclaimed object IDs and error status.
  * Updated reclamation to clean up remote/restored deep-archive artifacts at reclaim time.
* **Bug Fixes**
  * Improved “active restore” detection to avoid cleanup when restores are in progress.
  * Prevent incorrect “reclaimed” marking when archive-side cleanup fails.
* **Tests**
  * Expanded deep-archive E2E and unit tests for delete, delete-multiple, bucket reclaim, and lifecycle expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->