### PR TITLE
Restrict bucket access based on client IP address (aws:SourceIP).

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -361,6 +361,13 @@ module.exports = {
             }
         },
 
+        bucket_policy_ip_condition: {
+            type: 'object',
+            additionalProperties: {
+                $ref: '#/definitions/string_or_string_array'
+            }
+        },
+
         bucket_policy_null_condition: {
             type: 'object',
             additionalProperties: {
@@ -566,6 +573,15 @@ module.exports = {
                 },
                 Null: {
                     $ref: '#/definitions/bucket_policy_null_condition'
+                },
+                // IpAddress / NotIpAddress values are objects mapping a condition key (aws:SourceIp)
+                // to a single IP/CIDR string or an array of them. Per-value IP/CIDR format validation
+                // is performed in _validate_policy inside access_policy_utils.js.
+                IpAddress: {
+                    $ref: '#/definitions/bucket_policy_ip_condition'
+                },
+                NotIpAddress: {
+                    $ref: '#/definitions/bucket_policy_ip_condition'
                 }
             }
         },

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy_source_ip.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy_source_ip.js
@@ -1,0 +1,242 @@
+/* Copyright (C) 2016 NooBaa */
+'use strict';
+
+// setup coretest first to prepare the env
+const config = require('../../../../../config');
+const { require_coretest, TMP_PATH } = require('../../../system_tests/test_utils');
+const coretest = require_coretest();
+const { rpc_client, EMAIL, POOL_LIST } = coretest;
+coretest.setup({ pools_to_create: process.env.NC_CORETEST ? undefined : [POOL_LIST[1]] });
+const path = require('path');
+const fs_utils = require('../../../../util/fs_utils');
+
+const { S3 } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
+const http = require('http');
+const mocha = require('mocha');
+const assert = require('assert');
+
+// The test client always connects to localhost, so the server sees 127.0.0.1.
+const LOOPBACK_IP = '127.0.0.1';
+const OTHER_CIDR = '10.0.0.0/8'; // a range that never includes 127.0.0.1
+
+const BKT = 'test-source-ip-bucket-policy';
+const KEY = 'file1.txt';
+const BODY = 'source-ip-test-body';
+
+let s3_owner;
+let s3_user;
+
+async function assert_access_denied(promise) {
+    try {
+        await promise;
+        assert.fail('Expected Access Denied but the request succeeded');
+    } catch (err) {
+        if (err.message !== 'Access Denied') throw err;
+    }
+}
+
+async function setup() {
+    const self = this; // eslint-disable-line no-invalid-this
+    self.timeout(60000);
+
+    const tmp_fs_root = path.join(TMP_PATH, 'test_s3_bucket_policy_source_ip');
+    const s3_creds = {
+        endpoint: coretest.get_http_address(),
+        forcePathStyle: true,
+        region: config.DEFAULT_REGION,
+        requestHandler: new NodeHttpHandler({
+            httpAgent: new http.Agent({ keepAlive: false })
+        }),
+    };
+
+    if (process.env.NC_CORETEST) {
+        await fs_utils.create_fresh_path(tmp_fs_root, 0o777);
+    }
+
+    const nsr = 'source_ip_policy_nsr';
+    const account = {
+        has_login: false,
+        s3_access: true,
+        default_resource: process.env.NC_CORETEST ? nsr : POOL_LIST[1].name,
+    };
+    if (process.env.NC_CORETEST) {
+        account.nsfs_account_config = {
+            uid: process.getuid(),
+            gid: process.getgid(),
+            new_buckets_path: tmp_fs_root,
+        };
+    }
+
+    const admin_info = await rpc_client.account.read_account({ email: EMAIL });
+    const admin_keys = admin_info.access_keys;
+
+    const user_name = 'source-ip-test-user@test.com';
+    account.name = user_name;
+    account.email = user_name;
+    const user_details = await rpc_client.account.create_account(account);
+    const user_keys = user_details.access_keys;
+
+    s3_creds.credentials = {
+        accessKeyId: admin_keys[0].access_key.unwrap(),
+        secretAccessKey: admin_keys[0].secret_key.unwrap(),
+    };
+    s3_owner = new S3(s3_creds);
+
+    s3_creds.credentials = {
+        accessKeyId: user_keys[0].access_key.unwrap(),
+        secretAccessKey: user_keys[0].secret_key.unwrap(),
+    };
+    s3_user = new S3(s3_creds);
+
+    await s3_owner.createBucket({ Bucket: BKT });
+
+    // seed an object for GetObject tests
+    await s3_owner.putObject({ Bucket: BKT, Key: KEY, Body: BODY });
+}
+
+mocha.describe('s3_bucket_policy — aws:SourceIp condition', function() {
+    mocha.before(setup);
+
+    mocha.after(async function() {
+        await s3_owner.deleteObject({ Bucket: BKT, Key: KEY }).catch(() => undefined);
+        await s3_owner.deleteBucket({ Bucket: BKT }).catch(() => undefined);
+    });
+
+    // ------------------------------------------------------------------ helpers
+    function ip_allow_policy(cidr_or_ip) {
+        return {
+            Version: '2012-10-17',
+            Statement: [{
+                Effect: 'Allow',
+                Principal: { AWS: '*' },
+                Action: ['s3:GetObject'],
+                Resource: [`arn:aws:s3:::${BKT}/*`],
+                Condition: { IpAddress: { 'aws:SourceIp': cidr_or_ip } },
+            }],
+        };
+    }
+
+    function ip_deny_policy(cidr_or_ip) {
+        return {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { AWS: '*' },
+                    Action: ['s3:GetObject'],
+                    Resource: [`arn:aws:s3:::${BKT}/*`],
+                },
+                {
+                    Effect: 'Deny',
+                    Principal: { AWS: '*' },
+                    Action: ['s3:GetObject'],
+                    Resource: [`arn:aws:s3:::${BKT}/*`],
+                    Condition: { NotIpAddress: { 'aws:SourceIp': cidr_or_ip } },
+                },
+            ],
+        };
+    }
+
+    // ------------------------------------------------------------------ IpAddress Allow
+    mocha.describe('IpAddress operator — Allow statement', function() {
+        mocha.it('should allow GetObject when client IP matches the allowed CIDR', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy('127.0.0.1/32')),
+            });
+            const res = await s3_user.getObject({ Bucket: BKT, Key: KEY });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should deny GetObject when client IP is outside the allowed CIDR', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy(OTHER_CIDR)),
+            });
+            await assert_access_denied(s3_user.getObject({ Bucket: BKT, Key: KEY }));
+        });
+
+        mocha.it('should allow GetObject when client IP matches one of multiple CIDRs', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy([OTHER_CIDR, `${LOOPBACK_IP}/32`])),
+            });
+            const res = await s3_user.getObject({ Bucket: BKT, Key: KEY });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should deny GetObject when client IP matches none of multiple CIDRs', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy([OTHER_CIDR, '192.0.2.0/24'])),
+            });
+            await assert_access_denied(s3_user.getObject({ Bucket: BKT, Key: KEY }));
+        });
+    });
+
+    // ------------------------------------------------------------------ NotIpAddress Deny
+    mocha.describe('NotIpAddress operator — Deny statement (block all except range)', function() {
+        mocha.it('should allow GetObject when client IP is inside the allowed range', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_deny_policy('127.0.0.1/32')),
+            });
+            const res = await s3_user.getObject({ Bucket: BKT, Key: KEY });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should deny GetObject when client IP is outside the allowed range', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_deny_policy(OTHER_CIDR)),
+            });
+            await assert_access_denied(s3_user.getObject({ Bucket: BKT, Key: KEY }));
+        });
+    });
+
+    // ------------------------------------------------------------------ putBucketPolicy schema validation
+    mocha.describe('putBucketPolicy schema validation', function() {
+        mocha.it('should accept a policy with IpAddress condition', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            const res = await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy('127.0.0.1/32')),
+            });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should accept a policy with NotIpAddress condition', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            const res = await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_deny_policy('127.0.0.1/32')),
+            });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+
+        mocha.it('should accept a policy with an array of CIDRs', async function() {
+            const self = this; // eslint-disable-line no-invalid-this
+            self.timeout(15000);
+            const res = await s3_owner.putBucketPolicy({
+                Bucket: BKT,
+                Policy: JSON.stringify(ip_allow_policy(['127.0.0.1/32', '192.0.2.0/24'])),
+            });
+            assert.equal(res.$metadata.httpStatusCode, 200);
+        });
+    });
+});

--- a/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js
@@ -211,12 +211,91 @@ describe('access_policy_utils', () => {
             });
         });
 
+        describe('valid aws:SourceIp conditions', () => {
+            it('should accept aws:SourceIp with IpAddress operator', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': '192.0.2.0/24' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept aws:SourceIp with NotIpAddress operator', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { NotIpAddress: { 'aws:SourceIp': '192.0.2.0/24' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept aws:SourceIp with an array of CIDR ranges', async () => {
+                const policy = make_policy({
+                    action: 's3:PutObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': ['192.0.2.0/24', '10.0.0.0/8'] } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept aws:SourceIp with an exact IPv4 address', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': '203.0.113.5' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+
+            it('should accept aws:SourceIp with an IPv6 CIDR', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': '2001:db8::/32' } },
+                });
+                await expect(
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                ).resolves.toBeUndefined();
+            });
+        });
+
         describe('invalid conditions', () => {
             it('should reject an unsupported condition key', async () => {
                 const policy = make_policy({
                     action: 's3:PutObject',
                     resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
-                    condition: { StringEquals: { 'aws:SourceIp': '10.0.0.0/8' } },
+                    condition: { StringEquals: { 'aws:UnknownKey': 'value' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject a non-IP string as aws:SourceIp value', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': 'not-an-ip' } },
+                });
+                await expect_malformed_policy(() =>
+                    access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
+                );
+            });
+
+            it('should reject an invalid CIDR in an array value', async () => {
+                const policy = make_policy({
+                    action: 's3:GetObject',
+                    resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    condition: { IpAddress: { 'aws:SourceIp': ['192.0.2.0/24', 'bad-entry'] } },
                 });
                 await expect_malformed_policy(() =>
                     access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
@@ -501,6 +580,333 @@ describe('access_policy_utils', () => {
             await expect_malformed_policy(() =>
                 access_policy_utils.validate_bucket_policy(policy, BUCKET_NAME, account_handler_allow_all)
             );
+        });
+    });
+
+    describe('aws:SourceIp condition evaluation', () => {
+        /**
+         * Build a minimal fake req object with the given IP address.
+         * _is_source_ip_fit reads req.socket.remoteAddress directly — X-Forwarded-For
+         * is intentionally ignored as it is client-controlled.
+         */
+        function make_req(ip) {
+            return {
+                headers: {},
+                socket: { remoteAddress: ip },
+                query: {},
+                params: {},
+            };
+        }
+
+        /** Build a minimal policy statement for has_access_policy_permission */
+        function make_ip_statement({ effect = 'Allow', operator, ips }) {
+            return {
+                Version: '2012-10-17',
+                Statement: [{
+                    Effect: effect,
+                    Principal: '*',
+                    Action: 's3:GetObject',
+                    Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                    Condition: { [operator]: { 'aws:SourceIp': ips } },
+                }],
+            };
+        }
+
+        describe('IpAddress operator — CIDR matching', () => {
+            it('should ALLOW when client IP is in the allowed CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('192.0.2.100')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when client IP is outside the allowed CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('10.0.0.1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW when client IP matches one of multiple CIDRs', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: ['10.0.0.0/8', '192.0.2.0/24'] });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('10.1.2.3')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when client IP matches none of the CIDRs', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: ['10.0.0.0/8', '192.0.2.0/24'] });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('172.16.0.1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW when client IP matches an exact IP entry', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '203.0.113.5' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('203.0.113.5')
+                );
+                expect(result).toBe('ALLOW');
+            });
+        });
+
+        describe('NotIpAddress operator', () => {
+            it('should ALLOW when client IP is outside the excluded CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'NotIpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('10.0.0.1')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when client IP is inside the excluded CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'NotIpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('192.0.2.50')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+        });
+
+        describe('Deny + IpAddress (block unless in range)', () => {
+            it('should DENY when client IP is outside the allowed range', async () => {
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                        },
+                        {
+                            Effect: 'Deny',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                            Condition: { NotIpAddress: { 'aws:SourceIp': '192.0.2.0/24' } },
+                        },
+                    ],
+                };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('10.0.0.1')
+                );
+                expect(result).toBe('DENY');
+            });
+
+            it('should ALLOW when client IP is inside the allowed range', async () => {
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                        },
+                        {
+                            Effect: 'Deny',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                            Condition: { NotIpAddress: { 'aws:SourceIp': '192.0.2.0/24' } },
+                        },
+                    ],
+                };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('192.0.2.77')
+                );
+                expect(result).toBe('ALLOW');
+            });
+        });
+
+        describe('IPv6-mapped IPv4 normalisation', () => {
+            it('should ALLOW when client uses IPv6-mapped IPv4 address inside the CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('::ffff:192.0.2.100')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when client uses IPv6-mapped IPv4 address outside the CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('::ffff:10.0.0.1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+        });
+
+        describe('native IPv6', () => {
+            it('should ALLOW when client IPv6 address is inside an IPv6 CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '2001:db8::/32' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db8::1')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when client IPv6 address is outside the IPv6 CIDR', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '2001:db8::/32' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db9::1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW exact IPv6 address match', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '2001:db8::1' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db8::1')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY when IPv6 client is tested against an IPv4 CIDR', async () => {
+                // Different address families never match — an IPv6 client is not inside an IPv4 range.
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db8::1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should IMPLICIT_DENY when IPv4 client is tested against an IPv6 CIDR', async () => {
+                // Inverse of above — IPv4 client is not inside an IPv6 range.
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '2001:db8::/32' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('192.0.2.1')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW for NotIpAddress when IPv6 client is outside the excluded range', async () => {
+                const policy = make_ip_statement({ operator: 'NotIpAddress', ips: '2001:db8::/32' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db9::1')
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should IMPLICIT_DENY for NotIpAddress when IPv6 client is inside the excluded range', async () => {
+                const policy = make_ip_statement({ operator: 'NotIpAddress', ips: '2001:db8::/32' });
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, make_req('2001:db8::ff')
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+        });
+
+        describe('X-Forwarded-For spoofing resistance', () => {
+            it('should IMPLICIT_DENY when client forges X-Forwarded-For to appear inside the CIDR but real TCP IP is outside', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                // Client is actually at 10.0.0.1 but sends a spoofed header claiming 192.0.2.1
+                const req = {
+                    headers: { 'x-forwarded-for': '192.0.2.1' },
+                    socket: { remoteAddress: '10.0.0.1' },
+                    query: {},
+                    params: {},
+                };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, req
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW when real TCP IP is inside the CIDR regardless of X-Forwarded-For', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                // Client is legitimately at 192.0.2.50 but also sends a forwarded header
+                const req = {
+                    headers: { 'x-forwarded-for': '10.0.0.1' },
+                    socket: { remoteAddress: '192.0.2.50' },
+                    query: {},
+                    params: {},
+                };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, req
+                );
+                expect(result).toBe('ALLOW');
+            });
+        });
+
+        describe('missing client IP', () => {
+            // An absent remoteAddress is treated as '' which matches no range.
+            // Behaviour per Effect+operator:
+            //   Allow  + IpAddress    → condition false → Allow skipped  → IMPLICIT_DENY
+            //   Deny   + IpAddress    → condition false → Deny skipped   → (Allow elsewhere decides)
+            //   Allow  + NotIpAddress → condition true  → Allow fires    → ALLOW
+            //   Deny   + NotIpAddress → condition true  → Deny fires     → DENY
+            it('should IMPLICIT_DENY for Allow+IpAddress when socket has no remoteAddress', async () => {
+                const policy = make_ip_statement({ operator: 'IpAddress', ips: '192.0.2.0/24' });
+                const req = { headers: {}, socket: {}, query: {}, params: {} };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, req
+                );
+                expect(result).toBe('IMPLICIT_DENY');
+            });
+
+            it('should ALLOW for Allow+NotIpAddress when socket has no remoteAddress', async () => {
+                const policy = make_ip_statement({ operator: 'NotIpAddress', ips: '192.0.2.0/24' });
+                const req = { headers: {}, socket: {}, query: {}, params: {} };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, req
+                );
+                expect(result).toBe('ALLOW');
+            });
+
+            it('should DENY for Deny+NotIpAddress when socket has no remoteAddress', async () => {
+                const policy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                        },
+                        {
+                            Effect: 'Deny',
+                            Principal: '*',
+                            Action: 's3:GetObject',
+                            Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+                            Condition: { NotIpAddress: { 'aws:SourceIp': '192.0.2.0/24' } },
+                        },
+                    ],
+                };
+                const req = { headers: {}, socket: {}, query: {}, params: {} };
+                const result = await access_policy_utils.has_access_policy_permission(
+                    policy, '*', 's3:GetObject',
+                    `arn:aws:s3:::${BUCKET_NAME}/obj`, req
+                );
+                expect(result).toBe('DENY');
+            });
         });
     });
 });

--- a/src/test/utils/index/nc_index.js
+++ b/src/test/utils/index/nc_index.js
@@ -17,6 +17,7 @@ require('../../integration_tests/nsfs/test_nsfs_integration');
 require('../../unit_tests/nsfs/test_bucketspace_fs');
 require('../../unit_tests/nsfs/test_nsfs_glacier_backend');
 require('../../integration_tests/api/s3/test_s3_bucket_policy');
+require('../../integration_tests/api/s3/test_s3_bucket_policy_source_ip');
 require('../../unit_tests/nsfs/test_nsfs_versioning');
 require('../../integration_tests/nsfs/test_bucketspace_versioning');
 require('../../integration_tests/nc/cli/test_nc_bucket_logging');

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -6,6 +6,7 @@ const dbg = require('./debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
 const RpcError = require('../rpc/rpc_error');
 const jwt = require('jsonwebtoken');
+const net_utils = require('./net_utils');
 
 const OP_NAME_TO_ACTION = Object.freeze({
     delete_bucket_analytics: { regular: "s3:PutAnalyticsConfiguration" },
@@ -111,13 +112,18 @@ const predicate_map = {
         return !value_regex.test(request_value);
     },
     'Null': function(request_value, policy_value) { return policy_value === 'true' ? request_value === null : request_value !== null; },
+    // IpAddress: true when the request IP matches any of the given CIDR ranges (or exact IPs).
+    'IpAddress': _ip_address_predicate,
+    // NotIpAddress: true when the request IP does NOT match any of the given CIDR ranges (or exact IPs).
+    'NotIpAddress': (request_value, policy_value) => !_ip_address_predicate(request_value, policy_value),
 };
 
 const condition_fit_functions = {
     's3:ExistingObjectTag': _is_object_tag_fit,
     's3:x-amz-server-side-encryption': _is_server_side_encryption_fit,
     's3:VersionId': _is_object_version_fit,
-    'aws:PrincipalTag': _is_aws_principal_tag_fit
+    'aws:PrincipalTag': _is_aws_principal_tag_fit,
+    'aws:SourceIp': _is_source_ip_fit,
 };
 
 const keycloak_predicate_map = {
@@ -135,10 +141,66 @@ const supported_actions = {
 
 // Condition keys that are principal/session-scoped rather than action-scoped —
 // they apply regardless of which S3 method is being called.
-const SKIPPED_CONDITIONS_ACTION = new Set(['aws:PrincipalTag']);
+const SKIPPED_CONDITIONS_ACTION = new Set(['aws:PrincipalTag', 'aws:SourceIp']);
 
 
-const SUPPORTED_BUCKET_POLICY_CONDITIONS = Object.keys(supported_actions);
+const SUPPORTED_BUCKET_POLICY_CONDITIONS = [...Object.keys(supported_actions), 'aws:SourceIp'];
+
+/**
+ * _ip_address_predicate returns true when the given IP matches the policy value.
+ * The policy value may be a single CIDR/IP string or an array of CIDR/IP strings.
+ * Matching logic mirrors AWS: CIDR ranges use subnet containment; bare IPs use exact equality
+ * after normalising IPv6-mapped IPv4 addresses (e.g. ::ffff:1.2.3.4 → 1.2.3.4).
+ *
+ * An absent or empty request_ip means the source address was not available on the
+ * request (e.g. internal or test path with no socket). An unknown IP cannot
+ * meaningfully match any range, so we always return false — callers that invert
+ * this result (NotIpAddress) will receive true, which is the agreed semantics:
+ * "unknown IP is treated as not being in any range".
+ *
+ * @param {string} request_ip - The client IP address, or '' if unavailable.
+ * @param {string|string[]} policy_value - One or more CIDR ranges / exact IPs from the policy.
+ * @returns {boolean}
+ */
+function _ip_address_predicate(request_ip, policy_value) {
+    if (!request_ip) return false;
+    const ip = net_utils.unwrap_ipv6(request_ip);
+    for (const entry of _.flatten([policy_value])) {
+        if (net_utils.is_cidr(entry)) {
+            if (net_utils.cidr_subnet_contains(entry, ip)) return true;
+        } else if (ip === net_utils.unwrap_ipv6(entry)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * _is_source_ip_fit evaluates the aws:SourceIp condition key.
+ * Used by both IpAddress (allow when matches) and NotIpAddress (allow when does not match).
+ *
+ * X-Forwarded-For is intentionally ignored: it is fully client-controlled when
+ * there is no trusted proxy, and NooBaa has no trusted-proxy configuration.
+ * req.socket.remoteAddress is the only tamper-proof source of the client IP —
+ * it is set by the OS from the TCP handshake and cannot be forged.
+ *
+ * An absent remoteAddress is passed as '' to the predicate. _ip_address_predicate
+ * has an explicit null/empty check that returns false for a missing IP, making
+ * the "no IP" semantics clear at the predicate level:
+ *   - IpAddress    + no IP → predicate false → Allow skipped,  Deny skipped
+ *   - NotIpAddress + no IP → predicate true  → Allow granted,  Deny fires
+ *
+ * @param {Object} req - Incoming HTTP request.
+ * @param {Function} predicate - The operator predicate from predicate_map.
+ * @param {string|string[]} value - CIDR ranges or exact IPs from the policy condition.
+ * @returns {Promise<boolean>}
+ */
+async function _is_source_ip_fit(req, predicate, value) {
+    const client_ip = net_utils.unwrap_ipv6(req?.socket?.remoteAddress || '');
+    const res = predicate(client_ip, value);
+    dbg.log1('access_policy: source-ip fit?', value, client_ip, res);
+    return res;
+}
 
 async function _is_server_side_encryption_fit(req, predicate, value) {
     const encryption = s3_utils.parse_encryption(req);
@@ -474,6 +536,19 @@ function _parse_condition_keys(condition_statement) {
 }
 
 /**
+ * _validate_ip_condition_values checks that every entry in an IpAddress / NotIpAddress
+ * condition value is a valid IP address or CIDR range (IPv4 or IPv6).
+ * @param {string|string[]} condition_value
+ */
+function _validate_ip_condition_values(condition_value) {
+    for (const entry of _.flatten([condition_value])) {
+        if (!net_utils.is_cidr(entry) && !net_utils.is_ip(entry)) {
+            throw new RpcError('MALFORMED_POLICY', 'Policy has invalid IP or CIDR in condition', { detail: entry });
+        }
+    }
+}
+
+/**
  * _validate_policy is the shared validation logic for both S3 bucket policies and vector bucket policies.
  * @param {Object} policy - the policy document to validate
  * @param {string} bucket_name - the bucket name to validate resources against
@@ -529,11 +604,14 @@ async function _validate_policy(policy, bucket_name, get_account_handler, option
             }
         }
         if (statement.Condition) {
-            for (const condition of Object.values(statement.Condition)) {
-                for (const condition_key of Object.keys(condition)) {
+            for (const [condition_operator, condition] of Object.entries(statement.Condition)) {
+                for (const [condition_key, condition_value] of Object.entries(condition)) {
                     const key_to_check = split_condition_key ? condition_key.split("/")[0] : condition_key;
                     if (!supported_condition_keys.includes(key_to_check)) {
                         throw new RpcError('MALFORMED_POLICY', 'Policy has invalid condition key or unsupported condition key', { detail: condition_key });
+                    }
+                    if (condition_operator === 'IpAddress' || condition_operator === 'NotIpAddress') {
+                        _validate_ip_condition_values(condition_value);
                     }
                 }
             }


### PR DESCRIPTION

### Describe the Problem

Bucket policies should support adding restrictions based on client source IP (aws:SourceIP). F.ex. only allow S3 GET or S3 PUT from given IPs or IP ranges.

### Explain the Changes
1.  Implement support for aws:SourceIP in bucket policy conditions.
2.  Add unit test to make sure not to trust x-forwarded-for in this condition, since that can be spoofed.

### Testing Instructions:
1. Add bucket policy like the below, and test if it allows only the given client IPs:


```
{
  "Id": "SourceIP",
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "AllowTwoIPs",
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "*"
    },
    {
      "Sid": "DenyOthers",
      "Effect": "Deny",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "*",
      "Condition": {
        "NotIpAddress": {
          "aws:SourceIp": [
            "11.11.11.11/32",
            "22.22.22.22/32"
          ]
        }
      }
    }
  ]
}
```

and/or run unit tests:

```
npx jest src/test/unit_tests/util_functions_tests/test_access_policy_utils.test.js --no-coverage
```

- [ ] Doc added/updated

none

- [ ] Tests added

```
  access_policy_utils
    validate_bucket_policy
      valid aws:SourceIp conditions
        ✓ should accept aws:SourceIp with IpAddress operator (1 ms)
        ✓ should accept aws:SourceIp with NotIpAddress operator
        ✓ should accept aws:SourceIp with an array of CIDR ranges
        ✓ should accept aws:SourceIp with an exact IPv4 address
        ✓ should accept aws:SourceIp with an IPv6 CIDR (2 ms)

    aws:SourceIp condition evaluation
      IpAddress operator — CIDR matching
        ✓ should ALLOW when client IP is in the allowed CIDR (7 ms)
        ✓ should IMPLICIT_DENY when client IP is outside the allowed CIDR
        ✓ should ALLOW when client IP matches one of multiple CIDRs
        ✓ should IMPLICIT_DENY when client IP matches none of the CIDRs (1 ms)
        ✓ should ALLOW when client IP matches an exact IP entry
      NotIpAddress operator
        ✓ should ALLOW when client IP is outside the excluded CIDR
        ✓ should IMPLICIT_DENY when client IP is inside the excluded CIDR (2 ms)
      Deny + IpAddress (block unless in range)
        ✓ should DENY when client IP is outside the allowed range (1 ms)
        ✓ should ALLOW when client IP is inside the allowed range
      IPv6-mapped IPv4 normalisation
        ✓ should ALLOW when client uses IPv6-mapped IPv4 address inside the CIDR (1 ms)
        ✓ should IMPLICIT_DENY when client uses IPv6-mapped IPv4 address outside the CIDR
      native IPv6
        ✓ should ALLOW when client IPv6 address is inside an IPv6 CIDR
        ✓ should IMPLICIT_DENY when client IPv6 address is outside the IPv6 CIDR
        ✓ should ALLOW exact IPv6 address match
        ✓ should IMPLICIT_DENY when IPv6 client is tested against an IPv4 CIDR
        ✓ should IMPLICIT_DENY when IPv4 client is tested against an IPv6 CIDR
        ✓ should ALLOW for NotIpAddress when IPv6 client is outside the excluded range
        ✓ should IMPLICIT_DENY for NotIpAddress when IPv6 client is inside the excluded range
      X-Forwarded-For spoofing resistance
        ✓ should IMPLICIT_DENY when client forges X-Forwarded-For to appear inside the CIDR but real TCP IP is outside
        ✓ should ALLOW when real TCP IP is inside the CIDR regardless of X-Forwarded-For
      missing client IP
        ✓ should IMPLICIT_DENY for Allow+IpAddress when socket has no remoteAddress
        ✓ should ALLOW for Allow+NotIpAddress when socket has no remoteAddress (1 ms)
        ✓ should DENY for Deny+NotIpAddress when socket has no remoteAddress
```



This intentionally does *not* trust x-forwarded-for header, since that's a client controlled header, and hence will not work when there is a HTTP/HTTPS proxy between client and noobaa. If we're to support this via proxy, we will need to implement a "trusted proxy" configuration before we can change the code to consider x-forwarded-for header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for `aws:SourceIp` conditions via `IpAddress` and `NotIpAddress`, supporting single values, CIDR ranges, and IPv4/IPv6 matching (including IPv4-mapped IPv6).
  * Bucket policy evaluation now applies source-IP checks using the server-observed client IP.

* **Bug Fixes**
  * Improved allow/deny behavior for matching and non-matching client IPs.
  * Ensures policies behave safely when the client IP is missing (implicit deny for `IpAddress`).

* **Tests**
  * Added unit and S3 integration coverage, including schema validation for these new operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->