### PR TITLE
DEEP_ARCHIVE | Multipart Upload implementation

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -61,7 +61,7 @@ module.exports = {
                         idate: true
                     },
                     storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
-                    archive_upload_id: { type: 'string' },
+                    target_data_info: { $ref: '#/definitions/target_data_info' },
                     defer_put_mapping: { type: 'boolean' },
                 }
             },
@@ -218,6 +218,33 @@ module.exports = {
                 }
             },
             auth: { system: ['admin', 'user'] }
+        },
+
+        read_object_upload: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: [
+                    'obj_id',
+                    'bucket',
+                    'key',
+                ],
+                properties: {
+                    obj_id: { objectid: true },
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: { type: 'string' },
+                }
+            },
+            reply: {
+                type: 'object',
+                properties: {
+                    storage_class: {
+                        $ref: 'common_api#/definitions/storage_class_enum',
+                    },
+                    target_data_info: { $ref: '#/definitions/target_data_info' },
+                }
+            },
+            auth: { system: ['admin'] }
         },
 
         create_multipart: {
@@ -632,6 +659,8 @@ module.exports = {
                     cache_last_valid_time: { idate: true },
                     last_modified_time: { idate: true },
                     restore_status: { $ref: '#/definitions/restore_status' },
+                    target_data_info: { $ref: '#/definitions/target_data_info' },
+                    invalidate_md_cache: { type: 'boolean' },
                 }
             },
             auth: { system: ['admin', 'user'] }
@@ -1660,6 +1689,13 @@ module.exports = {
 
     definitions: {
 
+        target_data_info: {
+            type: 'object',
+            properties: {
+                upload_id: { type: 'string' },
+            }
+        },
+
         object_info: {
             type: 'object',
             required: [
@@ -1705,7 +1741,7 @@ module.exports = {
                 s3_signed_url: { type: 'string' },
                 lock_settings: { $ref: 'common_api#/definitions/lock_settings' },
                 storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
-                archive_upload_id: { type: 'string' },
+                target_data_info: { $ref: '#/definitions/target_data_info' },
                 // currently no properties for the object as there is no implementation
                 object_owner: {
                     type: 'object',

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -648,7 +648,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     IF_NONE_MATCH_ETAG: S3Error.NotModified,
     IO_STREAM_ITEM_TIMEOUT: S3Error.SlowDown,
     INVALID_PART: S3Error.InvalidPart,
-    INVALID_PORT_ORDER: S3Error.InvalidPartOrder,
+    INVALID_PART_ORDER: S3Error.InvalidPartOrder,
     INVALID_BUCKET_STATE: S3Error.InvalidBucketState,
     NOT_ENOUGH_SPACE: S3Error.InvalidBucketState,
     OBJECT_QUOTA_EXCEEDED: S3Error.ObjectQuotaExceeded,

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -38,6 +38,7 @@ const DEFAULT_OBJECT_ACL = Object.freeze({
 
 const XATTR_SORT_SYMBOL = Symbol('XATTR_SORT_SYMBOL');
 const base64_regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const object_id_regex = /^[0-9a-fA-F]{24}$/;
 
 const X_NOOBAA_AVAILABLE_STORAGE_CLASSES = 'x-noobaa-available-storage-classes';
 
@@ -746,6 +747,15 @@ function parse_version_id(version_id, empty_err = S3Error.InvalidArgumentEmptyVe
 }
 
 /**
+ * Throw S3 NoSuchUpload when upload id is missing or not a valid ObjectId.
+ * Avoids RPC schema INVALID_SCHEMA_PARAMS for malformed UploadId values.
+ * @param {string} [upload_id]
+ */
+function throw_if_invalid_upload_id(upload_id) {
+    if (!upload_id || !object_id_regex.test(upload_id)) throw new S3Error(S3Error.NoSuchUpload);
+}
+
+/**
  * 
  * @param {*} req 
  * @returns {number}
@@ -888,6 +898,7 @@ exports.response_field_encoder_url = response_field_encoder_url;
 exports.parse_decimal_int = parse_decimal_int;
 exports.parse_restore_request_days = parse_restore_request_days;
 exports.parse_version_id = parse_version_id;
+exports.throw_if_invalid_upload_id = throw_if_invalid_upload_id;
 exports.get_object_owner = get_object_owner;
 exports.get_default_object_owner = get_default_object_owner;
 exports.set_response_supported_storage_classes = set_response_supported_storage_classes;

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -4,9 +4,10 @@
 const _ = require('lodash');
 const dbg = require('../util/debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
-const { get_archive_key, throw_if_restore_incomplete, is_restore_active, compute_restore_expiry } = require('../util/deep_archive_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
-const { get_create_object_upload_params, get_complete_object_upload_params } = require('../util/object_utils');
+const { get_archive_key, throw_if_restore_incomplete, is_restore_active, compute_restore_expiry } = require('../util/deep_archive_utils');
+const { get_create_object_upload_params, get_complete_object_upload_params, CREATE_MULTIPART_PARAMS,
+    COMPLETE_MULTIPART_PARAMS, destroy_source_stream } = require('../util/object_utils');
 
 /**
  * NamespaceMultiStorageClass routes operations to different namespaces based on
@@ -97,7 +98,7 @@ class NamespaceMultiStorageClass {
 
     /**
      * Lists in-progress multipart uploads from the metadata namespace.
-     * Client UploadId is the NB obj_id; archive_upload_id is stored on the upload
+     * Client UploadId is the NB obj_id; target_data_info.upload_id is stored on the upload
      * object and looked up when talking to the archive backend.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
@@ -133,9 +134,10 @@ class NamespaceMultiStorageClass {
 
     /**
      * Streams object data.
-     * STANDARD (default) objects are read from the metadata namespace.
-     * Non-default storage classes (e.g. DEEP_ARCHIVE / GLACIER) are not
-     * readable until restored — throw InvalidObjectState.
+     * STANDARD objects and actively restored archive objects are read from the
+     * metadata namespace (NamespaceNB holds the live/restore copy).
+     * Non-default storage classes (e.g. DEEP_ARCHIVE / GLACIER) that are not
+     * restored throw InvalidObjectState.
      * add res to the params when NamespaceFS becomes a supported deep-archive resource
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
@@ -144,10 +146,7 @@ class NamespaceMultiStorageClass {
     async read_object_stream(params, object_sdk) {
         const object_md = params.object_md || await this._metadata_ns.read_object_md(params, object_sdk);
         const storage_class = s3_utils.parse_storage_class(object_md.storage_class);
-        if (storage_class !== this.default_storage_class) {
-            if (!s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) {
-                throw new S3Error(S3Error.NotImplemented);
-            }
+        if (!this.is_standard_storage_class(storage_class)) {
             throw_if_restore_incomplete(params.bucket, object_md);
         }
         return this._metadata_ns.read_object_stream({ ...params, object_md }, object_sdk);
@@ -168,13 +167,9 @@ class NamespaceMultiStorageClass {
      * @returns {Promise<object>}
      */
     async upload_object(params, object_sdk) {
-        const storage_class = s3_utils.parse_storage_class(params.storage_class);
-        const target_ns = this.namespace_by_storage_class[storage_class];
-        if (!target_ns) {
-            throw new S3Error(S3Error.NotImplemented);
-        }
-
-        if (storage_class === this.default_storage_class) {
+        const storage_class = params.storage_class;
+        const target_ns = this.get_namespace_for_storage_class(storage_class);
+        if (this.is_standard_storage_class(storage_class)) {
             return target_ns.upload_object(params, object_sdk);
         }
         return this._upload_object_non_standard_sc(params, object_sdk, { storage_class, target_ns });
@@ -213,27 +208,53 @@ class NamespaceMultiStorageClass {
 
     /**
      * Creates a multipart upload.
-     * For archive storage classes: create on archive + NB (pass archive_upload_id into
-     * NB create_object_upload), return the NB obj_id as the client UploadId.
+     * STANDARD: delegated to the target namespace (NamespaceNB) (data + MD in NooBaa).
+     * GLACIER / DEEP_ARCHIVE: create upload MD in NooBaa, create MPU on the
+     * archive resource, and map NooBaa `obj_id` (client UploadId) to
+     * `target_data_info.upload_id` on the upload MD.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async create_object_upload(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const storage_class = params.storage_class;
+        const target_ns = this.get_namespace_for_storage_class(storage_class);
+        if (this.is_standard_storage_class(storage_class)) {
+            return target_ns.create_object_upload(params, object_sdk);
+        }
+        return this._create_object_upload_archive(params, object_sdk, { storage_class, target_ns });
     }
 
     /**
+     * Uploads a multipart part.
+     * STANDARD: delegated to the target namespace directly (NamespaceNB) (MD + data in NooBaa)
+     * Archive: create part MD → upload part data to archive → complete part MD
+     * On failure - Destroy the source stream
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async upload_multipart(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        // Resolve upload MD before touching the body. Do not destroy the source
+        // stream on preflight NoSuchUpload — that aborts the HTTP request mid-body
+        // and surfaces as socket hang up to the client.
+        const upload_md = await this._read_upload_md(params, object_sdk);
+        const storage_class = upload_md.storage_class;
+        const target_ns = this.get_namespace_for_storage_class(storage_class);
+        if (this.is_standard_storage_class(storage_class)) {
+            return target_ns.upload_multipart(params, object_sdk);
+        }
+        try {
+            return await this._upload_multipart_archive(params, object_sdk, { upload_md, storage_class, target_ns });
+        } catch (err) {
+            destroy_source_stream(params);
+            throw err;
+        }
     }
 
     /**
-     * Lists uploaded parts from the metadata namespace (source of truth for part metadata).
+     * Lists uploaded parts from the metadata namespace (source of truth for part MD
+     * for all storage classes, including GLACIER / DEEP_ARCHIVE).
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
@@ -243,21 +264,41 @@ class NamespaceMultiStorageClass {
     }
 
     /**
+     * Completes a multipart upload.
+     * STANDARD: delegated to the target namespace directly (NamespaceNB).
+     * Archive: completes on the archive resource, then completes MD in NooBaa
+     * via the multipart path (validates part list, clears uncommitted, soft-deletes
+     * unused multiparts) with etag/size from archive.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async complete_object_upload(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const upload_md = await this._read_upload_md(params, object_sdk);
+        const storage_class = upload_md.storage_class;
+        const target_ns = this.get_namespace_for_storage_class(storage_class);
+        if (this.is_standard_storage_class(storage_class)) {
+            return target_ns.complete_object_upload(params, object_sdk);
+        }
+        return this._complete_object_upload_archive(params, object_sdk, { upload_md, storage_class, target_ns });
     }
 
     /**
+     * Aborts a multipart upload.
+     * STANDARD: delegated to the target namespace (NamespaceNB).
+     * Archive: aborts on the archive resource and soft-deletes upload MD in NooBaa.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
-     * @returns {Promise<object>}
+     * @returns {Promise<object|void>}
      */
     async abort_object_upload(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const upload_md = await this._read_upload_md(params, object_sdk);
+        const storage_class = upload_md.storage_class;
+        const target_ns = this.get_namespace_for_storage_class(storage_class);
+        if (this.is_standard_storage_class(storage_class)) {
+            return target_ns.abort_object_upload(params, object_sdk);
+        }
+        return this._abort_object_upload_archive(params, object_sdk, { upload_md, storage_class, target_ns });
     }
 
     ///////////////////
@@ -482,6 +523,221 @@ class NamespaceMultiStorageClass {
     //////////////
 
     /**
+     * Reads in-progress upload routing metadata by obj_id (storage_class,
+     * target_data_info). find_object_upload already requires upload_started.
+     * Maps missing/non-upload objects to NoSuchUpload (S3 multipart semantics).
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @returns {Promise<{ storage_class?: nb.StorageClass, target_data_info?: nb.TargetDataInfo }>}
+     */
+    async _read_upload_md(params, object_sdk) {
+        try {
+            const { bucket, key, obj_id } = params;
+            s3_utils.throw_if_invalid_upload_id(obj_id);
+            return await object_sdk.rpc_client.object.read_object_upload({ bucket, key, obj_id });
+        } catch (err) {
+            const err_code = err.name || err.Code || err.code;
+            if (this._is_no_such_upload_err(err) || err.rpc_code === 'NO_SUCH_OBJECT' || err_code === S3Error.NoSuchKey.code) {
+                throw new S3Error(S3Error.NoSuchUpload);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Archive create-multipart flow (aligned with PutObject):
+     * 1. Create upload MD in NooBaa (gets obj_id / bucket_id)
+     * 2. Create MPU on archive under get_archive_key(bucket_id, obj_id)
+     * 3. Update NB MD with target_data_info.upload_id
+     * On failure after MD create, aborts the NB upload; if archive MPU was created,
+     * also aborts it.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {{ storage_class: string, target_ns: nb.Namespace }} options
+     * @returns {Promise<object>}
+     */
+    async _create_object_upload_archive(params, object_sdk, { storage_class, target_ns }) {
+        let obj_id;
+        let archive_key;
+        let target_upload_id;
+        const { bucket, key } = params;
+
+        try {
+            const create_params = get_create_object_upload_params({ ...params, storage_class });
+            dbg.log1('NamespaceMultiStorageClass._create_object_upload_archive: create MD upload', create_params);
+            const create_reply = await this._metadata_ns.create_object_upload(create_params, object_sdk);
+
+            obj_id = create_reply.obj_id;
+            archive_key = get_archive_key(create_reply.bucket_id, obj_id);
+            const create_archive_params = { ...params, key: archive_key, storage_class };
+
+            dbg.log1('NamespaceMultiStorageClass._create_object_upload_archive: create archive MPU', { bucket, key, obj_id, archive_key, storage_class });
+            const archive_reply = await target_ns.create_object_upload(create_archive_params, object_sdk);
+            target_upload_id = archive_reply.obj_id;
+
+            // target_data_info is set shortly after create_object_upload seeds object_md_cache.
+            // Fast MPU (create→parts→complete within the 1s cache TTL) would otherwise complete
+            // with a stale object missing target_data_info.upload_id and hit BAD_SIZE (IncompleteBody).
+
+            const update_md_params = { bucket, key, obj_id, target_data_info: { upload_id: target_upload_id }, invalidate_md_cache: true };
+            await object_sdk.rpc_client.object.update_object_md(update_md_params);
+            dbg.log1('NamespaceMultiStorageClass._create_object_upload_archive: set target_data_info.upload_id', { obj_id, target_upload_id, archive_key });
+            return create_reply;
+        } catch (err) {
+            dbg.warn('NamespaceMultiStorageClass._create_object_upload_archive: failed', { bucket, key, obj_id, archive_key, target_upload_id }, err);
+            if (target_upload_id && archive_key) {
+                try {
+                    const abort_archive_params = { bucket, key: archive_key, obj_id: target_upload_id };
+                    await target_ns.abort_object_upload(abort_archive_params, object_sdk);
+                } catch (abort_err) {
+                    dbg.warn('NamespaceMultiStorageClass._create_object_upload_archive: Failed to abort archive MPU',
+                        { bucket, key, archive_key, target_upload_id }, abort_err);
+                }
+            }
+            if (obj_id) {
+                try {
+                    const abort_md_params = { bucket, key, obj_id };
+                    await this._metadata_ns.abort_object_upload(abort_md_params, object_sdk);
+                } catch (abort_err) {
+                    dbg.warn('NamespaceMultiStorageClass._create_object_upload_archive: Failed to abort MD upload', { obj_id }, abort_err);
+                }
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * MD-first part upload (same order as STANDARD object_io.upload_multipart):
+     * create_multipart → upload part data to archive → complete_multipart with archive etag
+     * Failed parts leave uncommitted MD for cleanup by Complete/Abort MPU.
+     * 1. Create part MD in NooBaa (uncommitted) before writing archive data.
+     * 2. Upload part data to archive namespace.
+     * 3. Commit part MD with archive etag (no chunk mappings).
+     * 4. if failed, uncommitted part is overwritten and MD is soft-deleted by Complete/Abort.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {{ upload_md: { target_data_info?: nb.TargetDataInfo }, storage_class: string, target_ns: nb.Namespace }} options
+     * @returns {Promise<{ etag: string }>}
+     */
+    async _upload_multipart_archive(params, object_sdk, { upload_md, storage_class, target_ns }) {
+        const { bucket, key, obj_id, num } = params;
+        const target_upload_id = upload_md.target_data_info?.upload_id;
+        if (!target_upload_id) {
+            dbg.error('NamespaceMultiStorageClass._upload_multipart_archive: missing target_data_info.upload_id', { bucket, key, obj_id });
+            throw new S3Error(S3Error.NoSuchUpload);
+        }
+        const bucket_info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        const archive_key = get_archive_key(bucket_info._id, obj_id);
+        dbg.log1('NamespaceMultiStorageClass._upload_multipart_archive: upload part', { bucket, key, archive_key, num, storage_class });
+        try {
+            const create_mp_params = _.pick(params, CREATE_MULTIPART_PARAMS);
+            const create_mp_reply = await object_sdk.rpc_client.object.create_multipart(create_mp_params);
+
+            const upload_archive_params = { ...params, key: archive_key, obj_id: target_upload_id };
+            const archive_reply = await target_ns.upload_multipart(upload_archive_params, object_sdk);
+
+            const etag = s3_utils.parse_etag(archive_reply.etag);
+            const complete_params = _.pick({ ...params, multipart_id: create_mp_reply.multipart_id }, COMPLETE_MULTIPART_PARAMS);
+            // Persist opaque archive ETag for ListParts (Part Etag is not necessarily the MD5)
+            Object.assign(complete_params,
+                { size: params.size, num_parts: 0, etag, md5_b64: params.md5_b64, sha256_b64: params.sha256_b64 });
+            await object_sdk.rpc_client.object.complete_multipart(complete_params);
+
+            dbg.log1('NamespaceMultiStorageClass._upload_multipart_archive: recorded part MD', { obj_id, num, etag });
+            return { etag };
+        } catch (err) {
+            dbg.warn('NamespaceMultiStorageClass._upload_multipart_archive: failed', { bucket, key, archive_key, num }, err);
+            throw err;
+        }
+    }
+
+    /**
+     * Completes archive MPU then completes NooBaa MD via the multipart path
+     * (part-list validation, clear uncommitted, soft-delete unused multiparts).
+     * Size/etag come from reading the archive object after complete — that reflects
+     * only the parts the client included in CompleteMultipartUpload.
+     * Retry-safe: if archive complete already succeeded (NoSuchUpload) but MD
+     * complete did not, MD read recovers etag/size and finishes MD complete.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {{ upload_md: { target_data_info?: nb.TargetDataInfo }, storage_class: nb.StorageClass, target_ns: nb.Namespace }} options
+     * @returns {Promise<object>}
+     */
+    async _complete_object_upload_archive(params, object_sdk, { upload_md, storage_class, target_ns }) {
+        const { bucket, key, obj_id } = params;
+        const target_upload_id = upload_md.target_data_info?.upload_id;
+        if (!target_upload_id) {
+            dbg.error('NamespaceMultiStorageClass._complete_object_upload_archive: missing target_data_info.upload_id', { bucket, key, obj_id });
+            throw new S3Error(S3Error.NoSuchUpload);
+        }
+        const bucket_info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        const archive_key = get_archive_key(bucket_info._id, obj_id);
+        const archive_params = { ...params, key: archive_key, obj_id: target_upload_id };
+
+        dbg.log1('NamespaceMultiStorageClass._complete_object_upload_archive: complete archive MPU', { bucket, key, archive_key, storage_class });
+        // Archive complete then NB MD complete are not atomic. If archive succeeds and MD
+        // fails, a client retry gets NoSuchUpload from archive (MPU already gone). Treat
+        // that as success and finish MD using Head of the archived object.
+        try {
+            await target_ns.complete_object_upload(archive_params, object_sdk);
+        } catch (err) {
+            if (!this._is_no_such_upload_err(err)) throw err;
+            dbg.warn('NamespaceMultiStorageClass._complete_object_upload_archive: archive MPU already completed, reading object', {
+                bucket, archive_key, target_upload_id }, err);
+        }
+
+        const archive_md = await target_ns.read_object_md({ bucket, key: archive_key }, object_sdk);
+        const { etag, size, last_modified_time, create_time } = archive_md;
+        const complete_params = get_complete_object_upload_params({
+            ...params,
+            etag,
+            size,
+            last_modified_time: last_modified_time || create_time,
+        });
+        dbg.log1('NamespaceMultiStorageClass._complete_object_upload_archive: complete MD upload', { ...complete_params, archive_key });
+        return this._metadata_ns.complete_object_upload(complete_params, object_sdk);
+    }
+
+    /**
+     * @param {Error & { code?: string, Code?: string, name?: string, rpc_code?: string }} err
+     * @returns {boolean}
+     */
+    _is_no_such_upload_err(err) {
+        const err_code = err.name || err.Code || err.code;
+        return err.rpc_code === 'NO_SUCH_UPLOAD' || err_code === S3Error.NoSuchUpload.code;
+    }
+
+    /**
+     * Aborts archive MPU then soft-deletes NooBaa upload MD.
+     * Ignore archive NoSuchUpload (already gone); propagate other archive abort
+     * errors so target_data_info.upload_id remains available for retry. MD abort errors
+     * also propagate so the client learns whether the UploadId was cleared.
+     * @param {object} params
+     * @param {nb.ObjectSDK} object_sdk
+     * @param {{ upload_md: { target_data_info?: nb.TargetDataInfo }, storage_class: nb.StorageClass, target_ns: nb.Namespace }} options
+     * @returns {Promise<object|void>}
+     */
+    async _abort_object_upload_archive(params, object_sdk, { upload_md, storage_class, target_ns }) {
+        const { bucket, key, obj_id } = params;
+        const bucket_info = await object_sdk.read_bucket_sdk_config_info(bucket);
+        const archive_key = get_archive_key(bucket_info._id, obj_id);
+        const target_upload_id = upload_md.target_data_info?.upload_id;
+        if (target_upload_id) {
+            try {
+                dbg.log1('NamespaceMultiStorageClass._abort_object_upload_archive: abort archive MPU', { bucket, key, archive_key, target_upload_id, storage_class });
+                await target_ns.abort_object_upload({ bucket, key: archive_key, obj_id: target_upload_id }, object_sdk);
+            } catch (archive_err) {
+                dbg.warn('NamespaceMultiStorageClass._abort_object_upload_archive: Failed to abort archive MPU', { bucket, key, archive_key, target_upload_id }, archive_err);
+                if (!this._is_no_such_upload_err(archive_err)) throw archive_err;
+            }
+        } else {
+            dbg.warn('NamespaceMultiStorageClass._abort_object_upload_archive: missing target_data_info.upload_id, aborting MD only', { bucket, key, obj_id });
+        }
+
+        return this._metadata_ns.abort_object_upload(params, object_sdk);
+    }
+
+    /**
      * Upload path for non-default storage classes: MD in NB, data plain to target_ns.
      * Flow: create_object_upload (NB MD) → upload_object to archive under
      * get_archive_key(bucket_id, obj_id) → complete_object_upload (NB MD).
@@ -523,9 +779,7 @@ class NamespaceMultiStorageClass {
             dbg.warn('NamespaceMultiStorageClass._upload_object_non_standard_sc: failed upload', abort_params, err);
             // Destroy if the body was never attached (e.g. create_object_upload failed).
             // No err arg: avoid emitting 'error' on a stream with no listeners; original err is rethrown.
-            if (params.source_stream && typeof params.source_stream.destroy === 'function') {
-                params.source_stream.destroy();
-            }
+            destroy_source_stream(params);
             if (abort_params.obj_id) {
                 try {
                     await this._metadata_ns.abort_object_upload(abort_params, object_sdk);
@@ -540,13 +794,30 @@ class NamespaceMultiStorageClass {
 
     /**
      * Resolves the namespace for a write based on `storage_class`.
-     * Falls back to `default_storage_class` when unset or unmapped.
-     * @param {string} [storage_class]
+     * Fails if the storage class is not supported or not mapped.
+     * @param {nb.StorageClass} storage_class
      * @returns {nb.Namespace}
      */
-    _ns_for_storage_class(storage_class) {
+    get_namespace_for_storage_class(storage_class) {
         const sc = s3_utils.parse_storage_class(storage_class);
-        return this.namespace_by_storage_class[sc] || this.namespace_by_storage_class[this.default_storage_class];
+        if (this.is_standard_storage_class(sc) || s3_utils.GLACIER_STORAGE_CLASSES.includes(sc)) {
+            const target_ns = this.namespace_by_storage_class[sc];
+            if (!target_ns) {
+                throw new S3Error(S3Error.NotImplemented);
+            }
+            return target_ns;
+        }
+        throw new S3Error(S3Error.NotImplemented);
+    }
+
+    /**
+     * Checks if the storage class is standard.
+     * Unset/empty is treated as STANDARD (same as s3_utils.parse_storage_class).
+     * @param {nb.StorageClass} storage_class
+     * @returns {boolean}
+     */
+    is_standard_storage_class(storage_class) {
+        return s3_utils.parse_storage_class(storage_class) === this.default_storage_class;
     }
 }
 

--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -7,8 +7,6 @@ const blob_translator = require('./blob_translator');
 const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 
-const object_id_regex = /^[0-9a-fA-F]{24}$/;
-
 /**
  * NamespaceNB maps objects using the noobaa bucket_api and object_api
  * and calls object_io to perform dedup, compression, encryption,
@@ -137,26 +135,26 @@ class NamespaceNB {
             client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
-        _throw_if_invalid_upload_id(params.obj_id);
+        s3_utils.throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.object_io.upload_multipart(params);
     }
 
     list_multiparts(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        _throw_if_invalid_upload_id(params.obj_id);
+        s3_utils.throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.rpc_client.object.list_multiparts(params);
     }
 
     async complete_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        _throw_if_invalid_upload_id(params.obj_id);
+        s3_utils.throw_if_invalid_upload_id(params.obj_id);
         const reply = await object_sdk.rpc_client.object.complete_object_upload(params);
         return reply;
     }
 
     abort_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        _throw_if_invalid_upload_id(params.obj_id);
+        s3_utils.throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.rpc_client.object.abort_object_upload(params);
     }
 
@@ -266,15 +264,6 @@ class NamespaceNB {
     async delete_uls() {
         throw new Error('TODO');
     }
-}
-
-/**
- * Throw S3 NoSuchUpload when upload id is missing or not a valid ObjectId.
- * Avoids RPC schema INVALID_SCHEMA_PARAMS for malformed UploadId values.
- * @param {string} [upload_id]
- */
-function _throw_if_invalid_upload_id(upload_id) {
-    if (!upload_id || !object_id_regex.test(upload_id)) throw new S3Error(S3Error.NoSuchUpload);
 }
 
 module.exports = NamespaceNB;

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -520,21 +520,27 @@ class NamespaceS3 {
         dbg.log0('NamespaceS3.complete_object_upload:', this.bucket, inspect(params));
         await this._prepare_sts_client();
 
-        const res = await this.s3.completeMultipartUpload({
-            Bucket: this.bucket,
-            Key: params.key,
-            UploadId: params.obj_id,
-            MultipartUpload: {
-                Parts: _.map(params.multiparts, p => ({
-                    PartNumber: p.num,
-                    ETag: `"${p.etag}"`,
-                }))
-            }
-        });
+        try {
+            const res = await this.s3.completeMultipartUpload({
+                Bucket: this.bucket,
+                Key: params.key,
+                UploadId: params.obj_id,
+                MultipartUpload: {
+                    Parts: _.map(params.multiparts, p => ({
+                        PartNumber: p.num,
+                        ETag: `"${p.etag}"`,
+                    }))
+                }
+            });
 
-        dbg.log0('NamespaceS3.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
-        const etag = s3_utils.parse_etag(res.ETag);
-        return { etag, version_id: res.VersionId };
+            dbg.log0('NamespaceS3.complete_object_upload:', this.bucket, inspect(params), 'res', inspect(res));
+            const etag = s3_utils.parse_etag(res.ETag);
+            return { etag, version_id: res.VersionId };
+        } catch (err) {
+            this._translate_error_code(params, err);
+            dbg.warn('NamespaceS3.complete_object_upload:', inspect(err));
+            throw err;
+        }
     }
 
     async abort_object_upload(params, object_sdk) {
@@ -890,6 +896,9 @@ class NamespaceS3 {
         else if (err_code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
         else if (err_code === 'InvalidRange') err.rpc_code = 'INVALID_RANGE';
         else if (err_code === 'RestoreAlreadyInProgress') err.rpc_code = 'RESTORE_ALREADY_IN_PROGRESS';
+        else if (err_code === 'InvalidPart') err.rpc_code = 'INVALID_PART';
+        else if (err_code === 'InvalidPartOrder') err.rpc_code = 'INVALID_PART_ORDER';
+        else if (err_code === 'NoSuchUpload') err.rpc_code = 'NO_SUCH_UPLOAD';
         else if (params.md_conditions) {
             const md_conditions = params.md_conditions;
             if (err_code === 'PreconditionFailed') {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -405,8 +405,13 @@ interface ObjectMultipart {
     size: number;
     md5_b64?: string;
     sha256_b64?: string;
+    etag?: string;
     create_time?: Date;
     // partial
+}
+
+interface TargetDataInfo {
+    upload_id?: string;
 }
 
 interface ObjectMD {
@@ -433,7 +438,7 @@ interface ObjectMD {
     md5_b64: string;
     sha256_b64: string;
     storage_class?: StorageClass;
-    archive_upload_id?: string;
+    target_data_info?: TargetDataInfo;
     xattr: {};
     stats: { reads: number; last_read: Date; };
     encryption: { algorithm: string; kms_key_id: string; context_b64: string; key_md5_b64: string; key_b64: string; };
@@ -484,7 +489,7 @@ interface ObjectInfo {
     content_range?: string;
     ns?: Namespace;
     storage_class?: StorageClass;
-    archive_upload_id?: string;
+    target_data_info?: TargetDataInfo;
     restore_status?: RestoreStatus;
     checksum?: Checksum;
     object_parts?: GetObjectAttributesParts;

--- a/src/sdk/object_io.js
+++ b/src/sdk/object_io.js
@@ -19,7 +19,7 @@ const system_store = require('../server/system_services/system_store').get_insta
 const { MapClient } = require('./map_client');
 const { ChunkAPI } = require('./map_api_types');
 const { RpcError } = require('../rpc');
-const { get_create_object_upload_params } = require('../util/object_utils');
+const { get_create_object_upload_params, CREATE_MULTIPART_PARAMS, COMPLETE_MULTIPART_PARAMS } = require('../util/object_utils');
 
 Object.isFrozen(RpcError); // otherwise unused
 
@@ -258,23 +258,8 @@ class ObjectIO {
      * @param {UploadParams} params
      */
     async upload_multipart(params) {
-        const create_params = _.pick(params,
-            'obj_id',
-            'bucket',
-            'key',
-            'num',
-            'size',
-            'md5_b64',
-            'sha256_b64',
-            'encryption'
-        );
-        const complete_params = _.pick(params,
-            'multipart_id',
-            'obj_id',
-            'bucket',
-            'key',
-            'num',
-        );
+        const create_params = _.pick(params, CREATE_MULTIPART_PARAMS);
+        const complete_params = _.pick(params, COMPLETE_MULTIPART_PARAMS);
         try {
             dbg.log1('upload_multipart: start upload', complete_params);
             const multipart_reply = await params.client.object.create_multipart(create_params);
@@ -320,7 +305,7 @@ class ObjectIO {
             complete_params.num_parts = num_parts;
             complete_params.md5_b64 = object_md.md5_b64;
             complete_params.sha256_b64 = object_md.sha256_b64;
-            complete_params.etag = object_md.etag; // preserve source etag
+            complete_params.etag = object_md.etag;
         } else {
             const object_md = await params.client.object.read_object_md({
                 bucket,

--- a/src/server/bg_services/objects_reclaimer.js
+++ b/src/server/bg_services/objects_reclaimer.js
@@ -21,11 +21,13 @@ class ObjectsReclaimer {
     /**
      * Reclaim unreclaimed deleted objects:
      * - STANDARD / tiering: map_deleter, then mark reclaimed.
-     * - Remote archive (archive SC + bucket archive_policy): map_deleter only if
-     *   restore_status is set, then delete remote keys and mark reclaimed.
-     *   map_deleter must succeed before the object is queued for remote delete;
-     *   if mapping cleanup throws, we skip enqueue so the object is not marked
-     *   reclaimed while restore copies may still remain.
+     * - Remote archive with restore_status: full map_deleter (local restore copy),
+     *   then delete remote keys and mark reclaimed.
+     * - Remote archive without restore_status but with target_data_info.upload_id
+     *   (archive MPU create/abort/complete): soft-delete multiparts only, then
+     *   delete remote keys and mark reclaimed.
+     *   Mapping cleanup must succeed before enqueue so we do not mark reclaimed
+     *   while restore copies may still remain.
      */
     async run_batch() {
         if (!this._can_run()) return;
@@ -45,12 +47,16 @@ class ObjectsReclaimer {
         await P.all(unreclaimed_objects.map(async obj => {
             try {
                 const bucket = system_store.data.get_by_id(obj.bucket);
-                const is_remote_archive = deep_archive_utils.is_remote_archive_object(obj, bucket);
-                const should_delete_mappings = is_remote_archive ? Boolean(obj.restore_status) : true;
+                const is_remote_data = deep_archive_utils.is_remote_archive_object(obj, bucket);
+                const should_delete_mappings = is_remote_data ? Boolean(obj.restore_status) : true;
+                const is_md_only_multipart_upload = Boolean(obj.target_data_info?.upload_id);
+                const should_delete_md_only_multiparts = is_remote_data && !should_delete_mappings && is_md_only_multipart_upload;
                 if (should_delete_mappings) {
                     await map_deleter.delete_object_mappings(obj);
+                } else if (should_delete_md_only_multiparts) {
+                    await map_deleter.delete_object_multiparts(obj);
                 }
-                if (is_remote_archive) {
+                if (is_remote_data) {
                     const bucket_id = String(obj.bucket);
                     (pending_archive_deletes_by_bucket[bucket_id] ??= []).push(obj);
                     return;

--- a/src/server/object_services/map_deleter.js
+++ b/src/server/object_services/map_deleter.js
@@ -30,6 +30,16 @@ async function delete_object_mappings(obj) {
 }
 
 /**
+ * Soft-delete multipart MD only (no parts/chunks). Used for remote-archive
+ * objects that never had a local restore copy (e.g. aborted archive MPU).
+ * @param {nb.ObjectMD} obj
+ */
+async function delete_object_multiparts(obj) {
+    if (!obj || obj.delete_marker) return;
+    await MDStore.instance().delete_multiparts_of_object(obj);
+}
+
+/**
  * @param {nb.ID[]} chunk_ids
  */
 async function delete_chunks_if_unreferenced(chunk_ids) {
@@ -160,6 +170,7 @@ async function delete_blocks_from_node(blocks) {
 
 // EXPORTS
 exports.delete_object_mappings = delete_object_mappings;
+exports.delete_object_multiparts = delete_object_multiparts;
 exports.delete_object_if_no_parts = delete_object_if_no_parts;
 exports.delete_chunks_if_unreferenced = delete_chunks_if_unreferenced;
 exports.delete_chunks = delete_chunks;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1333,9 +1333,13 @@ class MDStore {
             obj: { $eq: obj_id, $exists: true },
             num: { $gt: num_gt },
             size: { $exists: true },
-            md5_b64: { $exists: true },
             create_time: { $exists: true },
             deleted: null,
+            // STANDARD parts commit with md5_b64; archive parts commit with opaque etag.
+            $or: [
+                { md5_b64: { $exists: true } },
+                { etag: { $exists: true } },
+            ],
         }, {
             sort: {
                 num: 1,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -73,7 +73,7 @@ async function create_object_upload(req) {
             'application/octet-stream',
         tagging: req.rpc_params.tagging,
         storage_class: req.rpc_params.storage_class,
-        archive_upload_id: req.rpc_params.archive_upload_id,
+        target_data_info: req.rpc_params.target_data_info,
         encryption
     };
 
@@ -431,17 +431,29 @@ async function _complete_multipart_upload(req) {
 
     const map_res = await _complete_object_multiparts(obj, req.rpc_params.multiparts);
 
-    if (req.rpc_params.size !== map_res.size) {
-        if (req.rpc_params.size >= 0) {
-            throw new RpcError('BAD_SIZE',
-                `size on complete object (${
-                            req.rpc_params.size
-                        }) differs from parts (${
-                            map_res.size
-                        })`);
+    // Target-namespace MPU parts have no NB chunk mappings (target_data_info.upload_id set on create).
+    // Still validates part list / clears uncommitted / soft-deletes unused via map_res.
+    // Size comes from rpc (required) — do not compare against map_res.size.
+    // num_parts stays map_res.num_parts (0): that field counts NB chunk parts, not S3 MPU parts.
+    const md_only = Boolean(obj.target_data_info?.upload_id);
+    if (md_only) {
+        if (!(req.rpc_params.size >= 0)) {
+            throw new RpcError('BAD_SIZE', 'archive multipart complete requires size');
         }
+        set_updates.size = req.rpc_params.size;
+    } else {
+        if (req.rpc_params.size !== map_res.size) {
+            if (req.rpc_params.size >= 0) {
+                throw new RpcError('BAD_SIZE',
+                    `size on complete object (${
+                                req.rpc_params.size
+                            }) differs from parts (${
+                                map_res.size
+                            })`);
+            }
+        }
+        set_updates.size = map_res.size;
     }
-    set_updates.size = map_res.size;
     set_updates.num_parts = map_res.num_parts;
     if (req.rpc_params.etag) {
         set_updates.etag = req.rpc_params.etag;
@@ -644,6 +656,18 @@ async function abort_object_upload(req) {
     await MDStore.instance().delete_object_by_id(obj._id);
 }
 
+/**
+ * Read metadata for an in-progress object upload by obj_id.
+ * @param {Object} req
+ * @returns {Promise<{ storage_class?: string, target_data_info?: { upload_id?: string } }>}
+ */
+async function read_object_upload(req) {
+    const obj = await find_object_upload(req);
+    return {
+        storage_class: obj.storage_class,
+        target_data_info: obj.target_data_info,
+    };
+}
 
 
 /**
@@ -729,6 +753,12 @@ async function complete_multipart(req) {
     }
     set_updates.num_parts = req.rpc_params.num_parts;
     set_updates.create_time = new Date();
+    // STANDARD MPU keeps digest-derived etags (md5_b64) 
+    // Target-namespace MPU (obj.target_data_info.upload_id) - does not use digest-derived etags, so we need to store the etag from the client
+    // client's Etag is not necessarily md5 (opaque), therefore we store in the multipart etag
+    if (obj.target_data_info?.upload_id && req.rpc_params.etag) {
+        set_updates.etag = req.rpc_params.etag;
+    }
 
     await MDStore.instance().update_multipart_by_id(multipart_id, set_updates);
 
@@ -1063,7 +1093,7 @@ function _check_encryption_permissions(src_enc, req_enc) {
 async function update_object_md(req) {
     dbg.log1('object_server.update object md', req.rpc_params);
     throw_if_maintenance(req);
-    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time', 'restore_status');
+    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time', 'target_data_info', 'restore_status');
     if (set_updates.xattr) {
         set_updates.xattr = _.mapKeys(set_updates.xattr, (v, k) => k.replace(/\./g, '@'));
     }
@@ -1078,6 +1108,9 @@ async function update_object_md(req) {
     }
     const obj = await find_object_md(req);
     await MDStore.instance().update_object_by_id(obj._id, set_updates);
+    if (req.rpc_params.invalidate_md_cache) {
+        object_md_cache.invalidate_key(String(obj._id));
+    }
 }
 
 /**
@@ -1889,7 +1922,7 @@ function get_object_info(md, options = {}) {
         md5_b64: md.md5_b64 || undefined,
         sha256_b64: md.sha256_b64 || undefined,
         storage_class: md.storage_class,
-        archive_upload_id: md.archive_upload_id || undefined,
+        target_data_info: md.target_data_info || undefined,
         content_type: md.content_type || 'application/octet-stream',
         content_encoding: md.content_encoding,
         create_time: md.create_time ? md.create_time.getTime() : md._id.getTimestamp().getTime(),
@@ -2601,6 +2634,7 @@ exports.create_object_upload = create_object_upload;
 exports.complete_object_upload = complete_object_upload;
 exports.abort_object_upload = abort_object_upload;
 exports.get_upload_object_range_info = get_upload_object_range_info;
+exports.read_object_upload = read_object_upload;
 // multipart
 exports.create_multipart = create_multipart;
 exports.complete_multipart = complete_multipart;

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -97,9 +97,14 @@ module.exports = {
 
         storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
 
-        // Remote archive S3 UploadId for in-progress deep-archive multipart uploads.
-        // Client UploadId remains the NB obj_id; this field is used when calling the archive backend.
-        archive_upload_id: { type: 'string' },
+        // Info about the object/upload on the target namespace when data lives there
+        // (not in NB chunks). upload_id is the target MPU UploadId; nested for more fields.
+        target_data_info: {
+            type: 'object',
+            properties: {
+                upload_id: { type: 'string' },
+            }
+        },
 
         // xattr saved as free form object
         xattr: {

--- a/src/server/object_services/schemas/object_multipart_schema.js
+++ b/src/server/object_services/schemas/object_multipart_schema.js
@@ -44,11 +44,16 @@ module.exports = {
         },
 
         // hashes are saved when provided during upload
-        // md5 is used for multipart etag
+        // md5 is used for multipart etag (STANDARD); opaque etag is used for archive parts
+        // where ETag is not an MD5 of the part data.
         md5_b64: {
             type: 'string'
         },
         sha256_b64: {
+            type: 'string'
+        },
+        // Opaque part ETag (e.g. archive UploadPart). Prefer get_etag() over md5_b64 when set.
+        etag: {
             type: 'string'
         },
 

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2026 NooBaa */
 /* eslint-disable max-lines-per-function */
-
 'use strict';
 
 // setup coretest first to prepare the env
@@ -143,15 +142,16 @@ async function run_objects_reclaimer(...obj_ids) {
 
 /**
  * Asserts archived object MD and that payload lives under get_archive_key on the archive target.
- * @param {{ key: string, buf: Buffer, storage_class: string, bucket?: string, bid?: string }} args
+ * @param {{ key: string, buf: Buffer, storage_class: string, bucket?: string, version_id?: string }} args
  * @returns {Promise<void>}
  */
-async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET, bid = bucket_id }) {
-    const md = await rpc_client.object.read_object_md({ bucket, key });
+async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET, version_id }) {
+    const md = await rpc_client.object.read_object_md({ bucket, key, version_id });
     assert.strictEqual(md.storage_class, storage_class);
     assert.strictEqual(md.size, buf.length);
+    const bucket_md = await rpc_client.bucket.read_bucket_sdk_info({ name: bucket });
 
-    const archive_key = get_archive_key(bid, md.obj_id);
+    const archive_key = get_archive_key(bucket_md._id, md.obj_id);
     const archived_head = await s3.headObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: archive_key });
     assert.strictEqual(archived_head.StorageClass, storage_class);
     assert.strictEqual(archived_head.ContentLength, buf.length);
@@ -167,7 +167,7 @@ async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET
     );
 
     await assert.rejects(
-        s3.getObject({ Bucket: bucket, Key: key }),
+        s3.getObject({ Bucket: bucket, Key: key, VersionId: version_id }),
         err => err_code(err) === 'InvalidObjectState'
     );
 }
@@ -377,12 +377,7 @@ mocha.describe('deep_archive_via_s3', function() {
         const key = 's3-put/default-sc';
         const buf = crypto.randomBytes(32);
 
-        await s3.putObject({
-            Bucket: BUCKET,
-            Key: key,
-            Body: buf,
-            ContentType: 'application/octet-stream',
-        });
+        await s3.putObject({ Bucket: BUCKET, Key: key, Body: buf, ContentType: 'application/octet-stream' });
 
         const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
         assert.strictEqual(md.size, buf.length);
@@ -396,39 +391,17 @@ mocha.describe('deep_archive_via_s3', function() {
     mocha.it('puts object with StorageClass=DEEP_ARCHIVE', async function() {
         const key = 's3-put/deep-archive';
         const buf = Buffer.from('deep-archive-payload');
-
-        await s3.putObject({
-            Bucket: BUCKET,
-            Key: key,
-            Body: buf,
-            ContentType: 'application/octet-stream',
-            StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
-        });
-
-        await assert_archived_via_s3({
-            key,
-            buf,
-            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
-        });
+        const storage_class = s3_utils.STORAGE_CLASS_DEEP_ARCHIVE;
+        await s3.putObject({ Bucket: BUCKET, Key: key, Body: buf, StorageClass: storage_class, ContentType: 'application/octet-stream' });
+        await assert_archived_via_s3({ key, buf, storage_class });
     });
 
     mocha.it('puts object with StorageClass=GLACIER', async function() {
         const key = 's3-put/glacier';
         const buf = Buffer.from('glacier-payload');
-
-        await s3.putObject({
-            Bucket: BUCKET,
-            Key: key,
-            Body: buf,
-            ContentType: 'application/octet-stream',
-            StorageClass: s3_utils.STORAGE_CLASS_GLACIER,
-        });
-
-        await assert_archived_via_s3({
-            key,
-            buf,
-            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
-        });
+        const storage_class = s3_utils.STORAGE_CLASS_GLACIER;
+        await s3.putObject({ Bucket: BUCKET, Key: key, Body: buf, StorageClass: storage_class, ContentType: 'application/octet-stream' });
+        await assert_archived_via_s3({ key, buf, storage_class });
     });
 
     mocha.it('rejects StorageClass=GLACIER_IR with NotImplemented', async function() {
@@ -731,9 +704,19 @@ mocha.describe('deep_archive_via_s3', function() {
     mocha.describe('Lifecycle expiry', function() {
         this.timeout(120000); // eslint-disable-line no-invalid-this
 
+        let original_schedule_min;
+        let original_interval;
+
         mocha.before(function() {
+            original_schedule_min = config.LIFECYCLE_SCHEDULE_MIN;
+            original_interval = config.LIFECYCLE_INTERVAL;
             config.LIFECYCLE_SCHEDULE_MIN = 0;
             config.LIFECYCLE_INTERVAL = 0;
+        });
+
+        mocha.after(function() {
+            config.LIFECYCLE_SCHEDULE_MIN = original_schedule_min;
+            config.LIFECYCLE_INTERVAL = original_interval;
         });
 
         mocha.it('lifecycle expiry soft-deletes DEEP_ARCHIVE; reclaim removes archive data', async function() {
@@ -777,6 +760,621 @@ mocha.describe('deep_archive_via_s3', function() {
             assert.ok(!has_parts_after_reclaim);
         });
     });
+    mocha.describe('MultipartUpload', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        /**
+         * Runs create → uploadPart(s) → complete for the given storage class.
+         * @param {{ key: string, parts: Buffer[], storage_class?: string }} args
+         * @returns {Promise<{ upload_id: string, etag: string, version_id?: string }>}
+         */
+        async function multipart_upload({ bucket = BUCKET, key, parts, storage_class }) {
+            const create_res = await s3.createMultipartUpload({
+                Bucket: bucket,
+                Key: key,
+                ContentType: 'application/octet-stream',
+                StorageClass: storage_class,
+            });
+            const upload_id = create_res.UploadId;
+            assert.ok(upload_id);
+
+            const completed_parts = [];
+            for (let i = 0; i < parts.length; ++i) {
+                const part_res = await s3.uploadPart({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    PartNumber: i + 1,
+                    Body: parts[i],
+                    ContentLength: parts[i].length,
+                });
+                completed_parts.push({
+                    ETag: part_res.ETag,
+                    PartNumber: i + 1,
+                });
+            }
+
+            const complete_res = await s3.completeMultipartUpload({
+                Bucket: BUCKET,
+                Key: key,
+                UploadId: upload_id,
+                MultipartUpload: { Parts: completed_parts },
+            });
+            return { upload_id, etag: complete_res.ETag, version_id: complete_res.VersionId };
+        }
+
+        mocha.it('completes STANDARD multipart upload and allows getObject', async function() {
+            const key = 's3-mpu/standard';
+            const part1 = crypto.randomBytes(5 * 1024 * 1024);
+            const part2 = crypto.randomBytes(64);
+            const buf = Buffer.concat([part1, part2]);
+
+            const { etag } = await multipart_upload({
+                key,
+                parts: [part1, part2],
+                storage_class: s3_utils.STORAGE_CLASS_STANDARD,
+            });
+            assert.ok(etag);
+
+            const md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+            assert.strictEqual(md.size, buf.length);
+            assert.ok(!md.storage_class || md.storage_class === s3_utils.STORAGE_CLASS_STANDARD);
+            assert.ok(!md.target_data_info?.upload_id);
+
+            const get_res = await s3.getObject({ Bucket: BUCKET, Key: key });
+            const body = Buffer.from(await get_res.Body.transformToByteArray());
+            assert.strictEqual(Buffer.compare(body, buf), 0);
+        });
+
+        s3_utils.GLACIER_STORAGE_CLASSES.forEach(storage_class => {
+
+            mocha.it(`completes ${storage_class} multipart upload (MD in NB, data under archive_key)`, async function() {
+                const key = `s3-mpu/complete/${storage_class}`;
+                const part1 = crypto.randomBytes(5 * 1024 * 1024);
+                const part2 = crypto.randomBytes(128);
+                const buf = Buffer.concat([part1, part2]);
+
+                const { etag } = await multipart_upload({
+                    key,
+                    parts: [part1, part2],
+                    storage_class,
+                });
+
+                await assert_archived_via_s3({ key, buf, storage_class });
+                const head = await s3.headObject({ Bucket: BUCKET, Key: key });
+                assert.strictEqual(
+                    s3_utils.parse_etag(head.ETag),
+                    s3_utils.parse_etag(etag)
+                );
+            });
+            mocha.it(`rejects ${storage_class} complete with wrong part etag`, async function() {
+                const key = `s3-mpu/invalid-part/${storage_class}`;
+                const part_buf = crypto.randomBytes(64);
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+                const part_res = await s3.uploadPart({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    PartNumber: 1,
+                    Body: part_buf,
+                    ContentLength: part_buf.length,
+                });
+                assert.ok(part_res.ETag);
+
+                await assert.rejects(
+                    s3.completeMultipartUpload({
+                        Bucket: BUCKET,
+                        Key: key,
+                        UploadId: upload_id,
+                        MultipartUpload: {
+                            Parts: [{ ETag: '"00000000000000000000000000000000"', PartNumber: 1 }],
+                        },
+                    }),
+                    err => err_code(err) === 'InvalidPart'
+                );
+
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+            });
+
+            mocha.it(`rejects ${storage_class} complete with non-contiguous parts`, async function() {
+                const key = `s3-mpu/gap-parts/${storage_class}`;
+                const part1 = crypto.randomBytes(5 * 1024 * 1024);
+                const part2 = crypto.randomBytes(64);
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+                await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id, PartNumber: 1,
+                    Body: part1, ContentLength: part1.length,
+                });
+                const part2_res = await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id, PartNumber: 2,
+                    Body: part2, ContentLength: part2.length,
+                });
+
+                // Skip part 1 in Complete — NB requires contiguous 1..N.
+                await assert.rejects(
+                    s3.completeMultipartUpload({
+                        Bucket: BUCKET,
+                        Key: key,
+                        UploadId: upload_id,
+                        MultipartUpload: {
+                            Parts: [{ ETag: part2_res.ETag, PartNumber: 2 }],
+                        },
+                    }),
+                    err => err_code(err) === 'InvalidPart'
+                );
+
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+            });
+
+            mocha.it(`completes ${storage_class} MPU omitting an unused uploaded part`, async function() {
+                const key = `s3-mpu/unused-part/${storage_class}`;
+                const part1 = crypto.randomBytes(5 * 1024 * 1024);
+                const part2 = crypto.randomBytes(128);
+                const unused = crypto.randomBytes(64);
+                const buf = Buffer.concat([part1, part2]);
+
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+
+                const part1_res = await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id, PartNumber: 1,
+                    Body: part1, ContentLength: part1.length,
+                });
+                const part2_res = await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id, PartNumber: 2,
+                    Body: part2, ContentLength: part2.length,
+                });
+                // Uploaded but omitted from Complete — should be soft-deleted on MD finalize.
+                await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id, PartNumber: 3,
+                    Body: unused, ContentLength: unused.length,
+                });
+
+                await s3.completeMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    MultipartUpload: {
+                        Parts: [
+                            { ETag: part1_res.ETag, PartNumber: 1 },
+                            { ETag: part2_res.ETag, PartNumber: 2 },
+                        ],
+                    },
+                });
+
+                await assert_archived_via_s3({ key, buf, storage_class });
+
+                const remaining = await MDStore.instance().find_all_multiparts_of_object(parse_obj_id(upload_id));
+                assert.strictEqual(remaining.length, 2, 'unused multipart should be soft-deleted');
+                assert.ok(remaining.every(mp => !mp.uncommitted), 'used multiparts should clear uncommitted');
+                assert.deepStrictEqual(remaining.map(mp => mp.num).sort(), [1, 2]);
+            });
+
+            mocha.it(`create/uploadPart/listParts for ${storage_class} sets target_data_info`, async function() {
+                const key = `s3-mpu/in-progress/${storage_class}`;
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+
+                const md = await rpc_client.object.read_object_md({
+                    bucket: BUCKET,
+                    key,
+                    obj_id: upload_id,
+                });
+                assert.strictEqual(md.storage_class, storage_class);
+                assert.ok(md.target_data_info?.upload_id);
+                assert.notStrictEqual(md.target_data_info.upload_id, upload_id);
+
+                const archive_key = get_archive_key(bucket_id, upload_id);
+                const listed = await s3.listParts({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+                assert.strictEqual((listed.Parts || []).length, 0);
+
+                // Archive MPU exists under archive_key on the archive target.
+                const archive_parts = await s3.listParts({
+                    Bucket: ARCHIVE_TARGET_BUCKET,
+                    Key: archive_key,
+                    UploadId: md.target_data_info.upload_id,
+                });
+                assert.strictEqual((archive_parts.Parts || []).length, 0);
+
+                const part_buf = crypto.randomBytes(64);
+                const part_res = await s3.uploadPart({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    PartNumber: 1,
+                    Body: part_buf,
+                    ContentLength: part_buf.length,
+                });
+
+                // ListParts is served from NB MD for archive uploads as well.
+                const listed_after = await s3.listParts({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+                const listed_parts = listed_after.Parts || [];
+                assert.strictEqual(listed_parts.length, 1);
+                assert.strictEqual(listed_parts[0].PartNumber, 1);
+                assert.strictEqual(listed_parts[0].Size, part_buf.length);
+                assert.strictEqual(
+                    s3_utils.parse_etag(listed_parts[0].ETag),
+                    s3_utils.parse_etag(part_res.ETag)
+                );
+
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+            });
+
+            mocha.it(`aborts ${storage_class} multipart upload on both NB MD and archive`, async function() {
+                const key = `s3-mpu/abort/${storage_class}`;
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+                const md = await rpc_client.object.read_object_md({
+                    bucket: BUCKET,
+                    key,
+                    obj_id: upload_id,
+                });
+                const archive_key = get_archive_key(bucket_id, upload_id);
+                const target_upload_id = md.target_data_info.upload_id;
+
+                await s3.uploadPart({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    PartNumber: 1,
+                    Body: crypto.randomBytes(64),
+                });
+
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+
+                await assert.rejects(
+                    s3.listParts({ Bucket: BUCKET, Key: key, UploadId: upload_id }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.listParts({
+                        Bucket: ARCHIVE_TARGET_BUCKET,
+                        Key: archive_key,
+                        UploadId: target_upload_id,
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+
+                // Abort soft-deletes object MD only; multiparts remain until ObjectsReclaimer.
+                const multiparts_before = await MDStore.instance().find_all_multiparts_of_object(parse_obj_id(upload_id));
+                assert.strictEqual(multiparts_before.length, 1, 'multipart MD should remain until reclaim');
+                await assert_object_unreclaimed(upload_id);
+                await run_objects_reclaimer(upload_id);
+                const multiparts_after = await MDStore.instance().find_all_multiparts_of_object(parse_obj_id(upload_id));
+                assert.strictEqual(multiparts_after.length, 0, 'ObjectsReclaimer should soft-delete archive MPU multiparts');
+            });
+
+            mocha.it(`uploadPartCopy STANDARD → ${storage_class} MPU then completes`, async function() {
+                const source_key = `s3-mpu/part-copy-src/${storage_class}`;
+                const key = `s3-mpu/part-copy-dst/${storage_class}`;
+                const buf = Buffer.from(`part-copy-payload-${storage_class}`);
+
+                await s3.putObject({
+                    Bucket: BUCKET,
+                    Key: source_key,
+                    Body: buf,
+                    ContentType: 'application/octet-stream',
+                });
+
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+
+                const part_res = await s3.uploadPartCopy({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    PartNumber: 1,
+                    CopySource: `/${BUCKET}/${source_key}`,
+                });
+                assert.ok(part_res.CopyPartResult?.ETag);
+
+                await s3.completeMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                    MultipartUpload: {
+                        Parts: [{ ETag: part_res.CopyPartResult.ETag, PartNumber: 1 }],
+                    },
+                });
+
+                await assert_archived_via_s3({ key, buf, storage_class });
+            });
+
+        });
+
+        mocha.it('listMultipartUploads includes in-progress archive MPUs', async function() {
+            const prefix = 's3-mpu/list-uploads/';
+            const uploads = [];
+
+            for (const storage_class of s3_utils.GLACIER_STORAGE_CLASSES) {
+                const key = `${prefix}${storage_class}`;
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                uploads.push({ key, upload_id: create_res.UploadId, storage_class });
+            }
+
+            const listed = await s3.listMultipartUploads({
+                Bucket: BUCKET,
+                Prefix: prefix,
+            });
+            const by_key = new Map((listed.Uploads || []).map(u => [u.Key, u]));
+
+            for (const { key, upload_id, storage_class } of uploads) {
+                const entry = by_key.get(key);
+                assert.ok(entry, `expected listMultipartUploads to include ${key}`);
+                assert.strictEqual(entry.UploadId, upload_id);
+                assert.strictEqual(entry.StorageClass, storage_class);
+            }
+
+            for (const { key, upload_id } of uploads) {
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    UploadId: upload_id,
+                });
+            }
+
+            const listed_after = await s3.listMultipartUploads({
+                Bucket: BUCKET,
+                Prefix: prefix,
+            });
+            assert.strictEqual((listed_after.Uploads || []).length, 0);
+        });
+
+        mocha.it('rejects GLACIER_IR multipart with NotImplemented', async function() {
+            await assert.rejects(
+                s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: 's3-mpu/glacier-ir',
+                    ContentType: 'application/octet-stream',
+                    StorageClass: s3_utils.STORAGE_CLASS_GLACIER_IR,
+                }),
+                err => err_code(err) === 'NotImplemented'
+            );
+        });
+
+        mocha.describe('MPU error handling', function() {
+            const storage_class = s3_utils.STORAGE_CLASS_DEEP_ARCHIVE;
+            const nonexistent_upload_id = '000000000000000000000000';
+
+            mocha.it('returns NoSuchUpload for nonexistent upload id', async function() {
+                const key = 's3-mpu/err/no-such-upload-id';
+                await assert.rejects(
+                    s3.uploadPart({
+                        Bucket: BUCKET, Key: key, UploadId: nonexistent_upload_id,
+                        PartNumber: 1, Body: crypto.randomBytes(64),
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.listParts({ Bucket: BUCKET, Key: key, UploadId: nonexistent_upload_id }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.completeMultipartUpload({
+                        Bucket: BUCKET, Key: key, UploadId: nonexistent_upload_id,
+                        MultipartUpload: {
+                            Parts: [{ ETag: '"00000000000000000000000000000000"', PartNumber: 1 }],
+                        },
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.abortMultipartUpload({
+                        Bucket: BUCKET, Key: key, UploadId: nonexistent_upload_id,
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+            });
+
+            mocha.it('returns NoSuchUpload when key does not match the upload', async function() {
+                const key = 's3-mpu/err/key-mismatch';
+                const other_key = 's3-mpu/err/key-mismatch-other';
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+
+                await assert.rejects(
+                    s3.uploadPart({
+                        Bucket: BUCKET, Key: other_key, UploadId: upload_id,
+                        PartNumber: 1, Body: crypto.randomBytes(64),
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.listParts({ Bucket: BUCKET, Key: other_key, UploadId: upload_id }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.completeMultipartUpload({
+                        Bucket: BUCKET, Key: other_key, UploadId: upload_id,
+                        MultipartUpload: {
+                            Parts: [{ ETag: '"00000000000000000000000000000000"', PartNumber: 1 }],
+                        },
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id,
+                });
+            });
+
+            mocha.it('returns NoSuchUpload for MPU ops after abort', async function() {
+                const key = 's3-mpu/err/ops-after-abort';
+                const create_res = await s3.createMultipartUpload({
+                    Bucket: BUCKET,
+                    Key: key,
+                    ContentType: 'application/octet-stream',
+                    StorageClass: storage_class,
+                });
+                const upload_id = create_res.UploadId;
+                await s3.uploadPart({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id,
+                    PartNumber: 1, Body: crypto.randomBytes(64),
+                });
+                await s3.abortMultipartUpload({
+                    Bucket: BUCKET, Key: key, UploadId: upload_id,
+                });
+
+                await assert.rejects(
+                    s3.uploadPart({
+                        Bucket: BUCKET, Key: key, UploadId: upload_id,
+                        PartNumber: 2, Body: crypto.randomBytes(64),
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.listParts({ Bucket: BUCKET, Key: key, UploadId: upload_id }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.completeMultipartUpload({
+                        Bucket: BUCKET, Key: key, UploadId: upload_id,
+                        MultipartUpload: {
+                            Parts: [{ ETag: '"00000000000000000000000000000000"', PartNumber: 1 }],
+                        },
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+                await assert.rejects(
+                    s3.abortMultipartUpload({
+                        Bucket: BUCKET, Key: key, UploadId: upload_id,
+                    }),
+                    err => err_code(err) === 'NoSuchUpload'
+                );
+            });
+        });
+
+        mocha.describe('MPU + Versioning', function() {
+            const storage_class = s3_utils.STORAGE_CLASS_DEEP_ARCHIVE;
+
+            mocha.it('ENABLED: archive MPU creates distinct versions with separate archive keys', async function() {
+                await s3.putBucketVersioning({
+                    Bucket: BUCKET,
+                    VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Enabled' },
+                });
+
+                const key = 's3-mpu/versioning/enabled';
+                const parts1 = [crypto.randomBytes(5 * 1024 * 1024), crypto.randomBytes(32)];
+                const parts2 = [crypto.randomBytes(5 * 1024 * 1024), crypto.randomBytes(64)];
+                const buf1 = Buffer.concat(parts1);
+                const buf2 = Buffer.concat(parts2);
+
+                const r1 = await multipart_upload({ key, parts: parts1, storage_class });
+                assert.ok(r1.version_id);
+                assert.notStrictEqual(r1.version_id, 'null');
+
+                const r2 = await multipart_upload({ key, parts: parts2, storage_class });
+                assert.ok(r2.version_id);
+                assert.notStrictEqual(r2.version_id, 'null');
+                assert.notStrictEqual(r2.version_id, r1.version_id);
+
+                const listed = await s3.listObjectVersions({ Bucket: BUCKET, Prefix: key });
+                const versions = (listed.Versions || []).filter(v => v.Key === key);
+                assert.strictEqual(versions.length, 2);
+                assert.ok(versions.every(v => v.VersionId === r1.version_id || v.VersionId === r2.version_id));
+
+                const md1 = await rpc_client.object.read_object_md({ bucket: BUCKET, key, version_id: r1.version_id });
+                const md2 = await rpc_client.object.read_object_md({ bucket: BUCKET, key, version_id: r2.version_id });
+                assert.notStrictEqual(md1.obj_id, md2.obj_id);
+
+                await assert_archived_via_s3({ key, buf: buf1, storage_class, version_id: r1.version_id });
+                await assert_archived_via_s3({ key, buf: buf2, storage_class, version_id: r2.version_id });
+            });
+
+            mocha.it('SUSPENDED: archive MPU replaces null version; latest points at new archive object', async function() {
+                await s3.putBucketVersioning({
+                    Bucket: BUCKET,
+                    VersioningConfiguration: { MFADelete: 'Disabled', Status: 'Suspended' },
+                });
+
+                const key = 's3-mpu/versioning/suspended';
+                const parts1 = [crypto.randomBytes(5 * 1024 * 1024), crypto.randomBytes(16)];
+                const parts2 = [crypto.randomBytes(5 * 1024 * 1024), crypto.randomBytes(48)];
+                const buf2 = Buffer.concat(parts2);
+
+                await multipart_upload({ key, parts: parts1, storage_class });
+                await multipart_upload({ key, parts: parts2, storage_class });
+
+                const latest_md = await rpc_client.object.read_object_md({ bucket: BUCKET, key });
+                assert.strictEqual(latest_md.size, buf2.length);
+                assert.strictEqual(latest_md.storage_class, storage_class);
+
+                const listed = await s3.listObjectVersions({ Bucket: BUCKET, Prefix: key });
+                const latest_versions = (listed.Versions || []).filter(v => v.Key === key && v.IsLatest);
+                assert.strictEqual(latest_versions.length, 1);
+                assert.strictEqual(latest_versions[0].Size, buf2.length);
+
+                await assert_archived_via_s3({ key, buf: buf2, storage_class });
+            });
+        });
+
+    }); // MultipartUpload
 
     // TODO: add GetObject tests (STANDARD read, unrestored / ongoing / expired restore →
     // InvalidObjectState, restored archive read) once RestoreObject is implemented.

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -184,11 +184,22 @@ async function empty_and_delete_buckets(rpc_client, bucket_names) {
 
     await Promise.all(
         bucket_names.map(async bucket => {
-            const { objects } = await rpc_client.object.list_objects({ bucket });
-            await rpc_client.object.delete_multiple_objects({
-                bucket: bucket,
-                objects: objects.map(obj => _.pick(obj, ['key', 'version_id']))
-            });
+            // list_object_versions: list_objects only returns latest keys, so
+            // non-current versions (and delete markers) would leave NOT_EMPTY.
+            let key_marker;
+            let version_id_marker;
+            for (;;) {
+                const listed = await rpc_client.object.list_object_versions({ bucket, key_marker, version_id_marker });
+                if (listed.objects.length) {
+                    await rpc_client.object.delete_multiple_objects({
+                        bucket,
+                        objects: listed.objects.map(obj => _.pick(obj, ['key', 'version_id'])),
+                    });
+                }
+                if (!listed.is_truncated) break;
+                key_marker = listed.next_marker;
+                version_id_marker = listed.next_version_id_marker;
+            }
             await rpc_client.bucket.delete_bucket({ name: bucket });
         })
     );

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -1,12 +1,11 @@
 /* Copyright (C) 2024 NooBaa */
 'use strict';
 
-const NB_INTERNAL_STORAGE_DIR = 'noobaa_storage/';
 const dbg = require('../util/debug_module')(__filename);
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { GLACIER_STORAGE_CLASSES } = require('../endpoint/s3/s3_utils');
 
-
+const NB_INTERNAL_STORAGE_DIR = 'noobaa_storage/';
 
 /**
  * Returns the key used to store object data in the deep-archive backend.

--- a/src/util/object_utils.js
+++ b/src/util/object_utils.js
@@ -17,7 +17,7 @@ const CREATE_OBJECT_UPLOAD_PARAMS = [
     'lock_settings',
     'storage_class',
     'last_modified_time',
-    'archive_upload_id',
+    'target_data_info',
 ];
 
 const COMPLETE_OBJECT_UPLOAD_PARAMS = [
@@ -31,6 +31,26 @@ const COMPLETE_OBJECT_UPLOAD_PARAMS = [
     'etag',
     'num_parts',
     'last_modified_time',
+    'multiparts',
+];
+
+const CREATE_MULTIPART_PARAMS = [
+    'obj_id',
+    'bucket',
+    'key',
+    'num',
+    'size',
+    'md5_b64',
+    'sha256_b64',
+    'encryption',
+];
+
+const COMPLETE_MULTIPART_PARAMS = [
+    'multipart_id',
+    'obj_id',
+    'bucket',
+    'key',
+    'num',
 ];
 
 /**
@@ -51,5 +71,18 @@ function get_complete_object_upload_params(params) {
     return _.pick(params, COMPLETE_OBJECT_UPLOAD_PARAMS);
 }
 
+/**
+ * Safely destroys an upload source stream if present.
+ * @param {{ source_stream?: { destroy?: Function } }} params
+ */
+function destroy_source_stream(params) {
+    if (params.source_stream && typeof params.source_stream.destroy === 'function') {
+        params.source_stream.destroy();
+    }
+}
+
+exports.CREATE_MULTIPART_PARAMS = CREATE_MULTIPART_PARAMS;
+exports.COMPLETE_MULTIPART_PARAMS = COMPLETE_MULTIPART_PARAMS;
 exports.get_create_object_upload_params = get_create_object_upload_params;
 exports.get_complete_object_upload_params = get_complete_object_upload_params;
+exports.destroy_source_stream = destroy_source_stream;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
Adds multipart upload support for archive storage classes (DEEP_ARCHIVE / GLACIER) via **NamespaceMultiStorageClass**:

1. **Create MPU** - calls NamespaceNB create_object_upload(), then calls NamespaceS3 (the archive namespace) for creating the MPU in the archive as well, and eventually calls update the object_md with the archive_upload_id for mapping. if fails the uploads on noobaa and on the archived get aborted if needed. Client UploadId is the NooBaa obj_id; the archive MPU id is stored as archive_upload_id on object MD.
2. **Upload Part** - create a multipart md entity in noobaa db, uploads part to archive and completes the multipart upload by updating the md via complete_multipart(). if failed the source stream gets destoyed if needed.  
3. **Complete MPU** - calls archive to complete_object_upload and then calls read_object_md for verifying the size of the final MPU.
4. **Abort MPU** - Abort on both NooBaa and Deep Archive.
2. **ListParts** — part MD is recorded in NooBaa DB.
3. **Plumbing** — archive_upload_id on update_object_md / API; client ETag persistence on complete_multipart; shared multipart param helpers in object_utils (also used by object_io).
5. **Tests** — S3 integration coverage for archive MPU (including copy/list/abort) and unit tests for multipart_part_etag_to_md5_b64

### Issues: Fixed #xxx / Gap #xxx
1.

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end multipart upload support for Glacier/Deep Archive, including correct archive placement and visibility of in-progress archive uploads.
  - Introduced ability to read in-progress upload state by object id and expose archive upload id.
  - Extended metadata and multipart completion behavior to support archive-linked uploads and optional “metadata-only” multipart completion.

- **Bug Fixes**
  - Improved S3 metadata read fallback to recover from additional object-state errors.
  - Multipart completion now returns the client-supplied ETag and refines bulk-delete and error handling.

- **Tests**
  - Expanded deep-archive Glacier/S3 multipart integration and added unit/integration coverage for ETag-to-MD5-base64 conversion and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->