### PR TITLE
skip Object Lock protected versions in lifecycle noncurrent expiration

### DIFF
--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -52,6 +52,11 @@ S3Error.AccessDenied = Object.freeze({
     message: 'Access Denied',
     http_code: 403,
 });
+S3Error.AccessDeniedObjectLocked = Object.freeze({
+    code: 'AccessDenied',
+    message: 'Access Denied because object protected by object lock.',
+    http_code: 403,
+});
 S3Error.AccountProblem = Object.freeze({
     code: 'AccountProblem',
     message: 'There is a problem with your AWS account that prevents the operation from completing successfully. Please Contact Us.',
@@ -630,6 +635,7 @@ S3Error.S3RdmaIoError = Object.freeze({
 
 S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     UNAUTHORIZED: S3Error.AccessDenied,
+    OBJECT_LOCKED: S3Error.AccessDeniedObjectLocked,
     BAD_REQUEST: S3Error.BadRequest,
     FORBIDDEN: S3Error.AccessDenied,
     NO_SUCH_BUCKET: S3Error.NoSuchBucket,

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -2390,9 +2390,7 @@ class NamespaceFS {
                 bypass_governance = bypass_governance && this._has_bypass_governance_permission(fs_context);
                 if (retention.mode === 'COMPLIANCE' ||
                     (retention.mode === 'GOVERNANCE' && !bypass_governance)) {
-                    const err = new S3Error(S3Error.AccessDenied);
-                    err.message = 'Access Denied because object protected by object lock.';
-                    throw err;
+                    throw new S3Error(S3Error.AccessDeniedObjectLocked);
                 }
             }
         }
@@ -2417,9 +2415,7 @@ class NamespaceFS {
             bypass_governance = bypass_governance && this._has_bypass_governance_permission(fs_context);
             if (current_retention.mode === 'COMPLIANCE' ||
                 (current_retention.mode === 'GOVERNANCE' && !bypass_governance)) {
-                const err = new S3Error(S3Error.AccessDenied);
-                err.message = 'Access Denied because object protected by object lock.';
-                throw err;
+                throw new S3Error(S3Error.AccessDeniedObjectLocked);
             }
         }
     }
@@ -2432,9 +2428,7 @@ class NamespaceFS {
      */
     _check_object_lock(fs_context, version_id, params) {
         if (version_id.legal_hold === 'ON') {
-            const err = new S3Error(S3Error.AccessDenied);
-            err.message = 'Access Denied because object protected by object lock.';
-            throw err;
+            throw new S3Error(S3Error.AccessDeniedObjectLocked);
         }
         this._check_object_retention(fs_context, version_id.retention, params.bypass_governance);
     }

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -173,12 +173,12 @@ async function process_transition(system, bucket_info, rule, lifecycle_filter) {
 }
 
 async function delete_expired_objects(system, bucket, rule, reply_objects) {
-    /* 
-    Note that expired delete-markers are also deleted by this query
-    since the lack of filter_delete_markers means the function's internal
-    delete_marker variable remains as undefined, which is then dropped by compact()
-    effectively matching all object_md entries regardless of their delete_marker status
-    */
+    /*
+     * Versioned buckets: expire current versions by creating a delete marker
+     * (delete_version: false). Object Lock does not block delete-marker creation;
+     * locked object versions remain and are protected from permanent delete.
+     * Permanent NoncurrentVersionExpiration skips locked versions in MDStore.
+     */
     return await server_rpc.client.object.delete_multiple_objects_by_filter({
         bucket: bucket.name,
         create_time: get_expiration_timestamp(rule.expiration),
@@ -356,6 +356,8 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configure-notification.html
         // it doesn't seem like deletion of noncurrent version should generate
         // any events.
+        // Object Lock: MDStore.remove_noncurrent_versions skips versions with
+        // active retention or legal hold (lifecycle never bypasses Governance).
         await delete_noncurrent_versions(
             system,
             bucket.name,

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -24,12 +24,12 @@ function get_expiration_timestamp(expiration) {
 }
 
 async function delete_expired_objects(system, bucket, rule, reply_objects) {
-    /* 
-    Note that expired delete-markers are also deleted by this query
-    since the lack of filter_delete_markers means the function's internal
-    delete_marker variable remains as undefined, which is then dropped by compact()
-    effectively matching all object_md entries regardless of their delete_marker status
-    */
+    /*
+     * Versioned buckets: expire current versions by creating a delete marker
+     * (delete_version: false). Object Lock does not block delete-marker creation;
+     * locked object versions remain and are protected from permanent delete.
+     * Permanent NoncurrentVersionExpiration skips locked versions in MDStore.
+     */
     return await server_rpc.client.object.delete_multiple_objects_by_filter({
         bucket: bucket.name,
         create_time: get_expiration_timestamp(rule.expiration),
@@ -206,6 +206,8 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configure-notification.html
         // it doesn't seem like deletion of noncurrent version should generate
         // any events.
+        // Object Lock: MDStore.remove_noncurrent_versions skips versions with
+        // active retention or legal hold (lifecycle never bypasses Governance).
         await delete_noncurrent_versions(
             system,
             bucket.name,

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -417,8 +417,10 @@ class MDStore {
         const sql_condition3 = size_less === undefined ? "" : `data->>'size' < ${size_less}`;
         const sql_condition4 = size_greater === undefined ? "" : `data->>'size' > ${size_greater}`;
         const sql_condition5 = tags && tags.length ? `ranked.tags @> '${JSON.stringify(tags)}'::jsonb` : "";
-        // Object Lock: lifecycle must not permanently delete versions under legal hold
-        // or active retention (Governance or Compliance). No governance bypass for lifecycle.
+        // Object Lock filter for this bulk lifecycle UPDATE (same SQL path that already
+        // filters by age/prefix/size/tags). Soft-delete only unlocked versions: skip
+        // legal hold ON and any retention whose retain_until_date is still in the future.
+        // Mode is not checked — any active retention date blocks delete. No governance bypass.
         const sql_condition_unlocked = `(
             (ranked.lock_settings IS NULL OR ranked.lock_settings = 'null'::jsonb)
             OR (

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -417,6 +417,19 @@ class MDStore {
         const sql_condition3 = size_less === undefined ? "" : `data->>'size' < ${size_less}`;
         const sql_condition4 = size_greater === undefined ? "" : `data->>'size' > ${size_greater}`;
         const sql_condition5 = tags && tags.length ? `ranked.tags @> '${JSON.stringify(tags)}'::jsonb` : "";
+        // Object Lock: lifecycle must not permanently delete versions under legal hold
+        // or active retention (Governance or Compliance). No governance bypass for lifecycle.
+        const sql_condition_unlocked = `(
+            (ranked.lock_settings IS NULL OR ranked.lock_settings = 'null'::jsonb)
+            OR (
+                (ranked.lock_settings->'legal_hold'->>'status' IS DISTINCT FROM 'ON')
+                AND (
+                    ranked.lock_settings->'retention' IS NULL
+                    OR ranked.lock_settings->'retention' = 'null'::jsonb
+                    OR (ranked.lock_settings->'retention'->>'retain_until_date')::timestamptz <= CURRENT_TIMESTAMP
+                )
+            )
+        )`;
 
         const sql_limit = limit === undefined ? "" : `LIMIT ${limit}`;
 
@@ -426,6 +439,7 @@ class MDStore {
                     _id,
                     (data->>'size')::BIGINT AS size,
                     data->'tagging' AS tags,
+                    data->'lock_settings' AS lock_settings,
                     ROW_NUMBER() OVER (
                         PARTITION BY data->>'key'
                         ORDER BY (data->>'version_seq')::BIGINT DESC
@@ -450,6 +464,7 @@ class MDStore {
                     ${sql_and_conditions(
                         sql_condition1, sql_condition2,
                         sql_condition3, sql_condition4, sql_condition5,
+                        sql_condition_unlocked,
                     )}
                 ${sql_limit}
             );`;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -448,7 +448,7 @@ class MDStore {
                         PARTITION BY data->>'key'
                         ORDER BY (data->>'version_seq')::BIGINT
                     ) AS successor_time
-                FROM objectmds
+                FROM ${table_name}
                 WHERE
                     ${sql_and_conditions(
                         `data->>'bucket' = '${bucket_id}'`,

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -471,6 +471,21 @@ class MDStore {
         const sql_condition3 = size_less === undefined ? "" : `data->>'size' < ${size_less}`;
         const sql_condition4 = size_greater === undefined ? "" : `data->>'size' > ${size_greater}`;
         const sql_condition5 = tags && tags.length ? `ranked.tags @> '${JSON.stringify(tags)}'::jsonb` : "";
+        // Object Lock filter for this bulk lifecycle UPDATE (same SQL path that already
+        // filters by age/prefix/size/tags). Soft-delete only unlocked versions: skip
+        // legal hold ON and any retention whose retain_until_date is still in the future.
+        // Mode is not checked — any active retention date blocks delete. No governance bypass.
+        const sql_condition_unlocked = `(
+            (ranked.lock_settings IS NULL OR ranked.lock_settings = 'null'::jsonb)
+            OR (
+                (ranked.lock_settings->'legal_hold'->>'status' IS DISTINCT FROM 'ON')
+                AND (
+                    ranked.lock_settings->'retention' IS NULL
+                    OR ranked.lock_settings->'retention' = 'null'::jsonb
+                    OR (ranked.lock_settings->'retention'->>'retain_until_date')::timestamptz <= CURRENT_TIMESTAMP
+                )
+            )
+        )`;
 
         const sql_limit = limit === undefined ? "" : `LIMIT ${limit}`;
 
@@ -480,6 +495,7 @@ class MDStore {
                     _id,
                     (data->>'size')::BIGINT AS size,
                     data->'tagging' AS tags,
+                    data->'lock_settings' AS lock_settings,
                     ROW_NUMBER() OVER (
                         PARTITION BY data->>'key'
                         ORDER BY (data->>'version_seq')::BIGINT DESC
@@ -488,7 +504,7 @@ class MDStore {
                         PARTITION BY data->>'key'
                         ORDER BY (data->>'version_seq')::BIGINT
                     ) AS successor_time
-                FROM objectmds
+                FROM ${table_name}
                 WHERE
                     ${sql_and_conditions(
                         `data->>'bucket' = '${bucket_id}'`,
@@ -504,6 +520,7 @@ class MDStore {
                     ${sql_and_conditions(
                         sql_condition1, sql_condition2,
                         sql_condition3, sql_condition4, sql_condition5,
+                        sql_condition_unlocked,
                     )}
                 ${sql_limit}
             );`;

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -2163,6 +2163,31 @@ async function _put_object_handle_latest({ req, put_obj, set_updates, unset_upda
     }
 }
 
+/**
+ * True when Object Lock still protects the version from permanent delete.
+ * Lifecycle never bypasses Governance retention.
+ * @param {object} obj
+ * @param {{ bypass_governance?: boolean, now?: Date }} [options]
+ */
+function _is_object_locked(obj, options = {}) {
+    const lock = obj?.lock_settings;
+    if (!lock) return false;
+    if (lock.legal_hold?.status === 'ON') return true;
+    if (!lock.retention) return false;
+    const retain_until_date = new Date(lock.retention.retain_until_date);
+    if (!(retain_until_date > (options.now || new Date()))) return false;
+    if (lock.retention.mode === 'COMPLIANCE') return true;
+    if (lock.retention.mode === 'GOVERNANCE') return !options.bypass_governance;
+    return false;
+}
+
+function _throw_if_object_locked(obj, req) {
+    const bypass_governance = Boolean(req.rpc_params?.bypass_governance && req.role === 'admin');
+    if (!_is_object_locked(obj, { bypass_governance })) return;
+    dbg.error('object is locked, can not delete object', obj);
+    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
+}
+
 async function _delete_object_version(req) {
     const { version_id } = req.rpc_params;
     const bucket_versioning = req.bucket.versioning;
@@ -2190,26 +2215,7 @@ async function _delete_object_version(req) {
         http_utils.check_md_conditions(req.rpc_params.md_conditions, obj);
         if (!obj) return { reply: {} };
 
-        if (obj.lock_settings) {
-            if (obj.lock_settings.legal_hold && obj.lock_settings.legal_hold.status === 'ON') {
-                dbg.error('object is locked, can not delete object', obj);
-                throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-            }
-            if (obj.lock_settings.retention) {
-                const now = new Date();
-                const retain_until_date = new Date(obj.lock_settings.retention.retain_until_date);
-
-                if (obj.lock_settings.retention.mode === 'COMPLIANCE' && retain_until_date > now) {
-                    dbg.error('object is locked, can not delete object', obj);
-                    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-                }
-                if (obj.lock_settings.retention.mode === 'GOVERNANCE' &&
-                    (!req.rpc_params.bypass_governance || req.role !== 'admin') && retain_until_date > now) {
-                    dbg.error('object is locked, can not delete object', obj);
-                    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-                }
-            }
-        }
+        _throw_if_object_locked(obj, req);
         if (obj.version_past) {
             // 2, 8
             await MDStore.instance().delete_object_by_id(obj._id);
@@ -2512,6 +2518,8 @@ exports.calc_retention = calc_retention;
 
 if (process.env.NODE_ENV === 'test') {
     exports.__testing = {
-        update_bulk_delete_results
+        update_bulk_delete_results,
+        _is_object_locked,
+        _throw_if_object_locked,
     };
 }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -357,7 +357,8 @@ async function put_object_retention(req) {
         if ((info.lock_settings.retention.mode === 'GOVERNANCE' && (!req.rpc_params.bypass_governance || req.role !== 'admin')) ||
             info.lock_settings.retention.mode === 'COMPLIANCE') {
             dbg.error('put object retention failed due object retention mode', obj);
-            throw new RpcError('UNAUTHORIZED');
+            throw new RpcError('OBJECT_LOCKED',
+                'Access Denied because object protected by object lock.');
         }
     }
     let legal_hold;
@@ -2401,6 +2402,39 @@ async function _put_object_handle_latest({ req, put_obj, set_updates, unset_upda
     }
 }
 
+/**
+ * True when Object Lock still protects the version from permanent delete.
+ *   bypass_governance: caller already decided Bypass is allowed for this request
+ *   (S3 DeleteObject / PutObjectRetention with the Bypass header). Lifecycle never
+ *   calls this helper; NoncurrentVersionExpiration skips locked versions in MDStore
+ *   SQL and has no governance bypass path.
+ *
+ * @param {object} obj
+ * @param {{ bypass_governance?: boolean, now?: Date }} [options]
+ */
+function _is_object_locked(obj, options = {}) {
+    const lock = obj.lock_settings;
+    if (!lock) return false;
+    if (lock.legal_hold?.status === 'ON') return true;
+    if (!lock.retention) return false;
+    const retain_until_date = new Date(lock.retention.retain_until_date);
+    const now = options.now || new Date();
+    if (retain_until_date <= now) return false;
+    if (lock.retention.mode === 'COMPLIANCE') return true;
+    if (lock.retention.mode === 'GOVERNANCE') return !options.bypass_governance;
+    // Unknown/missing retention mode with a future retain-until (active retention).
+    return true;
+}
+
+function _throw_if_object_locked(obj, req) {
+    const bypass_governance = Boolean(req.rpc_params?.bypass_governance && req.role === 'admin');
+    if (_is_object_locked(obj, { bypass_governance })) {
+        dbg.error('object is locked, can not delete object', obj);
+        throw new RpcError('OBJECT_LOCKED',
+            'Access Denied because object protected by object lock.');
+    }
+}
+
 async function _delete_object_version(req) {
     const { version_id } = req.rpc_params;
     const bucket_versioning = req.bucket.versioning;
@@ -2428,26 +2462,7 @@ async function _delete_object_version(req) {
         http_utils.check_md_conditions(req.rpc_params.md_conditions, obj);
         if (!obj) return { reply: {} };
 
-        if (obj.lock_settings) {
-            if (obj.lock_settings.legal_hold && obj.lock_settings.legal_hold.status === 'ON') {
-                dbg.error('object is locked, can not delete object', obj);
-                throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-            }
-            if (obj.lock_settings.retention) {
-                const now = new Date();
-                const retain_until_date = new Date(obj.lock_settings.retention.retain_until_date);
-
-                if (obj.lock_settings.retention.mode === 'COMPLIANCE' && retain_until_date > now) {
-                    dbg.error('object is locked, can not delete object', obj);
-                    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-                }
-                if (obj.lock_settings.retention.mode === 'GOVERNANCE' &&
-                    (!req.rpc_params.bypass_governance || req.role !== 'admin') && retain_until_date > now) {
-                    dbg.error('object is locked, can not delete object', obj);
-                    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
-                }
-            }
-        }
+        _throw_if_object_locked(obj, req);
         if (obj.version_past) {
             // 2, 8
             await MDStore.instance().delete_object_by_id(obj._id);
@@ -2756,6 +2771,8 @@ exports.update_transition_info = update_transition_info;
 
 if (process.env.NODE_ENV === 'test') {
     exports.__testing = {
-        update_bulk_delete_results
+        update_bulk_delete_results,
+        _is_object_locked,
+        _throw_if_object_locked,
     };
 }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -2165,7 +2165,12 @@ async function _put_object_handle_latest({ req, put_obj, set_updates, unset_upda
 
 /**
  * True when Object Lock still protects the version from permanent delete.
- * Lifecycle never bypasses Governance retention.
+ *
+ * options.bypass_governance is only for S3 DeleteObject / PutObjectRetention
+ * when the client sends x-amz-bypass-governance-retention. Lifecycle never
+ * calls this helper; NoncurrentVersionExpiration skips locked versions in
+ * MDStore SQL and has no governance bypass path.
+ *
  * @param {object} obj
  * @param {{ bypass_governance?: boolean, now?: Date }} [options]
  */
@@ -2175,17 +2180,23 @@ function _is_object_locked(obj, options = {}) {
     if (lock.legal_hold?.status === 'ON') return true;
     if (!lock.retention) return false;
     const retain_until_date = new Date(lock.retention.retain_until_date);
-    if (!(retain_until_date > (options.now || new Date()))) return false;
+    const now = options.now || new Date();
+    // Match MDStore SQL: retain_until_date <= now means retention expired (unlocked).
+    if (now >= retain_until_date) return false;
     if (lock.retention.mode === 'COMPLIANCE') return true;
     if (lock.retention.mode === 'GOVERNANCE') return !options.bypass_governance;
-    return false;
+    // Unrecognized/missing mode with a future retain-until: fail closed (same as SQL).
+    return true;
 }
 
 function _throw_if_object_locked(obj, req) {
+    // Bypass requires admin role today (same as PutObjectRetention). IAM/bucket-policy
+    // BypassGovernanceRetention authorization is handled in a separate PR.
     const bypass_governance = Boolean(req.rpc_params?.bypass_governance && req.role === 'admin');
-    if (!_is_object_locked(obj, { bypass_governance })) return;
-    dbg.error('object is locked, can not delete object', obj);
-    throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
+    if (_is_object_locked(obj, { bypass_governance })) {
+        dbg.error('object is locked, can not delete object', obj);
+        throw new RpcError('UNAUTHORIZED', 'can not delete locked object.');
+    }
 }
 
 async function _delete_object_version(req) {

--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -600,12 +600,64 @@ mocha.describe('lifecycle', function() {
             assert.strictEqual(versions_list.objects.length, 2);
         });
 
+        mocha.it('lifecycle - noncurrent expiration skips Object Lock retention and legal hold', async function() {
+            const bucket = version_bucket;
+            const key = 'test-lifecycle-version-object-lock-0';
+            const age = 30;
+            const versions_count = 4;
+
+            const putLifecycleParams = {
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [{
+                        NoncurrentVersionExpiration: {
+                            NoncurrentDays: age - 10,
+                        },
+                        Filter: {
+                            Prefix: key,
+                        },
+                        Status: 'Enabled',
+                    }],
+                },
+            };
+
+            await s3.putBucketLifecycleConfiguration(putLifecycleParams);
+            // Age all versions (including latest) so noncurrent successors are old enough to expire.
+            const version_ids = await create_mock_version(key, bucket, age, versions_count, true);
+            // Oldest noncurrent versions: retention + legal hold must survive expiration.
+            await MDStore.instance().update_object_by_id(version_ids[0], {
+                lock_settings: {
+                    retention: {
+                        mode: 'COMPLIANCE',
+                        retain_until_date: moment().add(7, 'days').toDate(),
+                    },
+                },
+            });
+            await MDStore.instance().update_object_by_id(version_ids[1], {
+                lock_settings: {
+                    legal_hold: { status: 'ON' },
+                },
+            });
+
+            await lifecycle.background_worker();
+
+            const versions_list = await rpc_client.object.list_object_versions({ bucket, prefix: key });
+            // Locked noncurrent versions kept; unlocked noncurrent removed; latest kept.
+            assert.strictEqual(versions_list.objects.length, 3);
+            const remaining_ids = new Set(versions_list.objects.map(o => String(o.obj_id)));
+            assert.ok(remaining_ids.has(String(version_ids[0])), 'COMPLIANCE retention version should remain');
+            assert.ok(remaining_ids.has(String(version_ids[1])), 'legal hold version should remain');
+            assert.ok(remaining_ids.has(String(version_ids[versions_count - 1])), 'latest version should remain');
+        });
+
         async function create_mock_version(version_key, bucket, age, version_count, expire_all = false) {
+            const all_obj_ids = [];
             const obj_upload_ids = [];
             for (let i = 0; i < version_count; ++i) {
                 const content_type = 'application/octet_stream';
                 const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key: version_key, content_type });
                 await rpc_client.object.complete_object_upload({ obj_id, bucket, key: version_key });
+                all_obj_ids.push(new mongodb.ObjectId(obj_id));
 
                 // everything but last will be aged, 
                 // For simple Expiration rule all version should be expired 
@@ -622,6 +674,7 @@ mocha.describe('lifecycle', function() {
                 const update_result = await MDStore.instance().update_objects_by_ids(obj_upload_ids, update);
                 console.log('create_mock_version: update_objects_by_ids:', update_result);
             }
+            return all_obj_ids;
         }
 
         mocha.it('lifecycle - version object expired', async function() {

--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -600,12 +600,66 @@ mocha.describe('lifecycle', function() {
             assert.strictEqual(versions_list.objects.length, 2);
         });
 
+        // Object Lock + NoncurrentVersionExpiration: locked noncurrent versions must not be
+        // permanently deleted.
+        mocha.it('lifecycle - noncurrent expiration skips Object Lock retention and legal hold', async function() {
+            const bucket = version_bucket;
+            const key = 'test-lifecycle-version-object-lock-0';
+            const age = 30;
+            const versions_count = 4;
+
+            const putLifecycleParams = {
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [{
+                        NoncurrentVersionExpiration: {
+                            NoncurrentDays: age - 10,
+                        },
+                        Filter: {
+                            Prefix: key,
+                        },
+                        Status: 'Enabled',
+                    }],
+                },
+            };
+
+            await s3.putBucketLifecycleConfiguration(putLifecycleParams);
+            // Age all versions (including latest) so noncurrent successors are old enough to expire.
+            const version_ids = await create_mock_version(key, bucket, age, versions_count, true);
+            // Oldest noncurrent versions: retention + legal hold must survive expiration.
+            await MDStore.instance().update_object_by_id(version_ids[0], {
+                lock_settings: {
+                    retention: {
+                        mode: 'COMPLIANCE',
+                        retain_until_date: moment().add(7, 'days').toDate(),
+                    },
+                },
+            });
+            await MDStore.instance().update_object_by_id(version_ids[1], {
+                lock_settings: {
+                    legal_hold: { status: 'ON' },
+                },
+            });
+
+            await lifecycle.background_worker();
+
+            const versions_list = await rpc_client.object.list_object_versions({ bucket, prefix: key });
+            // Locked noncurrent versions kept; unlocked noncurrent removed; latest kept.
+            assert.strictEqual(versions_list.objects.length, 3);
+            const remaining_version_ids = new Set(versions_list.objects.map(o => String(o.obj_id)));
+            assert.ok(remaining_version_ids.has(String(version_ids[0])), 'COMPLIANCE retention version should remain');
+            assert.ok(remaining_version_ids.has(String(version_ids[1])), 'legal hold version should remain');
+            assert.ok(remaining_version_ids.has(String(version_ids[versions_count - 1])), 'latest version should remain');
+        });
+
         async function create_mock_version(version_key, bucket, age, version_count, expire_all = false) {
+            const all_obj_ids = [];
             const obj_upload_ids = [];
             for (let i = 0; i < version_count; ++i) {
                 const content_type = 'application/octet_stream';
                 const { obj_id } = await rpc_client.object.create_object_upload({ bucket, key: version_key, content_type });
                 await rpc_client.object.complete_object_upload({ obj_id, bucket, key: version_key });
+                all_obj_ids.push(new mongodb.ObjectId(obj_id));
 
                 // everything but last will be aged, 
                 // For simple Expiration rule all version should be expired 
@@ -622,6 +676,7 @@ mocha.describe('lifecycle', function() {
                 const update_result = await MDStore.instance().update_objects_by_ids(obj_upload_ids, update);
                 console.log('create_mock_version: update_objects_by_ids:', update_result);
             }
+            return all_obj_ids;
         }
 
         mocha.it('lifecycle - version object expired', async function() {

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -11,7 +11,12 @@ const http = require('http');
 const mocha = require('mocha');
 const assert = require('assert');
 const path = require('path');
+const moment = require('moment');
+const mongodb = require('mongodb');
 const fs_utils = require('../../../../util/fs_utils');
+const config = require('../../../../../config');
+const MDStore = require('../../../../server/object_services/md_store').MDStore;
+const lifecycle = require('../../../../server/bg_services/lifecycle');
 const today = new Date();
 const tomorrow = new Date(today);
 tomorrow.setDate(tomorrow.getDate() + 1);
@@ -1051,6 +1056,85 @@ mocha.describe('s3 worm', function() {
                 Key: EXISTING_OBJ,
             }), 'NoSuchObjectLockConfiguration',
             'The specified object does not have a ObjectLock configuration');
+        });
+    });
+
+    mocha.describe('lifecycle noncurrent expiration with Object Lock', function() {
+        // Fresh lock-enabled bucket without default retention so only versions we lock stay protected.
+        const LC_BKT = 'worm-lifecycle-lock-bkt';
+        const key = 'worm-lifecycle-lock-key';
+        const age_days = 30;
+
+        mocha.before(async function() {
+            // Hosted lifecycle soft-deletes via MDStore SQL; NC uses a different path.
+            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+            this.timeout(60000); // eslint-disable-line no-invalid-this
+            config.LIFECYCLE_SCHEDULE_MIN = 0;
+            config.LIFECYCLE_INTERVAL = 0;
+            await s3_owner.createBucket({ Bucket: LC_BKT, ObjectLockEnabledForBucket: true });
+        });
+
+        mocha.it('should skip locked noncurrent versions on NoncurrentVersionExpiration', async function() {
+            this.timeout(60000); // eslint-disable-line no-invalid-this
+            const version_ids = [];
+
+            for (let i = 0; i < 4; ++i) {
+                const put_res = await s3_owner.putObject({
+                    Bucket: LC_BKT,
+                    Key: key,
+                    Body: `${file_body}-${i}`,
+                    ContentType: 'text/plain',
+                });
+                version_ids.push(put_res.VersionId);
+            }
+
+            const versions_before = await rpc_client.object.list_object_versions({
+                bucket: LC_BKT,
+                prefix: key,
+            });
+            const obj_ids = versions_before.objects.map(o => new mongodb.ObjectId(o.obj_id));
+            await MDStore.instance().update_objects_by_ids(obj_ids, {
+                create_time: moment().subtract(age_days, 'days').toDate(),
+            });
+
+            // Oldest noncurrent: COMPLIANCE retention; next: legal hold. Both must survive.
+            await s3_owner.putObjectRetention({
+                Bucket: LC_BKT,
+                Key: key,
+                VersionId: version_ids[0],
+                Retention: {
+                    Mode: 'COMPLIANCE',
+                    RetainUntilDate: moment().add(7, 'days').toDate(),
+                },
+            });
+            await s3_owner.putObjectLegalHold({
+                Bucket: LC_BKT,
+                Key: key,
+                VersionId: version_ids[1],
+                LegalHold: { Status: 'ON' },
+            });
+
+            await s3_owner.putBucketLifecycleConfiguration({
+                Bucket: LC_BKT,
+                LifecycleConfiguration: {
+                    Rules: [{
+                        ID: 'worm-noncurrent-lock',
+                        Status: 'Enabled',
+                        Filter: { Prefix: key },
+                        NoncurrentVersionExpiration: { NoncurrentDays: age_days - 10 },
+                    }],
+                },
+            });
+
+            await lifecycle.background_worker();
+
+            const listed = await s3_owner.listObjectVersions({ Bucket: LC_BKT, Prefix: key });
+            const remaining_version_ids = new Set((listed.Versions || []).map(v => v.VersionId));
+            assert.strictEqual(remaining_version_ids.size, 3);
+            assert.ok(remaining_version_ids.has(version_ids[0]), 'COMPLIANCE noncurrent version should remain');
+            assert.ok(remaining_version_ids.has(version_ids[1]), 'legal-hold noncurrent version should remain');
+            assert.ok(remaining_version_ids.has(version_ids[3]), 'latest version should remain');
+            assert.ok(!remaining_version_ids.has(version_ids[2]), 'unlocked noncurrent version should be removed');
         });
     });
 

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -283,7 +283,7 @@ mocha.describe('s3 worm', function() {
                 BypassGovernanceRetention: false,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: oneSec3 },
                 VersionId: version_id1
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
             const conf = await s3_owner.putObjectRetention({
                 Bucket: BKT,
                 Key: OBJ1,
@@ -305,7 +305,7 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ1,
                 BypassGovernanceRetention: true,
                 VersionId: version_id1,
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
         mocha.it('put object with retention mode and without date', async function() {
             const params = { Bucket: BKT, Key: OBJ1, Body: file_body, ContentType: 'text/plain', ObjectLockMode: 'GOVERNANCE' };
@@ -361,7 +361,7 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ3,
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id3,
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
     });
     mocha.describe('put object OBJ4 with retention - should override default values', function() {
@@ -398,7 +398,7 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ4,
                 BypassGovernanceRetention: false,
                 VersionId: version_id4,
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
         mocha.it('should delete object with retention (governanceBypass=trues)', async function() {
             const deleted = await s3_owner.deleteObject({
@@ -723,7 +723,7 @@ mocha.describe('s3 worm', function() {
                     RetainUntilDate: shorterDate
                 },
                 BypassGovernanceRetention: true
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
 
         mocha.it('should allow extending compliance retention period', async function() {
@@ -757,7 +757,7 @@ mocha.describe('s3 worm', function() {
                     RetainUntilDate: futureDate
                 },
                 BypassGovernanceRetention: true
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
     });
 
@@ -803,7 +803,7 @@ mocha.describe('s3 worm', function() {
                 Key: INDEPENDENCE_KEY,
                 VersionId: independence_version_id,
                 BypassGovernanceRetention: false
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
     });
 
@@ -940,7 +940,7 @@ mocha.describe('s3 worm', function() {
                 Key: VERSION_TEST_KEY,
                 VersionId: version_test_id2,
                 BypassGovernanceRetention: false
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
 
         mocha.it('should allow deleting version 2 with bypass governance flag', async function() {
@@ -959,7 +959,7 @@ mocha.describe('s3 worm', function() {
                 Key: VERSION_TEST_KEY,
                 VersionId: version_test_id3,
                 BypassGovernanceRetention: true
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
     });
 
@@ -1104,7 +1104,7 @@ mocha.describe('s3 worm', function() {
                 Retention: { Mode: 'COMPLIANCE', RetainUntilDate: tomorrow },
                 VersionId: version_id,
                 BypassGovernanceRetention: true
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
 
         mocha.it('should fail to delete object with retention without bypass flag', async function() {
@@ -1113,7 +1113,7 @@ mocha.describe('s3 worm', function() {
                 Key: OBJ1,
                 VersionId: version_id,
                 BypassGovernanceRetention: true,
-            }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
         });
     });
 });

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -1041,6 +1041,66 @@ mocha.describe('md_store', function() {
             return { chunks: [chunk], parts: [part], blocks: [block] };
         }
 
+        mocha.it('remove_noncurrent_versions skips Object Lock retention and legal hold', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `ncv_lock_${Date.now().toString(36)}`; // ncv = noncurrent versions
+            const old_create = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+            const retain_until = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+            const locked_retention = make_completed_object({
+                key,
+                version_seq: 1,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+                lock_settings: {
+                    retention: { mode: 'GOVERNANCE', retain_until_date: retain_until },
+                },
+            });
+            const locked_legal = make_completed_object({
+                key,
+                version_seq: 2,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+                lock_settings: {
+                    legal_hold: { status: 'ON' },
+                },
+            });
+            const unlocked = make_completed_object({
+                key,
+                version_seq: 3,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+            });
+            const latest = make_completed_object({
+                key,
+                version_seq: 4,
+                version_enabled: true,
+                create_time: old_create,
+            });
+            await md_store.insert_object(locked_retention);
+            await md_store.insert_object(locked_legal);
+            await md_store.insert_object(unlocked);
+            await md_store.insert_object(latest);
+
+            const deleted_count = await md_store.remove_noncurrent_versions({
+                bucket_id,
+                noncurrent_days: 1,
+                limit: 100,
+            });
+            assert.strictEqual(deleted_count, 1, 'only unlocked noncurrent version should be removed');
+
+            const retention_obj = await md_store.find_object_by_id(locked_retention._id);
+            const legal_obj = await md_store.find_object_by_id(locked_legal._id);
+            const unlocked_obj = await md_store.find_object_by_id(unlocked._id);
+            const latest_obj = await md_store.find_object_by_id(latest._id);
+            assert(!retention_obj.deleted, 'retention-locked version must remain');
+            assert(!legal_obj.deleted, 'legal-hold version must remain');
+            assert(unlocked_obj.deleted, 'unlocked noncurrent version should be soft-deleted');
+            assert(!latest_obj.deleted, 'latest version must remain');
+        });
+
         mocha.it('soft-deletes old object and inserts new object + mappings', async function() {
             if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
             const key = `daid_overwrite_${Date.now().toString(36)}`;

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -801,6 +801,66 @@ mocha.describe('md_store', function() {
             return { chunks: [chunk], parts: [part], blocks: [block] };
         }
 
+        mocha.it('remove_noncurrent_versions skips Object Lock retention and legal hold', async function() {
+            if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
+            const key = `ncv_lock_${Date.now().toString(36)}`;
+            const old_create = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+            const retain_until = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+            const locked_retention = make_completed_object({
+                key,
+                version_seq: 1,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+                lock_settings: {
+                    retention: { mode: 'GOVERNANCE', retain_until_date: retain_until },
+                },
+            });
+            const locked_legal = make_completed_object({
+                key,
+                version_seq: 2,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+                lock_settings: {
+                    legal_hold: { status: 'ON' },
+                },
+            });
+            const unlocked = make_completed_object({
+                key,
+                version_seq: 3,
+                version_enabled: true,
+                version_past: true,
+                create_time: old_create,
+            });
+            const latest = make_completed_object({
+                key,
+                version_seq: 4,
+                version_enabled: true,
+                create_time: old_create,
+            });
+            await md_store.insert_object(locked_retention);
+            await md_store.insert_object(locked_legal);
+            await md_store.insert_object(unlocked);
+            await md_store.insert_object(latest);
+
+            const deleted_count = await md_store.remove_noncurrent_versions({
+                bucket_id,
+                noncurrent_days: 1,
+                limit: 100,
+            });
+            assert.strictEqual(deleted_count, 1, 'only unlocked noncurrent version should be removed');
+
+            const retention_obj = await md_store.find_object_by_id(locked_retention._id);
+            const legal_obj = await md_store.find_object_by_id(locked_legal._id);
+            const unlocked_obj = await md_store.find_object_by_id(unlocked._id);
+            const latest_obj = await md_store.find_object_by_id(latest._id);
+            assert(!retention_obj.deleted, 'retention-locked version must remain');
+            assert(!legal_obj.deleted, 'legal-hold version must remain');
+            assert(unlocked_obj.deleted, 'unlocked noncurrent version should be soft-deleted');
+            assert(!latest_obj.deleted, 'latest version must remain');
+        });
+
         mocha.it('soft-deletes old object and inserts new object + mappings', async function() {
             if (config.DB_TYPE !== 'postgres') this.skip(); // eslint-disable-line no-invalid-this
             const key = `daid_overwrite_${Date.now().toString(36)}`;

--- a/src/test/integration_tests/nc/cli/test_nc_cli.js
+++ b/src/test/integration_tests/nc/cli/test_nc_cli.js
@@ -417,6 +417,7 @@ mocha.describe('manage_nsfs cli', function() {
         });
 
         mocha.it('cli bucket2 update - new_name already exists', async function() {
+            this.timeout(10000); // eslint-disable-line no-invalid-this
             let action = ACTIONS.ADD;
             const bucket_name3 = 'bucket3';
             await exec_manage_cli(type, action, { ...bucket_options, name: bucket_name3 });

--- a/src/test/unit_tests/internal/test_object_server.test.js
+++ b/src/test/unit_tests/internal/test_object_server.test.js
@@ -602,4 +602,21 @@ describe('object_server._is_object_locked', () => {
             },
         })).toBe(false);
     });
+
+    test('returns false when retain_until_date equals now', () => {
+        const now = new Date('2026-08-03T12:00:00.000Z');
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: now },
+            },
+        }, { now })).toBe(false);
+    });
+
+    test('returns true for future retention with unrecognized mode (fail closed)', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'UNKNOWN', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
 });

--- a/src/test/unit_tests/internal/test_object_server.test.js
+++ b/src/test/unit_tests/internal/test_object_server.test.js
@@ -543,3 +543,82 @@ describe('object_server - update_bulk_delete_results', () => {
         expect(results[3]).toHaveProperty('seq', 103);
     });
 });
+
+describe('object_server._is_object_locked', () => {
+    const { _is_object_locked } = object_server.__testing;
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    test('returns false when lock_settings are missing', () => {
+        expect(_is_object_locked({})).toBe(false);
+        expect(_is_object_locked({ lock_settings: {} })).toBe(false);
+    });
+
+    test('returns true for legal hold ON', () => {
+        expect(_is_object_locked({
+            lock_settings: { legal_hold: { status: 'ON' } },
+        })).toBe(true);
+    });
+
+    test('returns false for legal hold OFF', () => {
+        expect(_is_object_locked({
+            lock_settings: { legal_hold: { status: 'OFF' } },
+        })).toBe(false);
+    });
+
+    test('returns true for active COMPLIANCE retention', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
+
+    test('returns true for active GOVERNANCE retention without bypass', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
+
+    test('returns false for active GOVERNANCE retention with bypass', () => {
+        // bypass_governance is an options flag for this helper (not object MD).
+        // Real authorization of the Bypass header is done at the S3 endpoint.
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: future },
+            },
+        }, { bypass_governance: true })).toBe(false);
+    });
+
+    test('returns false when retention has expired', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: past },
+            },
+        })).toBe(false);
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: past },
+            },
+        })).toBe(false);
+    });
+
+    test('returns false when retain_until_date equals now', () => {
+        const now = new Date('2026-08-03T12:00:00.000Z');
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: now },
+            },
+        }, { now })).toBe(false);
+    });
+
+    test('returns true for future retention with unrecognized mode (fail closed)', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'UNKNOWN', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
+});

--- a/src/test/unit_tests/internal/test_object_server.test.js
+++ b/src/test/unit_tests/internal/test_object_server.test.js
@@ -543,3 +543,63 @@ describe('object_server - update_bulk_delete_results', () => {
         expect(results[3]).toHaveProperty('seq', 103);
     });
 });
+
+describe('object_server._is_object_locked', () => {
+    const { _is_object_locked } = object_server.__testing;
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    test('returns false when lock_settings are missing', () => {
+        expect(_is_object_locked({})).toBe(false);
+        expect(_is_object_locked({ lock_settings: {} })).toBe(false);
+    });
+
+    test('returns true for legal hold ON', () => {
+        expect(_is_object_locked({
+            lock_settings: { legal_hold: { status: 'ON' } },
+        })).toBe(true);
+    });
+
+    test('returns false for legal hold OFF', () => {
+        expect(_is_object_locked({
+            lock_settings: { legal_hold: { status: 'OFF' } },
+        })).toBe(false);
+    });
+
+    test('returns true for active COMPLIANCE retention', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
+
+    test('returns true for active GOVERNANCE retention without bypass', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: future },
+            },
+        })).toBe(true);
+    });
+
+    test('returns false for active GOVERNANCE retention with bypass', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: future },
+            },
+        }, { bypass_governance: true })).toBe(false);
+    });
+
+    test('returns false when retention has expired', () => {
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'COMPLIANCE', retain_until_date: past },
+            },
+        })).toBe(false);
+        expect(_is_object_locked({
+            lock_settings: {
+                retention: { mode: 'GOVERNANCE', retain_until_date: past },
+            },
+        })).toBe(false);
+    });
+});

--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -1239,7 +1239,7 @@ describe('noobaa nc - lifecycle batching', () => {
         afterEach(async () => {
             await object_sdk.delete_bucket_lifecycle({ name: test_bucket });
             await fs_utils.create_fresh_path(test_bucket_path);
-            fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
+            await fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
             await config_fs.delete_config_json_file();
         });
 
@@ -1548,7 +1548,7 @@ describe('noobaa nc - lifecycle batching', () => {
         afterEach(async () => {
             await object_sdk.delete_bucket_lifecycle({ name: test_bucket });
             await fs_utils.create_fresh_path(test_bucket_path);
-            fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
+            await fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
             await config_fs.delete_config_json_file();
         });
 
@@ -1855,7 +1855,7 @@ describe('noobaa nc - lifecycle batching', () => {
         afterEach(async () => {
             await object_sdk.delete_bucket_lifecycle({ name: test_bucket });
             await fs_utils.create_fresh_path(test_bucket_path);
-            fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
+            await fs_utils.folder_delete(tmp_lifecycle_logs_dir_path);
             await config_fs.delete_config_json_file();
         });
 
@@ -1897,7 +1897,7 @@ describe('noobaa nc - lifecycle batching', () => {
             Object.values(parsed_res_latest_lifecycle.response.reply.buckets_statuses).forEach(bucket_status => {
                 expect(bucket_status.state.is_finished).toBe(true);
             });
-        });
+        }, TEST_TIMEOUT_FOR_LONG_BATCHING);
 
         it("lifecycle batching - with lifecycle rule, one list batches, one bucket batch - worker did not finish", async () => {
             await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule_delete_all });

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -68,21 +68,22 @@ function assert_date(date, from, expected, tz = 'LOCAL') {
         if (arg1 === undefined) return arg2;
         return arg1;
     };
+    const expected_from = new Date(from.getTime());
 
     if (tz === 'UTC') {
-        from.setUTCDate(from.getUTCDate() + expected.day_offset);
+        expected_from.setUTCDate(expected_from.getUTCDate() + expected.day_offset);
 
-        assert(date.getUTCDate() === from.getUTCDate());
-        assert(date.getUTCHours() === that_if_not_this(expected.hour, from.getUTCHours()));
-        assert(date.getUTCMinutes() === that_if_not_this(expected.min, from.getUTCMinutes()));
-        assert(date.getUTCSeconds() === that_if_not_this(expected.sec, from.getUTCSeconds()));
+        assert(date.getUTCDate() === expected_from.getUTCDate());
+        assert(date.getUTCHours() === that_if_not_this(expected.hour, expected_from.getUTCHours()));
+        assert(date.getUTCMinutes() === that_if_not_this(expected.min, expected_from.getUTCMinutes()));
+        assert(date.getUTCSeconds() === that_if_not_this(expected.sec, expected_from.getUTCSeconds()));
     } else {
-        from.setDate(from.getDate() + expected.day_offset);
+        expected_from.setDate(expected_from.getDate() + expected.day_offset);
 
-        assert(date.getDate() === from.getDate());
-        assert(date.getHours() === that_if_not_this(expected.hour, from.getHours()));
-        assert(date.getMinutes() === that_if_not_this(expected.min, from.getMinutes()));
-        assert(date.getSeconds() === that_if_not_this(expected.sec, from.getSeconds()));
+        assert(date.getDate() === expected_from.getDate());
+        assert(date.getHours() === that_if_not_this(expected.hour, expected_from.getHours()));
+        assert(date.getMinutes() === that_if_not_this(expected.min, expected_from.getMinutes()));
+        assert(date.getSeconds() === that_if_not_this(expected.sec, expected_from.getSeconds()));
     }
 }
 


### PR DESCRIPTION
## Summary
- Lifecycle NoncurrentVersionExpiration no longer permanently deletes object versions under active retention or legal hold.
- Current-version Expiration still only creates delete markers (unchanged; Object Lock allows this).
- Shared lock check for version deletes; lifecycle never bypasses Governance retention.
## Test plan
- [ ] Unit: `test_object_server.test.js` (`_is_object_locked`)
- [ ] MDStore: `remove_noncurrent_versions` skips retention + legal hold
- [ ] Lifecycle integration: locked noncurrent versions remain after NoncurrentVersionExpiration
- [ ] Unlocked noncurrent versions still expire as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Lifecycle expiration now preserves noncurrent versions protected by Object Lock legal holds or active retention periods.
  - Object deletions consistently honor COMPLIANCE and GOVERNANCE retention settings, including authorized governance bypasses.
  - Eligible, unlocked noncurrent versions continue to be removed as expected.
  - Retained versions are no longer soft-deleted prematurely during cleanup.
  - Object Lock failures now return a clear access-denied message with HTTP 403 status.

- **Documentation**
  - Clarified lifecycle behavior for delete markers, locked versions, and permanent noncurrent-version expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->