### PR TITLE
Fix: Change duplicate-key error/warn logs to log0

### DIFF
--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -2017,7 +2017,7 @@ async function _put_object_handle_latest_with_retries({ req, put_obj, set_update
         attempts: put_obj_attempts,
         delay_ms: 50,
         should_retry_func: err => MDStore.instance().is_err_duplicate_key(err),
-        error_logger: err => dbg.warn('got duplicate key error in _put_object_handle_latest. retrying...',
+        error_logger: err => dbg.log0('got duplicate key error in _put_object_handle_latest. retrying...',
             'bucket=', req.bucket.name, 'key=', put_obj.key, 'err=', err)
     });
 }

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -267,7 +267,7 @@ async function _do_query(pg_client, q, transaction_counter, options = {}) {
     } catch (err) {
         if (err.routine === 'index_create' && err.code === '42P07') return;
         if (log_errors) {
-            dbg.error(`postgres_client: ${tag}: failed with error:`, err);
+            dbg.log0(`postgres_client: ${tag}: failed with error:`, err);
         }
         await log_query(pg_client, q, tag, 0, /*should_explain*/ false);
         if (pg_client.retry_with_default_pool) {


### PR DESCRIPTION
### Describe the Problem
Concurrent PUTs to the same key can hit a Postgres unique-constraint error. Uploads still succeed after retry, but NooBaa logs these handled failures as ERROR/WARN and creates noisy alerts.

### Explain the Changes
1. Log `_do_query` failures in `postgres_client` at `log0` instead of error.
2. Log duplicate-key retries in `object_server` at `log0` instead of warn.

### Issues: Fixed #xxx / Gap #xxx
1.  Fixed: https://redhat.atlassian.net/browse/DFBUGS-8877

### Testing Instructions:
1. Concurrent overwrite same key, e.g.:
`seq 1 30 | xargs -P30 -I{} aws s3 cp /etc/hostname s3://<bucket>/same-key`
2. Check endpoint logs:
`kubectl -n default logs -l noobaa-s3 --tail=2000 | rg -i 'duplicate key|23505|BulkOp execute error|_put_object_handle_latest'`
3. Expect postgres_client failed with error, BulkOp execute error, and got duplicate key... retrying as `[L0]` (not `[ERROR]/[WARN]`). (Please ignore the `Bulk0p` error logs here if present)
4. Confirm PUTs still succeed (or client still gets InternalError only if retries are exhausted).


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted log verbosity/severity for duplicate-key retry handling and failed database query/batch execution errors.
  * Preserved existing retry behavior and overall error propagation/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->