### PR TITLE
nc - iam - add inline policy to account

### DIFF
--- a/docs/design/iam_nc.md
+++ b/docs/design/iam_nc.md
@@ -33,6 +33,7 @@ For certain deployments exposing the CLI is not a viable option (for security re
 Support IAM API:  
 - Users: CreateUser, GetUser, UpdateUser, DeleteUser, ListUsers.  
 - Access Keys: CreateAccessKey, GetAccessKeyLastUsed, UpdateAccessKey, DeleteAccessKey, ListAccessKeys.
+- Inline User Policy: PutUserPolicy, GetUserPolicy, ListUserPolicies, DeleteUserPolicy
 ### Out of Scope
 At this point we will not support additional IAM resources (group, policy, role, etc).
 
@@ -134,7 +135,6 @@ Would always return an empty list (to check that the user exists it runs GetUser
 - IAM ListServiceSpecificCredentials
 - IAM ListSigningCertificates
 - IAM ListSSHPublicKeys
-- IAM ListUserPolicies
 - IAM ListUserTags
 Would always return an empty list
 - IAM ListAccountAliases

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -1404,7 +1404,6 @@ async function authorize_request_iam_policy_impl(req, method, bucket_name, servi
         return deny_result;
     }
     if (iam_policies.length === 0) {
-        if (is_iam_user && req.object_sdk.nsfs_config_root) return true; // We do not have IAM policies in NC yet
         dbg.error('authorize_request_iam_policy:', iam_identity, 'has no inline policies configured');
         return deny_result;
     }

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -10,7 +10,7 @@ const { ConfigFS, CONFIG_TYPES } = require('./config_fs');
 const native_fs_utils = require('../util/native_fs_utils');
 const { create_arn_for_user, create_arn_for_root, get_action_message_title, check_iam_path_was_set } = require('../endpoint/iam/iam_utils');
 const { IAM_ACTIONS, MAX_NUMBER_OF_ACCESS_KEYS, IAM_DEFAULT_PATH,
-    ACCESS_KEY_STATUS_ENUM, IDENTITY_ENUM } = require('../endpoint/iam/iam_constants');
+    ACCESS_KEY_STATUS_ENUM, IDENTITY_ENUM, AWS_LIMIT_CHARS_INLINE_POLICY } = require('../endpoint/iam/iam_constants');
 const IamError = require('../endpoint/iam/iam_errors').IamError;
 const cloud_utils = require('../util/cloud_utils');
 const SensitiveString = require('../util/sensitive_string');
@@ -323,7 +323,7 @@ class AccountSpaceFS {
         dbg.log1(`AccountSpaceFS.${action}`, params);
         try {
             const requesting_account = account_sdk.requesting_account;
-            const requester = this._check_if_requesting_account_is_root_account_or_user_om_himself(action,
+            const requester = this._check_if_requesting_account_is_root_account_or_user_on_himself(action,
                 requesting_account, params.username);
             const username = params.username ?? requester.name;
             const on_itself = !params.username;
@@ -413,7 +413,7 @@ class AccountSpaceFS {
         try {
             const requesting_account = account_sdk.requesting_account;
             const access_key_id = params.access_key;
-            const requester = this._check_if_requesting_account_is_root_account_or_user_om_himself(action,
+            const requester = this._check_if_requesting_account_is_root_account_or_user_on_himself(action,
                 requesting_account, params.username);
             const username = params.username ?? requester.name; // username is not required
             await this._check_if_account_exists_by_access_key_symlink(action, access_key_id);
@@ -460,7 +460,7 @@ class AccountSpaceFS {
         try {
             const requesting_account = account_sdk.requesting_account;
             const access_key_id = params.access_key;
-            const requester = this._check_if_requesting_account_is_root_account_or_user_om_himself(action,
+            const requester = this._check_if_requesting_account_is_root_account_or_user_on_himself(action,
                 requesting_account, params.username);
             const username = params.username ?? requester.name; // username is not required
             await this._check_if_account_exists_by_access_key_symlink(action, access_key_id);
@@ -498,7 +498,7 @@ class AccountSpaceFS {
         dbg.log1(`AccountSpaceFS.${action}`, params);
         try {
             const requesting_account = account_sdk.requesting_account;
-            const requester = this._check_if_requesting_account_is_root_account_or_user_om_himself(action,
+            const requester = this._check_if_requesting_account_is_root_account_or_user_on_himself(action,
                 requesting_account, params.username);
             const username = params.username ?? requester.name;
             const on_itself = !params.username;
@@ -522,43 +522,146 @@ class AccountSpaceFS {
         }
     }
 
+    /////////////////
+    // USER POLICY //
+    /////////////////
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to update is owned by the root account
+    // 5 - find existing policy by name or create new entry
+    // 6 - check that the total policy size does not exceed the limit
+    // 7 - update the account config file
+    async put_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.PUT_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            this._check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
+            await this._check_if_account_config_file_exists(action, params.username, params, requesting_account);
+            const owner_account_id = this._get_owner_account_argument(requesting_account);
+            const requested_account = await this.config_fs.get_account_or_user_by_name(
+                params.username, owner_account_id, { show_secrets: true, decrypt_secret_key: true });
+            this._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
+            this._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
+            const iam_user_policies = [...(requested_account.iam_user_policies || [])];
+            const index_of_iam_user_policy = _get_iam_policy_index(iam_user_policies, params.policy_name);
+            const iam_user_policy_to_add = {
+                policy_name: params.policy_name,
+                policy_document: params.policy_document,
+            };
+            if (index_of_iam_user_policy === -1) {
+                iam_user_policies.push(iam_user_policy_to_add);
+            } else {
+                iam_user_policies[index_of_iam_user_policy] = iam_user_policy_to_add;
+            }
+            this._check_total_policy_size(action, iam_user_policies, params.username);
+            requested_account.iam_user_policies = iam_user_policies;
+            await this.config_fs.update_account_config_file(requested_account);
+            _clean_account_id_cache(requested_account);
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.USER);
+        }
+    }
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to get is owned by the root account
+    // 5 - find the policy by name (error if not found)
+    // 6 - return the policy document as a string
+    async get_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.GET_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        let iam_user_policies;
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            this._check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
+            await this._check_if_account_config_file_exists(action, params.username, params, requesting_account);
+            const owner_account_id = this._get_owner_account_argument(requesting_account);
+            const requested_account = await this.config_fs.get_account_or_user_by_name(params.username, owner_account_id);
+            this._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
+            this._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
+            iam_user_policies = requested_account.iam_user_policies || [];
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.USER);
+        }
+        //_check_iam_policy_exists will throw IamError.NoSuchEntity if policy doesn't exist
+        const iam_user_policy_index = this._check_iam_policy_exists(action, iam_user_policies, params.policy_name);
+        return {
+            username: params.username,
+            policy_name: params.policy_name,
+            policy_document: JSON.stringify(iam_user_policies[iam_user_policy_index].policy_document),
+        };
+    }
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to update is owned by the root account
+    // 5 - find the policy by name (error if not found)
+    // 6 - remove the policy from the array
+    // 7 - update the account config file
+    async delete_user_policy(params, account_sdk) {
+        const action = IAM_ACTIONS.DELETE_USER_POLICY;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            this._check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
+            await this._check_if_account_config_file_exists(action, params.username, params, requesting_account);
+            const owner_account_id = this._get_owner_account_argument(requesting_account);
+            const requested_account = await this.config_fs.get_account_or_user_by_name(
+                params.username, owner_account_id, { show_secrets: true, decrypt_secret_key: true });
+            this._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
+            this._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
+            const iam_user_policies = [...(requested_account.iam_user_policies || [])];
+            const iam_user_policy_index = this._check_iam_policy_exists(action, iam_user_policies, params.policy_name);
+            iam_user_policies.splice(iam_user_policy_index, 1);
+            requested_account.iam_user_policies = iam_user_policies;
+            await this.config_fs.update_account_config_file(requested_account);
+            _clean_account_id_cache(requested_account);
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.USER);
+        }
+    }
+
+    // 1 - check that the requesting account is a root user account
+    // 2 - check that the user account config file exists
+    // 3 - read the account config file
+    // 4 - check that the user to list is owned by the root account
+    // 5 - return the sorted list of policy names
+    async list_user_policies(params, account_sdk) {
+        const action = IAM_ACTIONS.LIST_USER_POLICIES;
+        dbg.log1(`AccountSpaceFS.${action}`, params);
+        try {
+            const requesting_account = account_sdk.requesting_account;
+            this._check_if_requesting_account_is_root_account(action,
+                requesting_account, params.username);
+            await this._check_if_account_config_file_exists(action, params.username, params, requesting_account);
+            const owner_account_id = this._get_owner_account_argument(requesting_account);
+            const requested_account = await this.config_fs.get_account_or_user_by_name(params.username, owner_account_id);
+            this._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
+            this._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
+            // TODO: Pagination not supported - currently returns all policies, ignoring marker and max_items params
+            const is_truncated = false;
+            let members = (requested_account.iam_user_policies || []).map(p => p.policy_name);
+            members = members.sort((a, b) => a.localeCompare(b));
+            return { members, is_truncated };
+        } catch (err) {
+            dbg.error(`AccountSpaceFS.${action} error`, err);
+            throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.USER);
+        }
+    }
+
     /////////////////////
     // OTHER FUNCTIONS //
     /////////////////////
     // The function here are implemented in AccountSpaceNB, but not in AccountSpaceFS
     // and will throw NotImplemented error, except for the function with list which will return an empty list
-
-    async put_user_policy(params, account_sdk) {
-        const action = IAM_ACTIONS.PUT_USER_POLICY;
-        dbg.log1(`AccountSpaceFS.${action}`, params);
-        const { code, http_code, type } = IamError.NotImplemented;
-        throw new IamError({ code, message: 'NotImplemented', http_code, type });
-    }
-
-    async get_user_policy(params, account_sdk) {
-        const action = IAM_ACTIONS.GET_USER_POLICY;
-        dbg.log1(`AccountSpaceFS.${action}`, params);
-        const { code, http_code, type } = IamError.NotImplemented;
-        throw new IamError({ code, message: 'NotImplemented', http_code, type });
-    }
-
-    async delete_user_policy(params, account_sdk) {
-        const action = IAM_ACTIONS.DELETE_USER_POLICY;
-        dbg.log1(`AccountSpaceFS.${action}`, params);
-        const { code, http_code, type } = IamError.NotImplemented;
-        throw new IamError({ code, message: 'NotImplemented', http_code, type });
-    }
-
-    async list_user_policies(params, account_sdk) {
-        const action = IAM_ACTIONS.LIST_USER_POLICIES;
-        dbg.log1(`AccountSpaceFS.${action}`, params);
-        dbg.log1('To check that we have the user we will run the IAM GET USER', params);
-        await account_sdk.get_user(params);
-        dbg.log1('IAM LIST USER POLICIES (returns empty list on every request)', params);
-        const is_truncated = false;
-        const members = [];
-        return { members, is_truncated };
-    }
 
     async tag_user(params, account_sdk) {
         const action = IAM_ACTIONS.TAG_USER;
@@ -941,6 +1044,7 @@ class AccountSpaceFS {
             await this._check_if_root_account_does_not_have_IAM_users_before_deletion(action, account_to_delete);
         }
         this._check_if_user_does_not_have_access_keys_before_deletion(action, account_to_delete);
+        this._check_if_user_does_not_have_user_policy_before_deletion(action, account_to_delete);
     }
 
     async _check_if_root_account_does_not_have_buckets_before_deletion(action, account_to_delete) {
@@ -969,6 +1073,38 @@ class AccountSpaceFS {
         const is_access_keys_empty = access_keys.length === 0;
         if (!is_access_keys_empty) {
             this._throw_error_delete_conflict(action, account_to_delete, resource_name);
+        }
+    }
+
+    _check_if_user_does_not_have_user_policy_before_deletion(action, account_to_delete) {
+        const resource_name = 'policies';
+        const iam_user_policies = account_to_delete.iam_user_policies || [];
+        if (iam_user_policies.length > 0) {
+            this._throw_error_delete_conflict(action, account_to_delete, resource_name);
+        }
+    }
+
+    _check_iam_policy_exists(action, iam_policies, policy_name) {
+        const iam_policy_index = _get_iam_policy_index(iam_policies, policy_name);
+        if (iam_policy_index === -1) {
+            dbg.error(`AccountSpaceFS.${action} policy does not exist`, policy_name);
+            const message_with_details = `The user policy with name ${policy_name} cannot be found.`;
+            const { code, http_code, type } = IamError.NoSuchEntity;
+            throw new IamError({ code, message: message_with_details, http_code, type });
+        }
+        return iam_policy_index;
+    }
+
+    _check_total_policy_size(action, iam_user_policies, username) {
+        let total_size = 0;
+        for (const iam_user_policy of iam_user_policies) {
+            total_size += JSON.stringify(iam_user_policy).length;
+        }
+        if (total_size > AWS_LIMIT_CHARS_INLINE_POLICY) {
+            dbg.error(`AccountSpaceFS.${action} maximum policy size exceeded for user`, username, total_size);
+            const message_with_details = `Maximum policy size of ${AWS_LIMIT_CHARS_INLINE_POLICY} bytes exceeded for user ${username}`;
+            const { code, http_code, type } = IamError.LimitExceeded;
+            throw new IamError({ code, message: message_with_details, http_code, type });
         }
     }
 
@@ -1084,7 +1220,7 @@ class AccountSpaceFS {
         return members;
     }
 
-    _check_if_requesting_account_is_root_account_or_user_om_himself(action, requesting_account, username) {
+    _check_if_requesting_account_is_root_account_or_user_on_himself(action, requesting_account, username) {
         const { is_root_account_or_user_on_itself, requester } = this._check_root_account_or_user(
             requesting_account,
             username
@@ -1159,6 +1295,16 @@ class AccountSpaceFS {
         }
         _clean_account_id_cache(requested_account);
     }
+}
+
+/**
+ * Returns the index of the policy with policy_name in the iam_policies array, or -1 if not found.
+ * @param {Array} iam_policies
+ * @param {string} policy_name
+ * @returns {number}
+ */
+function _get_iam_policy_index(iam_policies, policy_name) {
+    return iam_policies.findIndex(current_iam_policy => current_iam_policy.policy_name === policy_name);
 }
 
 // EXPORTS

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -589,7 +589,6 @@ class AccountSpaceFS {
             dbg.error(`AccountSpaceFS.${action} error`, err);
             throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.USER);
         }
-        //_check_iam_policy_exists will throw IamError.NoSuchEntity if policy doesn't exist
         const iam_user_policy_index = this._check_iam_policy_exists(action, iam_user_policies, params.policy_name);
         return {
             username: params.username,

--- a/src/sdk/accountspace_fs.js
+++ b/src/sdk/accountspace_fs.js
@@ -526,24 +526,30 @@ class AccountSpaceFS {
     // USER POLICY //
     /////////////////
 
-    // 1 - check that the requesting account is a root user account
-    // 2 - check that the user account config file exists
-    // 3 - read the account config file
-    // 4 - check that the user to update is owned by the root account
-    // 5 - find existing policy by name or create new entry
-    // 6 - check that the total policy size does not exceed the limit
-    // 7 - update the account config file
+    // 1 - check that the requesting account is a root account
+    // 2 - check that requested user is not root
+    // 3 - check that the user account config file exists
+    // 4 - read the account config file
+    // 5 - check that the user to update is owned by the root account
+    // 6 - find existing policy by name or create new entry
+    // 7 - check that the total policy size does not exceed the limit
+    // 8 - update the account config file
     async put_user_policy(params, account_sdk) {
         const action = IAM_ACTIONS.PUT_USER_POLICY;
+        const user_details = { username: params.username };
         dbg.log1(`AccountSpaceFS.${action}`, params);
         try {
             const requesting_account = account_sdk.requesting_account;
-            this._check_if_requesting_account_is_root_account(action, requesting_account, { username: params.username });
+            this._check_if_requesting_account_is_root_account(action, requesting_account, user_details);
+            //root cannot put user policies on itself
+            //see "Policies and the root user" in https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html
+            if (requesting_account.name.unwrap() === params.username) {
+                this._throw_access_denied_error(action, requesting_account, user_details, native_fs_utils.entity_enum.USER);
+            }
             await this._check_if_account_config_file_exists(action, params.username, params, requesting_account);
             const owner_account_id = this._get_owner_account_argument(requesting_account);
             const requested_account = await this.config_fs.get_account_or_user_by_name(
                 params.username, owner_account_id, { show_secrets: true, decrypt_secret_key: true });
-            this._check_if_requested_account_is_root_account_or_IAM_user(action, requesting_account, requested_account);
             this._check_if_requested_is_owned_by_root_account(action, requesting_account, requested_account);
             const iam_user_policies = [...(requested_account.iam_user_policies || [])];
             const index_of_iam_user_policy = _get_iam_policy_index(iam_user_policies, params.policy_name);

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -114,5 +114,11 @@ module.exports = {
         role_config: {
             $ref: 'common_api#/definitions/role_config'
         },
+        iam_user_policies: {
+            type: 'array',
+            items: {
+                $ref: 'common_api#/definitions/iam_user_policy',
+            }
+        },
     }
 };

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -111,5 +111,11 @@ module.exports = {
         role_config: {
             $ref: 'common_api#/definitions/role_config'
         },
+        iam_user_policies: {
+            type: 'array',
+            items: {
+                $ref: 'common_api#/definitions/iam_user_policy',
+            }
+        },
     }
 };

--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -290,7 +290,6 @@ mocha.describe('IAM integration tests', async function() {
         });
 
         mocha.describe('IAM User Policy API', async function() {
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             const username3 = 'Kai';
             const policy_name = 'AllAccessPolicy';
             const iam_user_inline_policy_document = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}';
@@ -1386,7 +1385,6 @@ mocha.describe('IAM integration tests', async function() {
                 });
 
                 mocha.it('delete a user - user has inline IAM policy - should fail', async function() {
-                    if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
                     await create_iam_user(iam_account, username3);
                     const policy_name = 'AllAccessPolicy';
                     const iam_user_inline_policy_document = '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}';
@@ -1824,7 +1822,6 @@ mocha.describe('IAM integration tests', async function() {
         });
 
         mocha.describe('IAM User Policy API', async function() {
-            if (is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
             const username = 'Luis';
             const username2 = 'Elena';
             let access_key_id;

--- a/src/test/integration_tests/api/iam/test_iam_basic_integration.js
+++ b/src/test/integration_tests/api/iam/test_iam_basic_integration.js
@@ -70,7 +70,11 @@ mocha.describe('IAM integration tests', async function() {
             await fs_utils.file_must_exist(new_bucket_path_param);
             account_res = await generate_nsfs_account(rpc_client, EMAIL, new_bucket_path_param, { admin: true });
         } else {
-            account_res = (await rpc_client.account.read_account({ email: EMAIL })).access_keys[0];
+            const read_account = await rpc_client.account.read_account({ email: EMAIL });
+            account_res = {
+                ...read_account.access_keys[0],
+                name: read_account.name,
+            };
         }
 
         // needed details for creating the account (and then the client)
@@ -1900,6 +1904,24 @@ mocha.describe('IAM integration tests', async function() {
                         const command = new PutUserPolicyCommand(input);
                         await iam_user_client.send(command);
                         assert.fail('put user policy - requester is IAM user - should throw an error');
+                    } catch (err) {
+                        const { err_code, err_message } = _get_err_code_and_message(err);
+                        assert.equal(err_code, IamError.AccessDeniedException.code);
+                        assert.ok(err_message.includes(`not authorized to perform: iam:PutUserPolicy`));
+                    }
+                });
+
+                mocha.it('put user policy - requested is root user - should throw an error', async function() {
+                    if (!is_nc_coretest) this.skip(); // eslint-disable-line no-invalid-this
+                    try {
+                        const input = {
+                            UserName: account_res.name,
+                            PolicyName: policy_name,
+                            PolicyDocument: iam_user_inline_policy_document
+                        };
+                        const command = new PutUserPolicyCommand(input);
+                        await iam_account.send(command);
+                        assert.fail('put user policy - requested is root user - should throw an error');
                     } catch (err) {
                         const { err_code, err_message } = _get_err_code_and_message(err);
                         assert.equal(err_code, IamError.AccessDeniedException.code);

--- a/src/test/system_tests/test_utils.js
+++ b/src/test/system_tests/test_utils.js
@@ -571,7 +571,8 @@ async function generate_nsfs_account(rpc_client, EMAIL, default_new_buckets_path
         });
         return {
             access_key: account.access_keys[0].access_key.unwrap(),
-            secret_key: account.access_keys[0].secret_key.unwrap()
+            secret_key: account.access_keys[0].secret_key.unwrap(),
+            name: account.name
         };
     }
     const random_name = account_name || (Math.random() + 1).toString(36).substring(7);


### PR DESCRIPTION
### Describe the Problem
Implement iam policy CRUD for NC.
Note native_fs_utils.entity_enum.USER was used for native_fs_utils.translate_error_codes.

### Explain the Changes
1. Add new iam_user_policies field to account schema.
2. Implement put, get, list, update, delete user policy in accountspace_fs

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full support for IAM user inline policies, including create/replace, retrieve, list, and delete operations.
  * Enforced aggregate inline policy size limits and improved policy document formatting.
  * Policy names are now listed in sorted order, with clear errors for policies that cannot be found.
* **Bug Fixes**
  * Blocked user deletion when inline policies remain, returning a conflict error.
* **Tests**
  * Expanded IAM integration coverage for inline policy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->