### PR TITLE
KeyCloack | Integration test

### DIFF
--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -5,7 +5,8 @@ const _ = require('lodash');
 const s3_utils = require('../s3/s3_utils');
 const { IamError } = require('./iam_errors');
 const { AWS_IAM_PATH_REGEXP, AWS_IAM_LIST_MARKER, AWS_IAM_ACCESS_KEY_INPUT_REGEXP, AWS_POLICY_NAME_REGEXP,
-    AWS_POLICY_DOCUMENT_REGEXP, AWS_POLICY_SID_REGEXP, AWS_ROLE_NAME_REGEXP, AWS_ROLE_DESCRIPTION_REGEXP } = require('../../util/string_utils');
+    AWS_POLICY_DOCUMENT_REGEXP, AWS_POLICY_SID_REGEXP, AWS_ROLE_NAME_REGEXP, AWS_ROLE_DESCRIPTION_REGEXP,
+    AWS_OIDC_PROVIDER_ARN_REGEXP } = require('../../util/string_utils');
 const iam_constants = require('./iam_constants');
 const { RpcError } = require('../../rpc');
 const validation_utils = require('../../util/validation_utils');
@@ -937,7 +938,8 @@ function validate_assume_role_policy_document(
 ) {
     try {
         if (input_policy_document === undefined) return;
-        _validate_policy_document_syntax(input_policy_document, parameter_name);
+        const policy_document = _validate_policy_document_syntax(input_policy_document, parameter_name);
+        _validate_assume_role_policy_document_iam_structure(policy_document);
         return true;
     } catch (err) {
         translate_rpc_error(err);
@@ -1108,6 +1110,52 @@ function _validate_policy_document_iam_structure(policy_document) {
         const statement_principal = statement.Principal || statement.NotPrincipal;
         if (statement_principal) {
             throw_malformed_policy_document_error('Policy document should not specify a principal.');
+        }
+    }
+}
+
+/**
+ * _validate_assume_role_policy_document_iam_structure validates the structural correctness of an
+ * assume-role trust policy document (which is allowed to have Principal / NotPrincipal).
+ *
+ * Specifically:
+ *  - Version must be '2012-10-17' or '2008-10-17'.
+ *  - Statement must be a non-empty array.
+ *  - Principal.Federated entries, when present, must conform to the OIDC-provider ARN format:
+ *      eg: arn:aws:iam::<12-digit-account-id>:oidc-provider/<provider-url> or arn:aws:iam:::oidc-provider/<provider-url>
+ *
+ * @param {object} policy_document - parsed trust policy JSON
+ */
+function _validate_assume_role_policy_document_iam_structure(policy_document) {
+    // validate version
+    if (policy_document.Version !== '2012-10-17' && policy_document.Version !== '2008-10-17') {
+        throw_malformed_policy_document_error('Syntax errors in policy.');
+    }
+    // ensure Statement is a non-empty array
+    if (!policy_document.Statement || !Array.isArray(policy_document.Statement) || policy_document.Statement.length === 0) {
+        throw_malformed_policy_document_error('Syntax errors in policy.');
+    }
+    // validate inside the Statement array
+    const statement_ids = new Set();
+    for (const statement of policy_document.Statement) {
+        if (statement.Sid) {
+            _statement_id_is_valid(statement.Sid, statement_ids);
+        }
+        const statement_principal = statement.Principal || statement.NotPrincipal;
+        if (!statement_principal) continue;
+
+        // Validate Principal.Federated ARN format when present
+        const federated = statement_principal.Federated;
+        if (federated !== undefined) {
+            const entries = Array.isArray(federated) ? federated : [federated];
+            for (const entry of entries) {
+                if (typeof entry !== 'string' || !AWS_OIDC_PROVIDER_ARN_REGEXP.test(entry)) {
+                    throw_malformed_policy_document_error(
+                        'Invalid Federated principal. ' +
+                        'Expected format: arn:aws:iam::<12-digit-account-id>:oidc-provider/<provider-url>'
+                    );
+                }
+            }
         }
     }
 }

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -6,9 +6,6 @@ const { require_coretest, is_nc_coretest, generate_iam_client,
     generate_s3_client, generate_sts_client, err_code } = require('../../../system_tests/test_utils');
 const coretest = require_coretest();
 coretest.setup();
-// TODO: Migrate remaining AWS.S3 usages in this file to SDK v3
-const AWS = require('aws-sdk');
-const https = require('https');
 const path = require('path');
 const fs = require('fs');
 const mocha = require('mocha');
@@ -474,7 +471,6 @@ mocha.describe('Session token tests', function() {
     const bob2 = 'bob2';
     const charlie2 = 'charlie2';
     const accounts = [{ email: alice2 }, { email: bob2 }, { email: charlie2 }];
-    let sts_creds;
     const role_alice = 'role_alice';
     let account_info_alice;
     const original_sts_expiry_ms = config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS;
@@ -487,7 +483,7 @@ mocha.describe('Session token tests', function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
 
-        await accounts[0].s3.deleteBucket({ Bucket: alice2_buck }).promise();
+        await accounts[0].s3.deleteBucket({ Bucket: alice2_buck });
         for (const account of accounts) {
             await rpc_client.account.delete_account({ email: account.email });
         }
@@ -496,16 +492,6 @@ mocha.describe('Session token tests', function() {
     mocha.before(async function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
-        sts_creds = {
-            endpoint: coretest.get_https_address_sts(),
-            region: 'us-east-1',
-            sslEnabled: true,
-            computeChecksums: true,
-            httpOptions: { agent: new https.Agent({ keepAlive: false, rejectUnauthorized: false }) },
-            s3ForcePathStyle: true,
-            signatureVersion: 'v4',
-            s3DisableBodySigning: false,
-        };
         const account_defaults = { has_login: false, s3_access: true };
         if (is_nc_coretest) {
             account_defaults.nsfs_account_config = {
@@ -527,12 +513,10 @@ mocha.describe('Session token tests', function() {
                 account.access_keys[0].secret_key.unwrap(),
                 coretest.get_https_address_sts());
 
-            account.s3 = new AWS.S3({
-                ...sts_creds,
-                endpoint: coretest.get_https_address(),
-                accessKeyId: account.access_keys[0].access_key.unwrap(),
-                secretAccessKey: account.access_keys[0].secret_key.unwrap()
-            });
+            account.s3 = generate_s3_client(
+                account.access_keys[0].access_key.unwrap(),
+                account.access_keys[0].secret_key.unwrap(),
+                coretest.get_http_address());
 
             account.iam = generate_iam_client(
                 account.access_keys[0].access_key.unwrap(),
@@ -590,7 +574,7 @@ mocha.describe('Session token tests', function() {
 
         // create a bucket owned by alice2 for ListBuckets to work
         // Note: bucket policy is not related to ListBuckets operation
-        await accounts[0].s3.createBucket({ Bucket: alice2_buck }).promise();
+        await accounts[0].s3.createBucket({ Bucket: alice2_buck });
     });
 
     mocha.it('user b assume role of user a - default expiry - list s3 - should be allowed', async function() {
@@ -605,15 +589,11 @@ mocha.describe('Session token tests', function() {
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3_with_session_token = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token
-        });
+        const temp_s3_with_session_token = generate_s3_client(
+            result_obj.access_key, result_obj.secret_key,
+            coretest.get_http_address(), result_obj.session_token);
 
-        const buckets1 = await temp_s3_with_session_token.listBuckets().promise();
+        const buckets1 = await temp_s3_with_session_token.listBuckets({});
         assert.ok(buckets1.Buckets[0].Name === alice2_buck);
     });
 
@@ -631,15 +611,11 @@ mocha.describe('Session token tests', function() {
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, duration_seconds);
 
-        const temp_s3_with_session_token = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token
-        });
+        const temp_s3_with_session_token = generate_s3_client(
+            result_obj.access_key, result_obj.secret_key,
+            coretest.get_http_address(), result_obj.session_token);
 
-        const buckets1 = await temp_s3_with_session_token.listBuckets().promise();
+        const buckets1 = await temp_s3_with_session_token.listBuckets({});
         assert.ok(buckets1.Buckets[0].Name === alice2_buck);
     });
 
@@ -672,14 +648,11 @@ mocha.describe('Session token tests', function() {
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3 = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-        });
+        const temp_s3 = generate_s3_client(
+            result_obj.access_key, result_obj.secret_key,
+            coretest.get_http_address());
 
-        await assert_throws_async(temp_s3.listBuckets().promise(),
+        await assert_throws_async(temp_s3.listBuckets({}),
             errors.invalid_access_key.code, errors.invalid_access_key.message);
     });
 
@@ -699,15 +672,11 @@ mocha.describe('Session token tests', function() {
         const result_obj2 = validate_assume_role_response(json2, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3 = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj1.access_key,
-            secretAccessKey: result_obj1.secret_key,
-            sessionToken: result_obj2.session_token
-        });
+        const temp_s3 = generate_s3_client(
+            result_obj1.access_key, result_obj1.secret_key,
+            coretest.get_http_address(), result_obj2.session_token);
 
-        await assert_throws_async(temp_s3.listBuckets().promise(),
+        await assert_throws_async(temp_s3.listBuckets({}),
             errors.signature_doesnt_match.code, errors.signature_doesnt_match.message);
     });
 
@@ -724,15 +693,11 @@ mocha.describe('Session token tests', function() {
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3_with_session_token = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: user_a_key,
-            secretAccessKey: user_a_secret,
-            sessionToken: result_obj.session_token
-        });
+        const temp_s3_with_session_token = generate_s3_client(
+            user_a_key, user_a_secret,
+            coretest.get_http_address(), result_obj.session_token);
 
-        await assert_throws_async(temp_s3_with_session_token.listBuckets().promise(),
+        await assert_throws_async(temp_s3_with_session_token.listBuckets({}),
             errors.signature_doesnt_match.code, errors.signature_doesnt_match.message);
     });
 
@@ -748,15 +713,11 @@ mocha.describe('Session token tests', function() {
         const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
             `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-        const temp_s3_with_session_token = new AWS.S3({
-            ...sts_creds,
-            endpoint: coretest.get_https_address(),
-            accessKeyId: result_obj.access_key,
-            secretAccessKey: result_obj.secret_key,
-            sessionToken: result_obj.session_token + 'dummy'
-        });
+        const temp_s3_with_session_token = generate_s3_client(
+            result_obj.access_key, result_obj.secret_key,
+            coretest.get_http_address(), result_obj.session_token + 'dummy');
 
-        await assert_throws_async(temp_s3_with_session_token.listBuckets().promise(),
+        await assert_throws_async(temp_s3_with_session_token.listBuckets({}),
             errors.invalid_token_s3.code, errors.invalid_token_s3.message);
     });
 
@@ -820,15 +781,11 @@ mocha.describe('Session token tests', function() {
             const result_obj = validate_assume_role_response(json, `arn:aws:sts::${user_a_id}:assumed-role/${role_alice}/${params.RoleSessionName}`,
                 `${user_a_id}:${params.RoleSessionName}`, user_a_key, defualt_expiry_seconds);
 
-            const temp_s3_with_session_token = new AWS.S3({
-                ...sts_creds,
-                endpoint: coretest.get_https_address(),
-                accessKeyId: result_obj.access_key,
-                secretAccessKey: result_obj.secret_key,
-                sessionToken: result_obj.session_token
-            });
+            const temp_s3_with_session_token = generate_s3_client(
+                result_obj.access_key, result_obj.secret_key,
+                coretest.get_http_address(), result_obj.session_token);
 
-            await assert_throws_async(temp_s3_with_session_token.listBuckets().promise(),
+            await assert_throws_async(temp_s3_with_session_token.listBuckets({}),
                 errors.expired_token_s3.code, errors.expired_token_s3.message);
         });
 

--- a/src/test/integration_tests/api/sts/test_sts_keycloak_integration.js
+++ b/src/test/integration_tests/api/sts/test_sts_keycloak_integration.js
@@ -1,0 +1,1889 @@
+/* Copyright (C) 2026 NooBaa */
+/* eslint max-lines-per-function: ['error', 700] */
+'use strict';
+
+/**
+ * Integration tests for AssumeRoleWithWebIdentity with Keycloak (OIDC) mock.
+ *
+ * Strategy
+ * --------
+ * Keycloak is never actually started.  We mock two integration points so that
+ * the NooBaa server-side code believes Keycloak is fully configured and that a
+ * supplied access token is valid:
+ *
+ *   1. `keycloak_client.is_keycloak_configured()` - stubbed to return `true`.
+ *   2. `keycloak_client.get_instance()` - returns a fake KeyCloakClientManager
+ *      whose `get_provider()` returns a mock provider with a controllable
+ *      `introspect_token()` implementation.
+ *
+ * Test groups
+ * -----------
+ * A. Role creation and basic AssumeRoleWithWebIdentity flow
+ * B. Trust-policy condition validation (aws:RequestTag, aud, sub, ForAnyValue)
+ * C. S3 request flow using the AWS_SESSION_TOKEN returned by AssumeRoleWithWebIdentity
+ * D. IAM role policy enforcement with temporary credentials + aws:PrincipalTag
+ */
+
+// setup coretest first to prepare the env
+const { require_coretest, is_nc_coretest, generate_iam_client,
+    generate_s3_client, generate_sts_client } = require('../../../system_tests/test_utils');
+const coretest = require_coretest();
+coretest.setup();
+
+const mocha = require('mocha');
+const assert = require('assert');
+const jwt = require('jsonwebtoken');
+const sinon = require('sinon');
+
+const stsErr = require('../../../../endpoint/sts/sts_errors').StsError;
+const { S3Error } = require('../../../../endpoint/s3/s3_errors');
+const jwt_utils = require('../../../../util/jwt_utils');
+const keycloak_client = require('../../../../util/keycloak_client');
+const config = require('../../../../../config');
+const { RpcError } = require('../../../../rpc');
+const dbg = require('../../../../util/debug_module')(__filename);
+
+const {
+    CreateRoleCommand,
+    DeleteRoleCommand,
+    PutRolePolicyCommand,
+} = require('@aws-sdk/client-iam');
+
+const { AssumeRoleWithWebIdentityCommand } = require('@aws-sdk/client-sts');
+
+// ---------------------------------------------------------------------------
+// Constants & helpers shared by all describe blocks
+// ---------------------------------------------------------------------------
+
+const KEYCLOAK_ISSUER = 'http://keycloak.noobaa.svc.cluster.local:8080/realms/noobaa';
+const KEYCLOAK_CLIENT_ID = 'noobaa-client';
+const KEYCLOAK_SUBJECT = '1e59d996-2aa9-4a91-9740-d9cf61ccfd3e';
+
+/** JWT private key used to sign mock Keycloak tokens (RS256-like but via HS256 for simplicity). */
+const MOCK_JWT_SECRET = 'mock-keycloak-test-secret';
+
+/**
+ * Admin-owned bucket shared by S3 temporary-credential suites (C, D, G).
+ * Created once via the coretest admin account (same ownership model as first.bucket).
+ */
+const KC_STS_TEST_BUCKET = 'kc-sts-test-bucket';
+
+/** @type {import('@aws-sdk/client-s3').S3 | undefined} */
+let admin_s3_for_kc_sts;
+
+mocha.before('create admin-owned Keycloak STS test bucket', async function() {
+    const self = this; // eslint-disable-line no-invalid-this
+    self.timeout(60000);
+    const { rpc_client, EMAIL } = coretest;
+    const admin_keys = (await rpc_client.account.read_account({ email: EMAIL })).access_keys;
+    admin_s3_for_kc_sts = generate_s3_client(
+        admin_keys[0].access_key.unwrap(),
+        admin_keys[0].secret_key.unwrap(),
+        coretest.get_http_address()
+    );
+    await admin_s3_for_kc_sts.createBucket({ Bucket: KC_STS_TEST_BUCKET });
+});
+
+mocha.after('delete admin-owned Keycloak STS test bucket', async function() {
+    const self = this; // eslint-disable-line no-invalid-this
+    self.timeout(60000);
+    if (!admin_s3_for_kc_sts) return;
+    try {
+        await admin_s3_for_kc_sts.deleteBucket({ Bucket: KC_STS_TEST_BUCKET });
+    } catch (_) { /* ignore */ }
+});
+
+/**
+ * Build the OIDC-provider ARN used as Principal.Federated in trust policies.
+ * Format: arn:aws:iam::<account_id>:oidc-provider/<issuer-host-and-path>
+ *
+ * @param {string} account_id - NooBaa account _id (used as the account-id segment)
+ * @returns {string}
+ */
+function make_keycloak_federated_arn(account_id) {
+    const issuer_without_scheme = KEYCLOAK_ISSUER.replace(/^https?:\/\//, '');
+    return `arn:aws:iam::${account_id}:oidc-provider/${issuer_without_scheme}`;
+}
+
+/**
+ * Build the expected IAM-policy access-denied message that NooBaa produces via
+ * create_detailed_message_for_iam_user_access() for an assumed-role session.
+ *
+ * Format:
+ *   User: <role_arn> is not authorized to perform: <action>
+ *   on resource: <resource_arn> because no identity-based policy allows the <action> action
+ *
+ * @param {string} role_arn   - e.g. 'arn:aws:sts::<id>:role/MyRole'
+ * @param {string} action     - e.g. 's3:ListBucket'
+ * @param {string} resource   - e.g. 'arn:aws:s3:::my-bucket'
+ * @returns {string}
+ */
+function make_iam_access_denied_message(role_arn, action, resource) {
+    return `User: ${role_arn} is not authorized to perform: ${action} ` +
+           `on resource: ${resource} ` +
+           `because no identity-based policy allows the ${action} action`;
+}
+
+/**
+ * Build a JWT that looks like a Keycloak access-token.
+ * Pass `extra_claims` to embed session tags, aud, sub, etc.
+ *
+ * @param {Object} extra_claims
+ * @param {Object} sign_opts - jsonwebtoken sign options (e.g. expiresIn, algorithm)
+ */
+function make_keycloak_jwt(extra_claims = {}, sign_opts = { expiresIn: '1h' }) {
+    return jwt.sign({
+        iss: KEYCLOAK_ISSUER,
+        sub: KEYCLOAK_SUBJECT,
+        aud: [KEYCLOAK_CLIENT_ID, 'account'],
+        azp: KEYCLOAK_CLIENT_ID,
+        ...extra_claims,
+    }, MOCK_JWT_SECRET, sign_opts);
+}
+
+/**
+ * Build a mock introspection response that mirrors what Keycloak would return.
+ *
+ * @param {Object} overrides - any field to override in the default response
+ */
+function make_introspect_response(overrides = {}) {
+    return {
+        active: true,
+        sub: KEYCLOAK_SUBJECT,
+        client_id: KEYCLOAK_CLIENT_ID,
+        aud: KEYCLOAK_CLIENT_ID,
+        iss: KEYCLOAK_ISSUER,
+        ...overrides,
+    };
+}
+
+/**
+ * Build a mock KeyCloakClientManager that `keycloak_client.get_instance()` will return.
+ * `introspect_fn` controls what `introspect_token()` does.
+ *
+ * @param {Function} introspect_fn async (token) => introspection_response | throws
+ */
+function make_mock_keycloak_instance(introspect_fn) {
+    return {
+        initialized: true,
+        initialize: async () => { /* no-op */ },
+        get_provider: issuer => (issuer === KEYCLOAK_ISSUER ? { configured: true } : null),
+        verify_token: async token => jwt.decode(token),
+        introspect_token: introspect_fn,
+    };
+}
+
+/**
+ * Install sinon stubs that make the server-side Keycloak path active.
+ * Returns a restore function; call it in `afterEach` / `after`.
+ *
+ * @param {Function} introspect_fn - async (token) => ...
+ * @returns {{ restore: Function }}
+ */
+function stub_keycloak(introspect_fn) {
+    const mock_instance = make_mock_keycloak_instance(introspect_fn);
+    const get_instance_stub = sinon.stub(keycloak_client, 'get_instance').returns(mock_instance);
+    const is_configured_stub = sinon.stub(keycloak_client, 'is_keycloak_configured').resolves(true);
+    return {
+        restore() {
+            get_instance_stub.restore();
+            is_configured_stub.restore();
+        },
+    };
+}
+
+/**
+ * Send AssumeRoleWithWebIdentity via the SDK v3 client and return the response.
+ */
+async function assume_role_with_web_identity(anon_sts, params) {
+    return anon_sts.send(new AssumeRoleWithWebIdentityCommand(params));
+}
+
+/**
+ * Validate the AssumeRoleWithWebIdentity response structure and return
+ * the temporary credentials.
+ */
+function validate_web_identity_response(response, expected_arn, expected_role_id, assumed_access_key) {
+    assert.ok(response && response.Credentials && response.AssumedRoleUser,
+        'Response must contain Credentials and AssumedRoleUser');
+
+    const credentials = response.Credentials;
+    assert.ok(credentials.AccessKeyId, 'AccessKeyId must be present');
+    assert.ok(credentials.SecretAccessKey, 'SecretAccessKey must be present');
+    assert.ok(credentials.SessionToken, 'SessionToken must be present');
+
+    // Verify the session token encodes the correct assumed-role access key
+    if (config.STS_DEFAULT_SESSION_TOKEN_EXPIRY_MS !== 0) {
+        const session_token_json = jwt_utils.authorize_jwt_token(credentials.SessionToken);
+        assert.equal(session_token_json.access_key, credentials.AccessKeyId);
+        assert.equal(session_token_json.secret_key, credentials.SecretAccessKey);
+        assert.equal(session_token_json.assumed_role_access_key, assumed_access_key);
+        assert.ok(session_token_json.assumed_role_arn);
+    }
+
+    // AssumedRoleUser
+    assert.equal(response.AssumedRoleUser.Arn, expected_arn, 'ARN must match');
+    assert.equal(response.AssumedRoleUser.AssumedRoleId, expected_role_id, 'AssumedRoleId must match');
+
+    return {
+        access_key: credentials.AccessKeyId,
+        secret_key: credentials.SecretAccessKey,
+        session_token: credentials.SessionToken,
+    };
+}
+
+/**
+ * Assert that a promise rejects with the expected AWS error code and message.
+ */
+async function assert_throws_async(promise, expected_code, expected_message) {
+    try {
+        await promise;
+        assert.fail('Test was suppose to fail on ' + expected_message);
+    } catch (err) {
+        dbg.log0('assert_throws_async err', err);
+        dbg.log0('assert_throws_async err.message', err.message, expected_message, err.message !== expected_message);
+        dbg.log0('assert_throws_async err.code', err.code, expected_code, err.code !== expected_code);
+        dbg.log0('assert_throws_async err.code', err.rpc_code, expected_code, err.rpc_code !== expected_code);
+        const code_or_rpc_code = err.code || err.rpc_code || err.Code || err.name;
+        if (err.message !== expected_message || code_or_rpc_code !== expected_code) throw err;
+    }
+}
+
+/**
+ * Create a test account with S3 access and return the read account object.
+ */
+async function create_test_account(rpc_client, email) {
+    const account_defaults = { has_login: false, s3_access: true };
+    await rpc_client.account.create_account({ ...account_defaults, name: email, email });
+    return rpc_client.account.read_account({ email });
+}
+
+/**
+ * Build IAM + anonymous STS clients for a role-owner account.
+ */
+function setup_role_owner_clients(account) {
+    const keys = account.access_keys;
+    return {
+        iam_client: generate_iam_client(
+            keys[0].access_key.unwrap(),
+            keys[0].secret_key.unwrap(),
+            coretest.get_https_address_iam()
+        ),
+        anon_sts: generate_sts_client('', '', coretest.get_https_address_sts()),
+    };
+}
+
+/**
+ * Delete the given IAM roles (ignoring missing roles) then delete the account.
+ */
+async function cleanup_roles_and_account(rpc_client, iam_client, role_names, email) {
+    for (const role of role_names) {
+        try {
+            await iam_client.send(new DeleteRoleCommand({ RoleName: role }));
+        } catch (_) { /* ignore */ }
+    }
+    await rpc_client.account.delete_account({ email });
+}
+
+/**
+ * Grant the account full s3:* access on the bucket via an open bucket policy.
+ */
+async function put_account_open_bucket_policy(rpc_client, bucket, account_id, email) {
+    await rpc_client.bucket.put_bucket_policy({
+        name: bucket,
+        policy: {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: {
+                    AWS: is_nc_coretest ? email : `arn:aws:iam::${account_id}:root`,
+                },
+                Action: ['s3:*'],
+                Resource: [
+                    `arn:aws:s3:::${bucket}`,
+                    `arn:aws:s3:::${bucket}/*`,
+                ],
+            }],
+        },
+    });
+}
+
+/**
+ * Build an S3 client from AssumeRoleWithWebIdentity temporary credentials.
+ * Pass session_token to override (e.g. omit, tamper, or swap tokens).
+ */
+function s3_client_from_temp_creds(creds, session_token = creds.SessionToken) {
+    return generate_s3_client(
+        creds.AccessKeyId,
+        creds.SecretAccessKey,
+        coretest.get_http_address(),
+        session_token
+    );
+}
+
+/**
+ * Assert that listObjects is denied by an IAM identity-based policy for the role.
+ */
+async function assert_s3_list_access_denied(s3, bucket, role_arn) {
+    await assert_throws_async(
+        s3.listObjects({ Bucket: bucket }),
+        S3Error.AccessDenied.code,
+        make_iam_access_denied_message(role_arn, 's3:ListBucket', `arn:aws:s3:::${bucket}`)
+    );
+}
+
+/**
+ * Restore Keycloak stubs if present; returns null for easy reassignment.
+ */
+function restore_kc_stubs(kc_stubs) {
+    if (kc_stubs) kc_stubs.restore();
+    return null;
+}
+
+
+// ---------------------------------------------------------------------------
+// A. Role creation and basic AssumeRoleWithWebIdentity flow
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity - basic flow', function() {
+    const { rpc_client } = coretest;
+
+    // Accounts
+    const role_owner_email = 'kc-role-owner-a1';
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+    const test_role_name = 'KeycloakTestRoleA';
+
+    /** Keycloak stubs; replaced per-test where needed */
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        // Create a role with a trust policy that accepts any Federated principal (web identity)
+        const trust_policy = {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                Action: ['sts:AssumeRoleWithWebIdentity'],
+            }],
+        };
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: test_role_name,
+            AssumeRolePolicyDocument: JSON.stringify(trust_policy),
+        }));
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        kc_stubs = restore_kc_stubs(kc_stubs);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner, [test_role_name], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    mocha.it('should successfully assume role with a valid Keycloak token', async function() {
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+        const account_id = role_owner_account._id.toString();
+        const role_session = 'my-kc-session';
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const web_identity_token = make_keycloak_jwt();
+        const params = {
+            RoleArn: `arn:aws:sts::${account_id}:role/${test_role_name}`,
+            RoleSessionName: role_session,
+            WebIdentityToken: web_identity_token,
+        };
+
+        const json = await assume_role_with_web_identity(anon_sts, params);
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${test_role_name}/${role_session}`,
+            `${account_id}:${role_session}`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('should be rejected when Keycloak token is expired (introspect returns active:false)', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        kc_stubs = stub_keycloak(async () => {
+            throw new RpcError('EXPIRED_WEB_IDENTITY_TOKEN',
+                'Token expired: current date/time must be before the expiration date/time');
+        });
+
+        const web_identity_token = make_keycloak_jwt();
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${test_role_name}`,
+                RoleSessionName: 'expired-session',
+                WebIdentityToken: web_identity_token,
+            }),
+            stsErr.ExpiredToken.code,
+            'Token expired: current date/time must be before the expiration date/time'
+        );
+    });
+
+    mocha.it('should be rejected when the web identity token is malformed (not a JWT)', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${test_role_name}`,
+                RoleSessionName: 'bad-token-session',
+                WebIdentityToken: 'not.a.jwt',
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    mocha.it('should be rejected when the role does not exist', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const web_identity_token = make_keycloak_jwt();
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/NonExistentRole`,
+                RoleSessionName: 'no-role-session',
+                WebIdentityToken: web_identity_token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    mocha.it('should be rejected when the token issuer is not a configured Keycloak provider', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Stub: Keycloak is configured BUT there is no provider for the token's issuer
+        const mock_instance = {
+            initialized: true,
+            initialize: async () => { /* no-op */ },
+            get_provider: () => null, // issuer not found
+            verify_token: async token => jwt.decode(token),
+            introspect_token: async () => make_introspect_response(),
+        };
+        const get_stub = sinon.stub(keycloak_client, 'get_instance').returns(mock_instance);
+        const cfg_stub = sinon.stub(keycloak_client, 'is_keycloak_configured').resolves(true);
+        kc_stubs = { restore() { get_stub.restore(); cfg_stub.restore(); } };
+
+        // Token whose issuer is *not* in our provider map
+        const foreign_token = jwt.sign(
+            { iss: 'https://foreign-idp.example.com', sub: 'user1' },
+            MOCK_JWT_SECRET,
+            { expiresIn: '1h' }
+        );
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${test_role_name}`,
+                RoleSessionName: 'foreign-issuer-session',
+                WebIdentityToken: foreign_token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// B. Trust-policy condition validation
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity - trust-policy condition validation', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-b1';
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+
+    const ROLE_WITH_DEPT_CONDITION = 'KcRoleDeptCondition';
+    const ROLE_WITH_AUD_CONDITION = 'KcRoleAudCondition';
+    const ROLE_WITH_FOR_ANY_VALUE = 'KcRoleForAnyValue';
+    const ROLE_WITH_SESSION_TAG_ALLOW = 'KcRoleWithTagSession';
+    const ROLE_WITH_MIXED_CONDITIONS = 'KcRoleMixedConditions';
+
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        // ── Role: Require Department = Engineering (StringEquals on aws:RequestTag)
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_WITH_DEPT_CONDITION,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity', 'sts:TagSession'],
+                    Condition: {
+                        StringEquals: { 'aws:RequestTag/Department': 'Engineering' },
+                    },
+                }],
+            }),
+        }));
+
+        // ── Role: Require specific `aud` claim (StringEquals on aud)
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_WITH_AUD_CONDITION,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                    Condition: {
+                        StringEquals: {
+                            [`${KEYCLOAK_ISSUER.replace('http://', '').replace('https://', '')}:aud`]: KEYCLOAK_CLIENT_ID,
+                        },
+                    },
+                }],
+            }),
+        }));
+
+        // ── Role: ForAnyValue:StringEquals on Team tag
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_WITH_FOR_ANY_VALUE,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity', 'sts:TagSession'],
+                    Condition: {
+                        'ForAnyValue:StringEquals': {
+                            'aws:RequestTag/Team': ['Engineering', 'DevOps'],
+                        },
+                    },
+                }],
+            }),
+        }));
+
+        // ── Role: session tags + sts:TagSession required
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_WITH_SESSION_TAG_ALLOW,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                        Action: ['sts:AssumeRoleWithWebIdentity'],
+                    },
+                    {
+                        Effect: 'Allow',
+                        Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                        Action: ['sts:TagSession'],
+                    },
+                ],
+            }),
+        }));
+
+        // ── Role: Mixed StringEquals + ForAnyValue conditions
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_WITH_MIXED_CONDITIONS,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity', 'sts:TagSession'],
+                    Condition: {
+                        StringEquals: { 'aws:RequestTag/Environment': 'Production' },
+                        'ForAnyValue:StringEquals': {
+                            'aws:RequestTag/Team': ['DevOps', 'SRE'],
+                        },
+                    },
+                }],
+            }),
+        }));
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner, [
+            ROLE_WITH_DEPT_CONDITION, ROLE_WITH_AUD_CONDITION, ROLE_WITH_FOR_ANY_VALUE,
+            ROLE_WITH_SESSION_TAG_ALLOW, ROLE_WITH_MIXED_CONDITIONS,
+        ], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    // ── B.1 aws:RequestTag / StringEquals ───────────────────────────────────
+
+    mocha.it('B.1a - StringEquals on aws:RequestTag/Department matches → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_DEPT_CONDITION}`,
+            RoleSessionName: 'dept-match-session',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_WITH_DEPT_CONDITION}/dept-match-session`,
+            `${account_id}:dept-match-session`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('B.1b - StringEquals on aws:RequestTag/Department does not match → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Finance' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_DEPT_CONDITION}`,
+                RoleSessionName: 'dept-no-match-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    mocha.it('B.1c - StringEquals on aws:RequestTag/Department - tag absent in token → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Token has no principal_tags at all
+        const token = make_keycloak_jwt();
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_DEPT_CONDITION}`,
+                RoleSessionName: 'dept-absent-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── B.2 aud claim condition ─────────────────────────────────────────────
+
+    mocha.it('B.2a - StringEquals on aud claim matches → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        // aud in token matches KEYCLOAK_CLIENT_ID
+        const token = make_keycloak_jwt({ aud: [KEYCLOAK_CLIENT_ID, 'account'] });
+        kc_stubs = stub_keycloak(async () => make_introspect_response({ aud: KEYCLOAK_CLIENT_ID }));
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_AUD_CONDITION}`,
+            RoleSessionName: 'aud-match-session',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_WITH_AUD_CONDITION}/aud-match-session`,
+            `${account_id}:aud-match-session`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('B.2b - StringEquals on aud claim does not match → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Token claims a different aud
+        const token = make_keycloak_jwt({ aud: ['wrong-client', 'account'] });
+        kc_stubs = stub_keycloak(async () => make_introspect_response({ aud: 'wrong-client' }));
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_AUD_CONDITION}`,
+                RoleSessionName: 'aud-no-match-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── B.3 ForAnyValue:StringEquals ────────────────────────────────────────
+
+    mocha.it('B.3a - ForAnyValue:StringEquals on Team tag - one of multiple values matches → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Team: ['QA', 'DevOps'] } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_FOR_ANY_VALUE}`,
+            RoleSessionName: 'forany-match-session',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_WITH_FOR_ANY_VALUE}/forany-match-session`,
+            `${account_id}:forany-match-session`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('B.3b - ForAnyValue:StringEquals on Team tag - no value matches → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Team: ['Support', 'Sales'] } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_FOR_ANY_VALUE}`,
+                RoleSessionName: 'forany-no-match-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── B.4 Session tag forwarding (sts:TagSession) ─────────────────────────
+
+    mocha.it('B.4 - Token with session tags and sts:TagSession in policy → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering', Env: 'staging' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_SESSION_TAG_ALLOW}`,
+            RoleSessionName: 'tag-session-allowed',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_WITH_SESSION_TAG_ALLOW}/tag-session-allowed`,
+            `${account_id}:tag-session-allowed`,
+            role_owner_access_key
+        );
+    });
+
+    // ── B.5 Mixed StringEquals + ForAnyValue ────────────────────────────────
+
+    mocha.it('B.5a - Mixed conditions: all conditions satisfied → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Environment: 'Production', Team: ['DevOps', 'SRE'] } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_MIXED_CONDITIONS}`,
+            RoleSessionName: 'mixed-ok-session',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_WITH_MIXED_CONDITIONS}/mixed-ok-session`,
+            `${account_id}:mixed-ok-session`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('B.5b - Mixed conditions: StringEquals passes but ForAnyValue fails → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            // Environment matches, but Team does NOT include DevOps or SRE
+            'https://aws.amazon.com/tags': { principal_tags: { Environment: 'Production', Team: ['QA'] } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_MIXED_CONDITIONS}`,
+                RoleSessionName: 'mixed-fail-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    mocha.it('B.5c - Mixed conditions: ForAnyValue passes but StringEquals fails → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            // Team matches, but Environment does NOT equal Production
+            'https://aws.amazon.com/tags': { principal_tags: { Environment: 'Staging', Team: ['DevOps'] } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_WITH_MIXED_CONDITIONS}`,
+                RoleSessionName: 'mixed-env-fail-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// C. S3 request flow using AWS_SESSION_TOKEN
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity - S3 with temporary credentials', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-c1';
+    const test_bucket = KC_STS_TEST_BUCKET;
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+    const ROLE_S3_ACCESS = 'KcRoleS3Access';
+
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        // Create a role that allows full S3 access to `test_bucket`
+        const trust_policy = {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                Action: ['sts:AssumeRoleWithWebIdentity'],
+            }],
+        };
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_S3_ACCESS,
+            AssumeRolePolicyDocument: JSON.stringify(trust_policy),
+        }));
+
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_S3_ACCESS,
+            PolicyName: 'KcRoleS3Policy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [
+                        `arn:aws:s3:::${test_bucket}`,
+                        `arn:aws:s3:::${test_bucket}/*`,
+                    ],
+                }],
+            }),
+        }));
+
+        // Grant the role owner's account access over test_bucket
+        const account_id = role_owner_account._id.toString();
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner, [ROLE_S3_ACCESS], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    mocha.it('C.1 - S3 listObjects succeeds with valid temporary credentials', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_S3_ACCESS}`,
+            RoleSessionName: 'c1-list-session',
+            WebIdentityToken: token,
+        });
+
+        const creds = json.Credentials;
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const result = await s3.listObjects({ Bucket: test_bucket });
+        assert.ok(result, 'listObjects should succeed');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D. IAM role policy enforcement + aws:PrincipalTag validation
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity - IAM role policy + aws:PrincipalTag', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-d1';
+    const test_bucket = KC_STS_TEST_BUCKET;
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+
+    const ROLE_PRINCIPAL_TAG = 'KcRolePrincipalTag';
+    const ROLE_DENY_POLICY = 'KcRoleDenyPolicy';
+    const ROLE_LIMITED_S3 = 'KcRoleLimitedS3';
+
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        const base_trust_policy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:TagSession'],
+                },
+            ],
+        };
+
+        // ── Role: role policy uses aws:PrincipalTag to gate access ───────────
+        // The bucket policy is open for the account; access is gated by the
+        // IAM role policy condition on aws:PrincipalTag/Department.
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_PRINCIPAL_TAG,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust_policy),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_PRINCIPAL_TAG,
+            PolicyName: 'PrincipalTagPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [
+                        `arn:aws:s3:::${test_bucket}`,
+                        `arn:aws:s3:::${test_bucket}/*`,
+                    ],
+                    Condition: {
+                        StringEquals: { 'aws:PrincipalTag/Department': 'Engineering' },
+                    },
+                }],
+            }),
+        }));
+
+        // ── Role: explicit Deny in IAM role policy ───────────────────────────
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_DENY_POLICY,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust_policy),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_DENY_POLICY,
+            PolicyName: 'DenyS3Policy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: ['s3:*'],
+                        Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`],
+                    },
+                    {
+                        Effect: 'Deny',
+                        Action: ['s3:ListBucket'],
+                        Resource: [`arn:aws:s3:::${test_bucket}`],
+                    },
+                ],
+            }),
+        }));
+
+        // ── Role: limited S3 access (no ListBucket) ──────────────────────────
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_LIMITED_S3,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust_policy),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_LIMITED_S3,
+            PolicyName: 'LimitedS3Policy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:GetObject'],
+                    Resource: [`arn:aws:s3:::${test_bucket}/*`],
+                }],
+            }),
+        }));
+
+        // Bucket policy: allow role owner's account
+        const account_id = role_owner_account._id.toString();
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner,
+            [ROLE_PRINCIPAL_TAG, ROLE_DENY_POLICY, ROLE_LIMITED_S3], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    mocha.it('D.1 - aws:PrincipalTag in role policy: matching session tag → s3:ListObjects allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Bucket policy is open for the account (set in before()).
+        // Access is gated by the IAM role policy condition on aws:PrincipalTag/Department.
+        // Token embeds a session tag: Department = Engineering → role policy condition satisfied.
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_PRINCIPAL_TAG}`,
+            RoleSessionName: 'd1-principal-tag-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const result = await s3.listObjects({ Bucket: test_bucket });
+        assert.ok(result, 'listObjects should succeed when session tag matches role policy condition');
+    });
+
+    mocha.it('D.2 - aws:PrincipalTag in role policy: non-matching session tag → s3:ListObjects denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Bucket policy is open for the account (set in before()).
+        // Token embeds Department = Finance - role policy condition requires Engineering → denied.
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Finance' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_PRINCIPAL_TAG}`,
+            RoleSessionName: 'd2-principal-mismatch-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_PRINCIPAL_TAG}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+
+    mocha.it('D.3 - IAM role policy with explicit Deny on s3:ListBucket → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Open bucket policy (no principal-tag condition)
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_DENY_POLICY}`,
+            RoleSessionName: 'd3-deny-policy-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        // ListBucket is explicitly denied by the role policy
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_DENY_POLICY}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+
+    mocha.it('D.4 - IAM role policy update: remove s3 access → subsequent S3 call denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Open bucket policy
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+
+        // First assume-role gives us working creds
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_PRINCIPAL_TAG}`,
+            RoleSessionName: 'd4-role-update-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        // Now revoke S3 access via role policy update (deny all)
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_PRINCIPAL_TAG,
+            PolicyName: 'PrincipalTagPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Deny',
+                    Action: ['s3:*'],
+                    Resource: ['*'],
+                }],
+            }),
+        }));
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_PRINCIPAL_TAG}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+
+        // Restore original policy so other tests are not affected
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_PRINCIPAL_TAG,
+            PolicyName: 'PrincipalTagPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [
+                        `arn:aws:s3:::${test_bucket}`,
+                        `arn:aws:s3:::${test_bucket}/*`,
+                    ],
+                }],
+            }),
+        }));
+    });
+
+    mocha.it('D.5 - IAM role policy grants only s3:GetObject; s3:ListBucket is implicitly denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Open bucket policy
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_LIMITED_S3}`,
+            RoleSessionName: 'd5-limited-s3-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        // ListBucket is not granted by the role policy → implicitly denied
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_LIMITED_S3}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// E. Token / claims edge cases
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity – token & claims edge cases', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-e1';
+    const ROLE_E = 'KcRoleTokenEdge';
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_E,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                }],
+            }),
+        }));
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner, [ROLE_E], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    // ── E.1 ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: any error from the identity provider (network, timeout, etc.)
+    // during token validation surfaces as AccessDenied to the caller.
+    // Reference: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+
+    mocha.it('E.1 - introspection endpoint throws a network/timeout error → should be rejected with AccessDenied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Simulate a transient network/timeout error from the introspection endpoint.
+        // The SDK's get_assumed_oidc_user() catches any non-RpcError and re-throws it as
+        // ACCESS_DENIED, which sts_post_assume_role_with_web_identity maps to AccessDeniedException.
+        kc_stubs = stub_keycloak(async () => {
+            const network_err = new Error('connect ECONNREFUSED 127.0.0.1:8080');
+            network_err.code = 'ECONNREFUSED';
+            throw network_err;
+        });
+
+        const token = make_keycloak_jwt();
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_E}`,
+                RoleSessionName: 'e1-network-error-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            'Not authorized to perform sts:AssumeRoleWithWebIdentity'
+        );
+    });
+
+    // ── E.2 ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: a valid token whose issuer is served by one of multiple configured
+    // Keycloak providers is routed correctly.  A token from a provider that is NOT
+    // configured falls through to LDAP (no OIDC provider match) → ACCESS_DENIED.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+
+    mocha.it('E.2a - multiple providers configured: token routed to the correct provider → should be allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+        const role_owner_access_key = role_owner_account.access_keys[0].access_key.unwrap();
+
+        // Two providers: our known issuer and a second one.  Token carries our issuer.
+        const SECOND_ISSUER = 'https://other-idp.example.com/realms/test';
+        const mock_instance = {
+            initialized: true,
+            initialize: async () => { /* no-op */ },
+            get_provider: issuer => {
+                if (issuer === KEYCLOAK_ISSUER) return { configured: true };
+                if (issuer === SECOND_ISSUER) return { configured: true };
+                return null;
+            },
+            verify_token: async token => jwt.decode(token),
+            introspect_token: async () => make_introspect_response(),
+        };
+        const get_stub = sinon.stub(keycloak_client, 'get_instance').returns(mock_instance);
+        const cfg_stub = sinon.stub(keycloak_client, 'is_keycloak_configured').resolves(true);
+        kc_stubs = { restore() { get_stub.restore(); cfg_stub.restore(); } };
+
+        const token = make_keycloak_jwt(); // iss = KEYCLOAK_ISSUER
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_E}`,
+            RoleSessionName: 'e2a-multi-provider-match',
+            WebIdentityToken: token,
+        });
+        validate_web_identity_response(
+            json,
+            `arn:aws:sts::${account_id}:assumed-role/${ROLE_E}/e2a-multi-provider-match`,
+            `${account_id}:e2a-multi-provider-match`,
+            role_owner_access_key
+        );
+    });
+
+    mocha.it('E.2b - multiple providers configured: token from an unknown issuer → should be rejected', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const SECOND_ISSUER = 'https://other-idp.example.com/realms/test';
+        const UNKNOWN_ISSUER = 'https://unknown-idp.example.com/realms/unknown';
+        const mock_instance = {
+            initialized: true,
+            initialize: async () => { /* no-op */ },
+            get_provider: issuer => {
+                if (issuer === KEYCLOAK_ISSUER) return { configured: true };
+                if (issuer === SECOND_ISSUER) return { configured: true };
+                return null; // UNKNOWN_ISSUER not found
+            },
+            verify_token: async token => jwt.decode(token),
+            introspect_token: async () => make_introspect_response(),
+        };
+        const get_stub = sinon.stub(keycloak_client, 'get_instance').returns(mock_instance);
+        const cfg_stub = sinon.stub(keycloak_client, 'is_keycloak_configured').resolves(true);
+        kc_stubs = { restore() { get_stub.restore(); cfg_stub.restore(); } };
+
+        // Token from an issuer that is NOT in any provider
+        const unknown_token = jwt.sign(
+            { iss: UNKNOWN_ISSUER, sub: 'user1', aud: 'client' },
+            MOCK_JWT_SECRET,
+            { expiresIn: '1h' }
+        );
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_E}`,
+                RoleSessionName: 'e2b-multi-provider-unknown',
+                WebIdentityToken: unknown_token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── E.9 ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: when no OIDC provider is configured the request falls through
+    // to LDAP.  With LDAP also unconfigured the result is InvalidIdentityToken.
+    // Reference: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+
+    mocha.it('E.9 - is_keycloak_configured() returns false → falls through to LDAP → InvalidIdentityToken', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Stub Keycloak as NOT configured.  The SDK falls through to the LDAP handler
+        // which will fail with ACCESS_DENIED because LDAP is not configured either.
+        const cfg_stub = sinon.stub(keycloak_client, 'is_keycloak_configured').resolves(false);
+        kc_stubs = { restore() { cfg_stub.restore(); } };
+
+        const token = make_keycloak_jwt();
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_E}`,
+                RoleSessionName: 'e9-keycloak-not-configured',
+                WebIdentityToken: token,
+            }),
+            stsErr.InvalidIdentityToken.code,
+            'Missing a required claim: user'
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// F. Trust-policy / _validate_assume_role_policy_document_iam_structure
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity – trust-policy structure validation', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-f1';
+    const ROLE_F_NOTPRINCIPAL = 'KcRoleNotPrincipalFederated';
+    const ROLE_F_NO_TAGSESSION = 'KcRoleNoTagSession';
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+
+        // Role F3: trust policy only allows AssumeRoleWithWebIdentity, no sts:TagSession statement.
+        // Tokens that carry session tags will have the tags silently dropped on AWS but the
+        // AssumeRole itself still succeeds (sts:TagSession is only needed if the caller
+        // explicitly requests tag propagation through the API DurationSeconds path).
+        // NooBaa extracts tags from the JWT directly, so sts:TagSession in the trust policy
+        // is honoured during trust-policy evaluation.  When the policy has NO sts:TagSession
+        // statement the assume-role call is still expected to succeed — only tag-propagation
+        // checks for the missing statement.
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_F_NO_TAGSESSION,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Principal: { Federated: make_keycloak_federated_arn(role_owner_account._id.toString()) },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                    // Intentionally no sts:TagSession
+                }],
+            }),
+        }));
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner, [ROLE_F_NOTPRINCIPAL, ROLE_F_NO_TAGSESSION], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    // ── F.3 ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: NotPrincipal is not supported with AWS AssumeRoleWithWebIdentity
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html
+
+    mocha.it('F.3 - Federated in trust policy: creating role is Deny ', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Create the role with NotPrincipal.Federated – the server must accept the document.
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_F_NOTPRINCIPAL,
+            AssumeRolePolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Deny',
+                    Principal: { Federated: make_keycloak_federated_arn(account_id) },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                }],
+            }),
+        }));
+
+        // At evaluation time, NotPrincipal in a trust policy always denies.
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_F_NOTPRINCIPAL}`,
+                RoleSessionName: 'f3-notprincipal-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── F.4 ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: a token that carries session tags when sts:TagSession is NOT
+    // present in the trust policy means the AssumeRoleWithWebIdentity call fail.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_adding-assume-role-idp
+
+    mocha.it('F.4 - token with session tags but trust policy has no sts:TagSession → assume role to fail', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Token carries session tags but the role's trust policy only allows
+        // sts:AssumeRoleWithWebIdentity (no sts:TagSession).
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        await assert_throws_async(
+            assume_role_with_web_identity(anon_sts, {
+                RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_F_NO_TAGSESSION}`,
+                RoleSessionName: 'f4-no-tagsession-session',
+                WebIdentityToken: token,
+            }),
+            stsErr.AccessDeniedException.code,
+            stsErr.AccessDeniedException.message
+        );
+    });
+
+    // ── F (validation) ───────────────────────────────────────────────────────
+    // AWS behaviour: an invalid Federated ARN (wrong format) in the trust policy
+    // must be rejected at CreateRole time with MalformedPolicyDocument.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+
+    mocha.it('F.v - CreateRole with invalid Federated ARN format → MalformedPolicyDocument', async function() {
+        const ROLE_INVALID_FEDERATED = 'KcRoleInvalidFederated';
+
+        let caught_err;
+        try {
+            await iam_client_role_owner.send(new CreateRoleCommand({
+                RoleName: ROLE_INVALID_FEDERATED,
+                AssumeRolePolicyDocument: JSON.stringify({
+                    Version: '2012-10-17',
+                    Statement: [{
+                        Effect: 'Allow',
+                        // Raw issuer URL instead of oidc-provider ARN — must be rejected
+                        Principal: { Federated: KEYCLOAK_ISSUER },
+                        Action: ['sts:AssumeRoleWithWebIdentity'],
+                    }],
+                }),
+            }));
+        } catch (err) {
+            caught_err = err;
+        } finally {
+            // Clean up if the role was somehow created
+            try {
+                await iam_client_role_owner.send(new DeleteRoleCommand({ RoleName: ROLE_INVALID_FEDERATED }));
+            } catch (_) { /* ignore */ }
+        }
+
+        assert.ok(caught_err, 'CreateRole should have thrown');
+        assert.equal(caught_err.Code || caught_err.code, 'MalformedPolicyDocument',
+            `Expected MalformedPolicyDocument but got: ${caught_err.Code || caught_err.code}`);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// G. PrincipalTag / ABAC edge cases
+// ---------------------------------------------------------------------------
+
+mocha.describe('Keycloak AssumeRoleWithWebIdentity – PrincipalTag ABAC edge cases', function() {
+    const { rpc_client } = coretest;
+
+    const role_owner_email = 'kc-role-owner-g1';
+    const test_bucket = KC_STS_TEST_BUCKET;
+
+    const ROLE_CASE_SENSITIVE = 'KcRoleCaseSensitive';
+    const ROLE_EMPTY_TAG = 'KcRoleEmptyTag';
+    const ROLE_MULTI_CONDITION = 'KcRoleMultiCondition';
+    const ROLE_DENY_CONFLICTS = 'KcRoleDenyConflicts';
+
+    let role_owner_account;
+    let iam_client_role_owner;
+    let anon_sts;
+    let kc_stubs;
+
+    mocha.before(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+
+        role_owner_account = await create_test_account(rpc_client, role_owner_email);
+
+        ({ iam_client: iam_client_role_owner, anon_sts } = setup_role_owner_clients(role_owner_account));
+        const federated_arn = make_keycloak_federated_arn(role_owner_account._id.toString());
+        const base_trust = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { Federated: federated_arn },
+                    Action: ['sts:AssumeRoleWithWebIdentity'],
+                },
+                {
+                    Effect: 'Allow',
+                    Principal: { Federated: federated_arn },
+                    Action: ['sts:TagSession'],
+                },
+            ],
+        };
+
+        // ── Role: StringEquals on Department (case-sensitive by default in AWS)
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_CASE_SENSITIVE,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_CASE_SENSITIVE,
+            PolicyName: 'CaseSensitivePolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`],
+                    Condition: { StringEquals: { 'aws:PrincipalTag/Department': 'Engineering' } },
+                }],
+            }),
+        }));
+
+        // ── Role: empty string tag value
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_EMPTY_TAG,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_EMPTY_TAG,
+            PolicyName: 'EmptyTagPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`],
+                    Condition: { StringEquals: { 'aws:PrincipalTag/Department': 'Engineering' } },
+                }],
+            }),
+        }));
+
+        // ── Role: multiple PrincipalTag conditions (AND logic)
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_MULTI_CONDITION,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_MULTI_CONDITION,
+            PolicyName: 'MultiConditionPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Allow',
+                    Action: ['s3:*'],
+                    Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`, `arn:aws:s3:::test11`],
+                    Condition: {
+                        StringEquals: {
+                            'aws:PrincipalTag/Department': 'Engineering',
+                            'aws:PrincipalTag/Env': 'prod',
+                        },
+                    },
+                }],
+            }),
+        }));
+
+        // ── Role: Allow in role policy + explicit Deny in bucket policy (Deny wins)
+        await iam_client_role_owner.send(new CreateRoleCommand({
+            RoleName: ROLE_DENY_CONFLICTS,
+            AssumeRolePolicyDocument: JSON.stringify(base_trust),
+        }));
+        await iam_client_role_owner.send(new PutRolePolicyCommand({
+            RoleName: ROLE_DENY_CONFLICTS,
+            PolicyName: 'AllowAllPolicy',
+            PolicyDocument: JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: 'Deny',
+                    Action: ['s3:*'],
+                    Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`],
+                }],
+            }),
+        }));
+
+        // Open bucket policy for the account
+        const account_id = role_owner_account._id.toString();
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+    });
+
+    mocha.after(async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(60000);
+        await cleanup_roles_and_account(rpc_client, iam_client_role_owner,
+            [ROLE_CASE_SENSITIVE, ROLE_EMPTY_TAG, ROLE_MULTI_CONDITION, ROLE_DENY_CONFLICTS], role_owner_email);
+    });
+
+    mocha.afterEach(function() {
+        kc_stubs = restore_kc_stubs(kc_stubs);
+    });
+
+    // ── G.5a ─────────────────────────────────────────────────────────────────
+    // AWS behaviour: StringEquals is case-sensitive.  Tag value 'engineering'
+    // must NOT match the condition 'Engineering'.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html
+
+    mocha.it('G.5a - tag value case mismatch (engineering vs Engineering) → s3:ListBucket denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Session tag: lowercase 'engineering' — policy requires 'Engineering'
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'engineering' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_CASE_SENSITIVE}`,
+            RoleSessionName: 'g5a-case-mismatch-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_CASE_SENSITIVE}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+
+    mocha.it('G.5b - tag value case matches exactly (Engineering) → s3:ListBucket allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_CASE_SENSITIVE}`,
+            RoleSessionName: 'g5b-case-match-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const result = await s3.listObjects({ Bucket: test_bucket });
+        assert.ok(result, 'listObjects should succeed when tag value matches exactly');
+    });
+
+    // ── G.6 ──────────────────────────────────────────────────────────────────
+    // AWS behaviour: an empty-string tag value does NOT satisfy a StringEquals
+    // condition that expects a non-empty value.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html
+
+    mocha.it('G.6 - tag key present but value is empty string → s3:ListBucket denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Tag key is present but value is '' — policy requires 'Engineering'
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: '' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_EMPTY_TAG}`,
+            RoleSessionName: 'g6-empty-tag-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_EMPTY_TAG}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+
+    // ── G.7 ──────────────────────────────────────────────────────────────────
+    // AWS behaviour: multiple keys inside a single Condition block are AND-ed.
+    // Both Department=Engineering AND Env=prod must be satisfied simultaneously.
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_multi-value-conditions.html
+
+    mocha.it('G.7a - both PrincipalTag conditions satisfied → s3:ListBucket allowed', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering', Env: 'prod' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_MULTI_CONDITION}`,
+            RoleSessionName: 'g7a-both-tags-match',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const result = await s3.listObjects({ Bucket: test_bucket });
+        assert.ok(result, 'listObjects should succeed when all PrincipalTag conditions are satisfied');
+    });
+
+    mocha.it('G.7b - only one of two PrincipalTag conditions satisfied → s3:ListBucket denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Department matches but Env does not
+        const token = make_keycloak_jwt({
+            'https://aws.amazon.com/tags': { principal_tags: { Department: 'Engineering', Env: 'staging' } },
+        });
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_MULTI_CONDITION}`,
+            RoleSessionName: 'g7b-one-tag-fails',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_MULTI_CONDITION}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+    });
+
+    // ── G.8 ──────────────────────────────────────────────────────────────────
+    // AWS behaviour: an explicit Deny in a bucket policy overrides an Allow in the
+    // role's identity policy.  Deny always wins (AWS evaluation logic order 5→4→3→2→1).
+    // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html
+
+    mocha.it('G.8 - explicit Deny in bucket policy overrides Allow in role policy → s3:ListBucket denied', async function() {
+        const account_id = role_owner_account._id.toString();
+
+        // Put a bucket policy that explicitly Denies listObjects for the assumed-role ARN
+        // while the role's identity policy allows s3:*.
+        await rpc_client.bucket.put_bucket_policy({
+            name: test_bucket,
+            policy: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        // Allow the account root so other tests are not affected
+                        Effect: 'Allow',
+                        Principal: {
+                            AWS: is_nc_coretest ? role_owner_email : `arn:aws:iam::${account_id}:root`,
+                        },
+                        Action: ['s3:*'],
+                        Resource: [`arn:aws:s3:::${test_bucket}`, `arn:aws:s3:::${test_bucket}/*`],
+                    },
+                    {
+                        // Explicitly Deny the assumed-role principal
+                        Effect: 'Deny',
+                        Principal: {
+                            AWS: is_nc_coretest ? role_owner_email : `arn:aws:iam::${account_id}:root`,
+                        },
+                        Action: ['s3:ListBucket'],
+                        Resource: [`arn:aws:s3:::${test_bucket}`],
+                    },
+                ],
+            },
+        });
+
+        kc_stubs = stub_keycloak(async () => make_introspect_response());
+        const token = make_keycloak_jwt();
+
+        const json = await assume_role_with_web_identity(anon_sts, {
+            RoleArn: `arn:aws:sts::${account_id}:role/${ROLE_DENY_CONFLICTS}`,
+            RoleSessionName: 'g8-deny-wins-session',
+            WebIdentityToken: token,
+        });
+        const creds = json.Credentials;
+
+        const s3 = s3_client_from_temp_creds(creds);
+        const role_arn = `arn:aws:sts::${account_id}:role/${ROLE_DENY_CONFLICTS}`;
+        await assert_s3_list_access_denied(s3, test_bucket, role_arn);
+
+        // Restore open bucket policy
+        await put_account_open_bucket_policy(rpc_client, test_bucket, account_id, role_owner_email);
+    });
+});

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -212,11 +212,15 @@ async function _is_server_side_encryption_fit(req, predicate, value) {
 
 async function _is_object_tag_fit(req, predicate, value) {
     const reply = await req.object_sdk.get_object_tagging(req.params);
-    const tag = reply?.tagging?.find(element => (element.key === value.key));
-    const tag_value = tag ? tag.value : null;
-    const res = predicate(tag_value, value.value);
-    dbg.log1('access_policy: object tag fit?', value, tag, res);
-    return res;
+    const entries = Array.isArray(value) ? value : [value];
+    for (const entry of entries) {
+        const tag = reply?.tagging?.find(element => (element.key === entry.key));
+        const tag_value = tag ? tag.value : null;
+        const res = predicate(tag_value, entry.value);
+        dbg.log1('access_policy: object tag fit?', entry, tag, res);
+        if (!res) return false;
+    }
+    return true;
 }
 async function _is_object_version_fit(req, predicate, value) {
     const version_id = req.query.versionId;
@@ -232,10 +236,15 @@ async function _is_aws_principal_tag_fit(req, predicate, value) {
     if (!session_tags) {
         return true;
     }
-    const tag_value = session_tags?.[value.key] ?? undefined;
-    const res = predicate(tag_value, value.value);
-    dbg.log1('access_policy: principal tag fit?', value, tag_value, res);
-    return res;
+    // value is an array of {key, value} entries — all must match (AND logic)
+    const entries = Array.isArray(value) ? value : [value];
+    for (const entry of entries) {
+        const tag_value = session_tags?.[entry.key] ?? undefined;
+        const res = predicate(tag_value, entry.value);
+        dbg.log1('access_policy: principal tag fit?', entry, tag_value, res);
+        if (!res) return false;
+    }
+    return true;
 }
 
 /**
@@ -522,13 +531,23 @@ async function _is_condition_fit(policy_statement, req, method, { web_identity_i
 
 function _parse_condition_keys(condition_statement) {
     // condition key might include two parts: the condition itself and the key it uses.
-    // for example s3:ExistingObjectTag/<key>: ExistingObjectTag is the condition, and <key> 
-    // is the tag key it refers
+    // for example s3:ExistingObjectTag/<key>: ExistingObjectTag is the condition, and <key>
+    // is the tag key it refers to.
+    //
+    // Multiple entries may share the same base key (e.g. aws:PrincipalTag/Department AND
+    // aws:PrincipalTag/Env).  We accumulate them into an array so that every sub-key is
+    // evaluated; previously the last write silently overwrote all earlier ones.
     for (const condition of Object.values(condition_statement)) {
         for (const [condition_key, value] of Object.entries(condition)) {
             const key_parts = condition_key.split("/");
             if (key_parts[1]) {
-                condition[key_parts[0]] = {key: key_parts[1], value: value};
+                const base_key = key_parts[0];
+                const entry = {key: key_parts[1], value: value};
+                if (Array.isArray(condition[base_key])) {
+                    condition[base_key].push(entry);
+                } else {
+                    condition[base_key] = [entry];
+                }
                 delete condition[condition_key];
             }
         }

--- a/src/util/string_utils.js
+++ b/src/util/string_utils.js
@@ -22,6 +22,9 @@ const AWS_POLICY_DOCUMENT_REGEXP = /^[\u0009\u000A\u000D\u0020-\u00FF]+$/;
 const AWS_ROLE_DESCRIPTION_REGEXP = /^[\u0009\u000A\u000D\u0020-\u007E\u00A1-\u00FF]*$/;
 const AWS_POLICY_SID_REGEXP = /^[A-Za-z0-9]*$/;
 const AWS_IAM_ARN_REGEXP = /^arn:aws:iam::\w{10,}:(?:root|user\/[\w\-\.\/]+)$/;
+// Matches a Federated OIDC-provider ARN used in Principal.Federated of a trust policy, e.g.:
+// arn:aws:iam::<account-id>:oidc-provider/keycloak.noobaa.svc.cluster.local:8080/realms/noobaa
+const AWS_OIDC_PROVIDER_ARN_REGEXP = /^arn:aws:iam::(\w+)?:oidc-provider\/.+$/;
 
 function crypto_random_string(len, charset = ALPHA_NUMERIC_CHARSET) {
     // In order to not favor any specific chars over others we limit the maximum random value
@@ -179,3 +182,4 @@ exports.AWS_POLICY_DOCUMENT_REGEXP = AWS_POLICY_DOCUMENT_REGEXP;
 exports.AWS_ROLE_DESCRIPTION_REGEXP = AWS_ROLE_DESCRIPTION_REGEXP;
 exports.AWS_POLICY_SID_REGEXP = AWS_POLICY_SID_REGEXP;
 exports.AWS_IAM_ARN_REGEXP = AWS_IAM_ARN_REGEXP;
+exports.AWS_OIDC_PROVIDER_ARN_REGEXP = AWS_OIDC_PROVIDER_ARN_REGEXP;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. Integration test for Keycloack
2. Validate assume role policy document iam structure 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. node  ./node_modules/.bin/mocha ./src/test/integration_tests/api/sts/test_sts_keycloak_integration.js

make run-single-test testpath=integration_tests/api/sts/test_sts_keycloak_integration.js


- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded STS `AssumeRoleWithWebIdentity` support for federated OIDC providers, including enhanced trust-policy condition evaluation and issuer-to-provider mapping.

- **Bug Fixes**
  - Strengthened IAM trust-policy validation and federated principal format checks.
  - Improved handling of `NotPrincipal` and multiple tag/principal-tag conditions with proper AND semantics.

- **Tests**
  - Added comprehensive mocked Keycloak/OIDC coverage for STS, ABAC, session tokens, and token edge cases.
  - Updated STS tests to use the S3 session-token client helper consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->