### PR TITLE
DEEP_ARCHIVE | Object Restore API Implementation

### DIFF
--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -631,6 +631,7 @@ module.exports = {
                     xattr: { $ref: '#/definitions/xattr' },
                     cache_last_valid_time: { idate: true },
                     last_modified_time: { idate: true },
+                    restore_status: { $ref: '#/definitions/restore_status' },
                 }
             },
             auth: { system: ['admin', 'user'] }
@@ -1538,6 +1539,36 @@ module.exports = {
             },
             auth: { system: ['admin', 'user'] }
         },
+
+        get_object_restore_info: {
+            method: 'GET',
+            params: {
+                type: 'object',
+                required: [
+                    'bucket',
+                    'key',
+                ],
+                properties: {
+                    bucket: { $ref: 'common_api#/definitions/bucket_name' },
+                    key: { type: 'string' },
+                    version_id: { type: 'string' },
+                }
+            },
+            reply: {
+                type: 'object',
+                required: [
+                    'obj_id',
+                    'bucket_id',
+                ],
+                properties: {
+                    obj_id: { objectid: true },
+                    bucket_id: { objectid: true },
+                    storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
+                    restore_status: { $ref: '#/definitions/restore_status' },
+                }
+            },
+            auth: { system: ['admin', 'user'] }
+        },
     },
 
     definitions: {
@@ -1599,6 +1630,7 @@ module.exports = {
                 },
                 transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
                 data_expired: { idate: true },
+                restore_status: { $ref: '#/definitions/restore_status' },
             }
         },
 
@@ -1779,6 +1811,15 @@ module.exports = {
                 total: { type: 'number' },
                 used: { type: 'number' }
             }
-        }
+        },
+
+        restore_status: {
+            type: 'object',
+            properties: {
+                ongoing: { type: 'boolean' },
+                expiry_time: { idate: true },
+                days: { type: 'integer' },
+            }
+        },
     },
 };

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -669,6 +669,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     INVALID_ENCODING_TYPE: S3Error.InvalidEncodingType,
     INVALID_TARGET_BUCKET: S3Error.InvalidTargetBucketForLogging,
     METHOD_NOT_ALLOWED: S3Error.MethodNotAllowed,
+    RESTORE_ALREADY_IN_PROGRESS: S3Error.RestoreAlreadyInProgress,
 });
 
 exports.S3Error = S3Error;

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -759,7 +759,7 @@ function parse_restore_request_days(req) {
     const days = parse_decimal_int(req.body.RestoreRequest.Days[0]);
     if (days < 1) {
         dbg.warn('parse_restore_request_days: days cannot be less than 1');
-        throw new S3Error(S3Error.InvalidArgument);
+        throw new S3Error({ ...S3Error.InvalidArgument, message: 'restoration days should be at least 1'});
     }
 
     if (days > config.S3_RESTORE_REQUEST_MAX_DAYS) {

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -4,7 +4,7 @@
 const _ = require('lodash');
 const dbg = require('../util/debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
-const { get_archive_key, throw_if_restore_incomplete } = require('../util/deep_archive_utils');
+const { get_archive_key, throw_if_restore_incomplete, is_restore_active, compute_restore_expiry } = require('../util/deep_archive_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { get_create_object_upload_params, get_complete_object_upload_params } = require('../util/object_utils');
 
@@ -411,12 +411,70 @@ class NamespaceMultiStorageClass {
     ////////////////////
 
     /**
+     * Initiates or updates a temporary restore of an archived object.
+     * Loads restore fields via get_object_restore_info (no s3:GetObject check),
+     * records restore_status on object MD, and calls restore_object on the archive
+     * target namespace. A background worker later completes the temporary STANDARD
+     * copy and sets expiry_time. On an already-restored object, replaces expiry with
+     * now+days (AWS-compatible, may shorten). On archive failure other than
+     * RestoreAlreadyInProgress, clears ongoing so the client can retry.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
-     * @returns {Promise<{ accepted: boolean }>}
+     * @returns {Promise<{ accepted: boolean, expires_on?: Date, storage_class?: string }>}
      */
     async restore_object(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        const { bucket, key, days } = params;
+        // Use restore-specific MD RPC (no s3:GetObject). Endpoint already checked s3:RestoreObject.
+        const object_restore_info = await object_sdk.rpc_client.object.get_object_restore_info(
+            _.pick(params, 'bucket', 'key', 'version_id')
+        );
+        const storage_class = s3_utils.parse_storage_class(object_restore_info.storage_class);
+        if (!s3_utils.GLACIER_STORAGE_CLASSES.includes(storage_class)) {
+            throw new S3Error(S3Error.InvalidObjectStorageClass);
+        }
+        const target_ns = this.namespace_by_storage_class[storage_class];
+        if (!target_ns) {
+            throw new S3Error(S3Error.NotImplemented);
+        }
+
+        if (object_restore_info.restore_status?.ongoing) {
+            throw new S3Error(S3Error.RestoreAlreadyInProgress);
+        }
+
+        if (is_restore_active(object_restore_info.restore_status)) {
+            const expires_on = compute_restore_expiry(days, new Date());
+            await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
+                restore_status: { ongoing: false, expiry_time: expires_on.getTime() } });
+            dbg.log1('NamespaceMultiStorageClass.restore_object: updated restore expiry', { bucket, key, expires_on });
+            return {
+                accepted: false, // accepted:false means already restored
+                expires_on,
+                storage_class,
+            };
+        }
+
+        const archive_key = get_archive_key(object_restore_info.bucket_id, object_restore_info.obj_id);
+        const archive_params = { ..._.pick(params, 'bucket', 'days', 'encryption'), key: archive_key}; // omit version-id because archive object is keyed by bucket_id/obj_id
+        await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
+            restore_status: { ongoing: true, days } });
+        dbg.log1('NamespaceMultiStorageClass.restore_object: initiating archive restore', { bucket, key, archive_key, days });
+        try {
+            await target_ns.restore_object(archive_params, object_sdk);
+        } catch (err) {
+            dbg.error('NamespaceMultiStorageClass.restore_object: archive restore failed', { bucket, key, archive_key }, err);
+            if (err.code === S3Error.RestoreAlreadyInProgress.code || err.rpc_code === 'RESTORE_ALREADY_IN_PROGRESS') {
+                throw err;
+            }
+            try {
+                await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
+                    restore_status: { ongoing: false }});
+            } catch (err2) {
+                dbg.error('NamespaceMultiStorageClass.restore_object: failed to clear ' +
+                    'restore_status after archive failure', { bucket, key, archive_key }, err2);
+            }
+            throw err;
+        }
+        return { accepted: true }; // accepted:true means initiate restore succeeded
     }
 
     //////////////

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -10,7 +10,6 @@ const s3_utils = require('../endpoint/s3/s3_utils');
 const cloud_utils = require('../util/cloud_utils');
 const stream_utils = require('../util/stream_utils');
 const blob_translator = require('./blob_translator');
-const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const noobaa_s3_client = require('../sdk/noobaa_s3_client/noobaa_s3_client');
 const { PutObjectCommand } = require('@aws-sdk/client-s3');
 
@@ -212,9 +211,14 @@ class NamespaceS3 {
                     await this.s3.headObject(request);
             } catch (err) {
                 // catch invalid range error for objects of size 0 and try head object instead
-                const httpCode = err?.$metadata?.httpStatusCode;
-                const isInvalidRange = err?.name === 'InvalidRange' || httpCode === 416;
-                if (!isInvalidRange) {
+                // InvalidObjectState: unrestored glacier/archive — GetObject is blocked but HeadObject still returns metadata.
+                const http_code = err.$metadata?.httpStatusCode;
+                const err_code = err.name || err.code || err.Code;
+                const should_fallback_to_head_object = can_use_get_inline && (
+                    err_code === 'InvalidRange' || http_code === 416 ||
+                    err_code === 'InvalidObjectState'
+                );
+                if (!should_fallback_to_head_object) {
                     throw err;
                 }
                 res = await this.s3.headObject({ ...request, Range: undefined });
@@ -227,11 +231,8 @@ class NamespaceS3 {
 
             // It's totally expected to issue `HeadObject` against an object that doesn't exist
             // this shouldn't be counted as an issue for the namespace store
-            //
-            // @TODO: Another error to tolerate is 'InvalidObjectState'. This shouldn't also
-            // result in IO_ERROR for the namespace however that means we can not do `getObject`
-            // even when `can_use_get_inline` is true.
-            if (err.rpc_code !== 'NO_SUCH_OBJECT') {
+            const err_code = err.name || err.code || err.Code;
+            if (err.rpc_code !== 'NO_SUCH_OBJECT' && err_code !== 'InvalidObjectState') {
                 object_sdk.rpc_client.pool.update_issues_report({
                     namespace_resource_id: this.namespace_resource_id,
                     error_code: String(err.code),
@@ -345,6 +346,7 @@ class NamespaceS3 {
                 ContentLength: params.size,
                 ContentType: params.content_type,
                 ContentMD5: params.md5_b64,
+                StorageClass: params.storage_class,
                 Metadata: params.xattr,
                 Tagging,
             };
@@ -760,7 +762,23 @@ class NamespaceS3 {
     ////////////////////
 
     async restore_object(params, object_sdk) {
-        throw new S3Error(S3Error.NotImplemented);
+        dbg.log0('NamespaceS3.restore_object:', this.bucket, inspect(params));
+        await this._prepare_sts_client();
+        try {
+            await this.s3.restoreObject({
+                Bucket: this.bucket,
+                Key: params.key,
+                VersionId: params.version_id,
+                RestoreRequest: {
+                    Days: params.days,
+                },
+            });
+            return { accepted: true };
+        } catch (err) {
+            this._translate_error_code(params, err);
+            dbg.warn('NamespaceS3.restore_object:', inspect(err));
+            throw err;
+        }
     }
 
     //////////////////////////
@@ -860,10 +878,11 @@ class NamespaceS3 {
     }
 
     _translate_error_code(params, err) {
-        const err_code = err.code || err.Code;
+        const err_code = err.name || err.code || err.Code;
         if (err_code === 'NoSuchKey') err.rpc_code = 'NO_SUCH_OBJECT';
         else if (err_code === 'NotFound') err.rpc_code = 'NO_SUCH_OBJECT';
         else if (err_code === 'InvalidRange') err.rpc_code = 'INVALID_RANGE';
+        else if (err_code === 'RestoreAlreadyInProgress') err.rpc_code = 'RESTORE_ALREADY_IN_PROGRESS';
         else if (params.md_conditions) {
             const md_conditions = params.md_conditions;
             if (err_code === 'PreconditionFailed') {

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -438,6 +438,7 @@ interface ObjectMD {
     lock_settings: { retention: { mode: string; retain_until_date: Date; }, legal_hold: { status: string } };
     transition_status?: string;
     data_expired?: Date;
+    restore_status?: RestoreStatus;
 }
 
 interface ObjectOwner {
@@ -1360,9 +1361,10 @@ type NodeCallback<T = void> = (err: Error | null, res?: T) => void;
 type RestoreState = 'CAN_RESTORE' | 'ONGOING' | 'RESTORED';
 
 interface RestoreStatus {
-    state: nb.RestoreState;
+    state?: nb.RestoreState; // currently used in NC Glacier only
     ongoing?: boolean;
     expiry_time?: Date;
+    days?: number; // currently used in MSC only
 
     tape_info?: TapeInfo[];
 }

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1063,7 +1063,7 @@ function _check_encryption_permissions(src_enc, req_enc) {
 async function update_object_md(req) {
     dbg.log1('object_server.update object md', req.rpc_params);
     throw_if_maintenance(req);
-    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time');
+    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time', 'restore_status');
     if (set_updates.xattr) {
         set_updates.xattr = _.mapKeys(set_updates.xattr, (v, k) => k.replace(/\./g, '@'));
     }
@@ -1072,6 +1072,9 @@ async function update_object_md(req) {
     }
     if (set_updates.last_modified_time) {
         set_updates.last_modified_time = new Date(set_updates.last_modified_time);
+    }
+    if (set_updates.restore_status?.expiry_time) {
+        set_updates.restore_status.expiry_time = new Date(set_updates.restore_status.expiry_time);
     }
     const obj = await find_object_md(req);
     await MDStore.instance().update_object_by_id(obj._id, set_updates);
@@ -1775,6 +1778,12 @@ function get_object_info(md, options = {}) {
         object_owner: _get_object_owner(),
         transition_status: md.transition_status || undefined,
         data_expired: md.data_expired ? md.data_expired.getTime() : undefined,
+        restore_status: md.restore_status ? {
+            ongoing: md.restore_status.ongoing,
+            days: md.restore_status.days,
+            expiry_time: md.restore_status.expiry_time ?
+                new Date(md.restore_status.expiry_time).getTime() : undefined,
+        } : undefined,
     };
 }
 
@@ -1989,6 +1998,19 @@ function check_quota(bucket) {
         dbg.error(message);
         throw new RpcError('OBJECT_QUOTA_EXCEEDED', message);
     }
+}
+
+async function get_object_restore_info(req) {
+    dbg.log1('object_server.get_object_restore_info:', req.rpc_params);
+    load_bucket(req);
+    const obj = await find_object_md(req);
+    const info = get_object_info(obj);
+    return {
+        obj_id: info.obj_id,
+        bucket_id: String(obj.bucket),
+        storage_class: info.storage_class,
+        restore_status: info.restore_status,
+    };
 }
 
 
@@ -2455,6 +2477,7 @@ exports.read_node_mapping = read_node_mapping;
 // object meta-data
 exports.read_object_md = read_object_md;
 exports.update_object_md = update_object_md;
+exports.get_object_restore_info = get_object_restore_info;
 // deletion
 exports.delete_object = delete_object;
 exports.delete_multiple_objects = delete_multiple_objects;

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -144,5 +144,14 @@ module.exports = {
         transition_status: { $ref: 'common_api#/definitions/transition_status_enum' },
 
         data_expired: { date: true },
+
+        restore_status: {
+            type: 'object',
+            properties: {
+                ongoing: { type: 'boolean' },
+                expiry_time: { date: true },
+                days: { type: 'integer' },
+            }
+        },
     }
 };

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -49,14 +49,16 @@ function parse_obj_id(obj_id) {
 /**
  * @param {string} bid
  * @param {string} obj_id
- * @returns {Promise<Buffer>}
+ * @param {number} expected_len
+ * @returns {Promise<void>}
  */
-async function get_archive_body(bid, obj_id) {
-    const archived = await s3.getObject({
+async function assert_archive_present(bid, obj_id, expected_len) {
+    // Use HeadObject — GetObject on unrestored DEEP_ARCHIVE archive keys returns InvalidObjectState.
+    const archived_head = await s3.headObject({
         Bucket: ARCHIVE_TARGET_BUCKET,
         Key: get_archive_key(bid, obj_id),
     });
-    return Buffer.from(await archived.Body.transformToByteArray());
+    assert.strictEqual(archived_head.ContentLength, expected_len);
 }
 
 /**
@@ -149,8 +151,15 @@ async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET
     assert.strictEqual(md.storage_class, storage_class);
     assert.strictEqual(md.size, buf.length);
 
-    const archived_body = await get_archive_body(bid, md.obj_id);
-    assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+    const archive_key = get_archive_key(bid, md.obj_id);
+    const archived_head = await s3.headObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: archive_key });
+    assert.strictEqual(archived_head.StorageClass, storage_class);
+    assert.strictEqual(archived_head.ContentLength, buf.length);
+
+    await assert.rejects(
+        s3.getObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: archive_key }),
+        err => err_code(err) === 'InvalidObjectState'
+    );
 
     await assert.rejects(
         s3.headObject({ Bucket: ARCHIVE_TARGET_BUCKET, Key: key }),
@@ -560,8 +569,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await s3.deleteObject({ Bucket: BUCKET, Key: key });
 
             await assert_md_absent(BUCKET, key);
-            const archived_body = await get_archive_body(bucket_id, obj_id);
-            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+            await assert_archive_present(bucket_id, obj_id, buf.length);
             await assert_object_unreclaimed(obj_id);
 
             await run_objects_reclaimer(obj_id);
@@ -583,8 +591,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await assert_md_absent(BUCKET, key);
             const has_parts_after_delete = await object_has_parts(obj_id);
             assert.ok(has_parts_after_delete, 'restore copy parts remain until reclaim');
-            const archived_body = await get_archive_body(bucket_id, obj_id);
-            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+            await assert_archive_present(bucket_id, obj_id, buf.length);
 
             await run_objects_reclaimer(obj_id);
 
@@ -620,8 +627,7 @@ mocha.describe('deep_archive_via_s3', function() {
 
             await assert_md_absent(BUCKET, std_key);
             await assert_md_absent(BUCKET, arch_key);
-            const archived_body = await get_archive_body(bucket_id, arch_md.obj_id);
-            assert.strictEqual(Buffer.compare(archived_body, arch_buf), 0);
+            await assert_archive_present(bucket_id, arch_md.obj_id, arch_buf.length);
 
             await run_objects_reclaimer(std_md.obj_id, arch_md.obj_id);
 
@@ -653,7 +659,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await assert_md_absent(BUCKET, arch_key);
             const has_parts_after_delete = await object_has_parts(arch_md.obj_id);
             assert.ok(has_parts_after_delete);
-            await get_archive_body(bucket_id, arch_md.obj_id);
+            await assert_archive_present(bucket_id, arch_md.obj_id, arch_buf.length);
 
             await run_objects_reclaimer(std_md.obj_id, arch_md.obj_id);
 
@@ -741,8 +747,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await lifecycle.background_worker();
 
             await assert_md_absent(BUCKET, key);
-            const archived_body = await get_archive_body(bucket_id, md.obj_id);
-            assert.strictEqual(Buffer.compare(archived_body, buf), 0);
+            await assert_archive_present(bucket_id, md.obj_id, buf.length);
 
             await run_objects_reclaimer(md.obj_id);
             await assert_archive_absent(bucket_id, md.obj_id);
@@ -763,7 +768,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await assert_md_absent(BUCKET, key);
             const has_parts_after_expiry = await object_has_parts(md.obj_id);
             assert.ok(has_parts_after_expiry);
-            await get_archive_body(bucket_id, md.obj_id);
+            await assert_archive_present(bucket_id, md.obj_id, buf.length);
 
             await run_objects_reclaimer(md.obj_id);
 

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
@@ -179,12 +179,14 @@ async function assert_archived_payload({ msc, arch_ns, object_sdk, key, buf, sto
         `expected archive key ${archive_key} in target, got: ${JSON.stringify(keys)}`
     );
 
-    const archived_stream = await arch_ns.read_object_stream({
+    // Archive payload is written with the user-facing storage_class (DEEP_ARCHIVE/GLACIER).
+    // Head/MD works; GetObject is blocked until restore (same as AWS).
+    const archive_md = await arch_ns.read_object_md({
         bucket: ARCHIVE_TARGET_BUCKET,
         key: archive_key,
     }, object_sdk);
-    const archived_buf = await buffer_utils.read_stream_join(archived_stream);
-    assert.strictEqual(Buffer.compare(archived_buf, buf), 0);
+    assert.strictEqual(archive_md.storage_class, storage_class);
+    assert.strictEqual(archive_md.size, buf.length);
 
     // User-facing key must not be used for archive data
     await assert.rejects(
@@ -196,6 +198,10 @@ async function assert_archived_payload({ msc, arch_ns, object_sdk, key, buf, sto
     await assert.rejects(
         msc.read_object_stream({ bucket: BUCKET, key, object_md: md }, object_sdk),
         err => err instanceof S3Error && err.code === 'InvalidObjectState'
+    );
+    await assert.rejects(
+        arch_ns.read_object_stream({ bucket: ARCHIVE_TARGET_BUCKET, key: archive_key }, object_sdk),
+        err => err.code === 'InvalidObjectState' || err.Code === 'InvalidObjectState'
     );
 }
 
@@ -602,13 +608,13 @@ mocha.describe('delete_object', function() {
             err => err.rpc_code === 'NO_SUCH_OBJECT'
         );
 
-        // Archive-side object is still present until ObjectsReclaimer runs
-        const archived_stream = await arch_ns.read_object_stream({
+        // Archive-side object is still present until ObjectsReclaimer runs.
+        // Use read_object_md (HeadObject) — GetObject/stream on unrestored DEEP_ARCHIVE is InvalidObjectState.
+        const archive_md = await arch_ns.read_object_md({
             bucket: ARCHIVE_TARGET_BUCKET,
             key: archive_key,
         }, object_sdk);
-        const archived_buf = await buffer_utils.read_stream_join(archived_stream);
-        assert.strictEqual(Buffer.compare(archived_buf, buf), 0);
+        assert.strictEqual(archive_md.size, buf.length);
     });
 
     mocha.it('ObjectsReclaimer deletes archive-side data for unreclaimed DEEP_ARCHIVE objects', async function() {

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
@@ -1,0 +1,311 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const NamespaceMultiStorageClass = require('../../../sdk/namespace_multi_storage_class');
+const s3_utils = require('../../../endpoint/s3/s3_utils');
+const S3Error = require('../../../endpoint/s3/s3_errors').S3Error;
+const { RpcError } = require('../../../rpc');
+const { get_archive_key, compute_restore_expiry } = require('../../../util/deep_archive_utils');
+
+const BUCKET = 'restore-it-bucket';
+const BUCKET_ID = '507f1f77bcf86cd799439011';
+const OBJ_ID = '507f1f77bcf86cd799439012';
+const KEY = 'archived/object';
+
+/**
+ * Builds MSC with mock metadata ns and archive ns for restore_object tests.
+ * @param {{ object_restore_info?: object, archive_restore_impl?: Function }} [opts]
+ */
+function make_msc_fixture({ object_restore_info: object_restore_info_override, archive_restore_impl } = {}) {
+    const object_restore_info = {
+        obj_id: OBJ_ID,
+        bucket_id: BUCKET_ID,
+        key: KEY,
+        storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        ...object_restore_info_override,
+    };
+
+    // archive_restore_object stands in for whatever sits behind the archive namespacestore
+    // (usually NamespaceS3).
+    const archive_restore_object = jest.fn().mockImplementation(
+        archive_restore_impl || (async () => ({ accepted: true }))
+    );
+    const get_object_restore_info = jest.fn().mockResolvedValue(object_restore_info);
+    const update_object_md = jest.fn().mockResolvedValue(undefined);
+
+    const metadata_ns = {};
+    const archive_ns = { restore_object: archive_restore_object };
+    const object_sdk = {
+        rpc_client: {
+            object: { get_object_restore_info, update_object_md },
+        },
+    };
+
+    const ns_msc = new NamespaceMultiStorageClass({
+        namespace_by_storage_class: {
+            [s3_utils.STORAGE_CLASS_STANDARD]: metadata_ns,
+            [s3_utils.STORAGE_CLASS_DEEP_ARCHIVE]: archive_ns,
+            [s3_utils.STORAGE_CLASS_GLACIER]: archive_ns,
+        },
+    });
+
+    return {
+        ns_msc,
+        object_restore_info,
+        metadata_ns,
+        archive_ns,
+        object_sdk,
+        get_object_restore_info,
+        archive_restore_object,
+        update_object_md,
+    };
+}
+
+describe('NamespaceMultiStorageClass.restore_object', () => {
+    const params = { bucket: BUCKET, key: KEY, days: 7 };
+
+    it('rejects STANDARD objects with error InvalidObjectStorageClass', async () => {
+        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+            object_restore_info: {
+                storage_class: s3_utils.STORAGE_CLASS_STANDARD,
+            },
+        });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            code: S3Error.InvalidObjectStorageClass.code,
+        });
+        expect(update_object_md).not.toHaveBeenCalled();
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('initiates restore: sets ongoing restore_status then calls archive restore_object', async () => {
+        const {
+            ns_msc,
+            object_sdk,
+            archive_restore_object,
+            update_object_md,
+        } = make_msc_fixture();
+
+        const result = await ns_msc.restore_object(params, object_sdk);
+
+        expect(result).toEqual({ accepted: true });
+        expect(update_object_md).toHaveBeenCalledTimes(1);
+        expect(update_object_md).toHaveBeenCalledWith({
+            bucket: BUCKET,
+            key: KEY,
+            obj_id: OBJ_ID,
+            restore_status: {
+                ongoing: true,
+                days: 7,
+            },
+        });
+
+        expect(archive_restore_object).toHaveBeenCalledTimes(1);
+        expect(archive_restore_object).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bucket: BUCKET,
+                key: get_archive_key(BUCKET_ID, OBJ_ID),
+                days: 7,
+            }),
+            object_sdk,
+        );
+        // Initiate only — BG worker owns clearing ongoing / setting expiry_time.
+        expect(update_object_md.mock.calls[0][0].restore_status.expiry_time).toBeUndefined();
+        // restore_status update must happen before the archive call.
+        expect(update_object_md.mock.invocationCallOrder[0])
+            .toBeLessThan(archive_restore_object.mock.invocationCallOrder[0]);
+    });
+
+    it('does not forward client version_id to archive restore_object', async () => {
+        const { ns_msc, object_sdk, archive_restore_object } = make_msc_fixture();
+        const versioned_params = { ...params, version_id: 'client-version-abc' };
+
+        await ns_msc.restore_object(versioned_params, object_sdk);
+
+        expect(archive_restore_object).toHaveBeenCalledTimes(1);
+        const archive_call_params = archive_restore_object.mock.calls[0][0];
+        expect(archive_call_params.key).toBe(get_archive_key(BUCKET_ID, OBJ_ID));
+        expect(archive_call_params).not.toHaveProperty('version_id');
+    });
+
+    it('rejects when restore_status.ongoing is true with error RestoreAlreadyInProgress', async () => {
+        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+            object_restore_info: {
+                restore_status: { ongoing: true, days: 3 },
+            },
+        });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            code: S3Error.RestoreAlreadyInProgress.code,
+        });
+        expect(update_object_md).not.toHaveBeenCalled();
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('replaces expiry with now+days even when that shortens it', async () => {
+        const future_expiry = new Date('2099-01-01T00:00:00Z');
+        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+            object_restore_info: {
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: future_expiry.getTime(),
+                },
+            },
+        });
+
+        const before = Date.now();
+        const result = await ns_msc.restore_object({ ...params, days: 14 }, object_sdk);
+        const after = Date.now();
+
+        expect(result.accepted).toBe(false);
+        expect(result.storage_class).toBe(s3_utils.STORAGE_CLASS_GLACIER);
+        const expected_min = compute_restore_expiry(14, new Date(before)).getTime();
+        const expected_max = compute_restore_expiry(14, new Date(after)).getTime();
+        expect(result.expires_on.getTime()).toBeGreaterThanOrEqual(expected_min);
+        expect(result.expires_on.getTime()).toBeLessThanOrEqual(expected_max);
+        expect(result.expires_on.getTime()).toBeLessThan(future_expiry.getTime());
+
+        expect(update_object_md).toHaveBeenCalledWith({
+            bucket: BUCKET,
+            key: KEY,
+            obj_id: OBJ_ID,
+            restore_status: {
+                ongoing: false,
+                expiry_time: result.expires_on.getTime(),
+            },
+        });
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('updates expiry to now+days when that is later than existing', async () => {
+        const existing_expiry = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000);
+        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+            object_restore_info: {
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: existing_expiry.getTime(),
+                },
+            },
+        });
+
+        const before = Date.now();
+        const result = await ns_msc.restore_object({ ...params, days: 14 }, object_sdk);
+        const after = Date.now();
+
+        expect(result.accepted).toBe(false);
+        const expected_min = compute_restore_expiry(14, new Date(before)).getTime();
+        const expected_max = compute_restore_expiry(14, new Date(after)).getTime();
+        expect(result.expires_on.getTime()).toBeGreaterThanOrEqual(expected_min);
+        expect(result.expires_on.getTime()).toBeLessThanOrEqual(expected_max);
+        expect(result.expires_on.getTime()).toBeGreaterThan(existing_expiry.getTime());
+
+        expect(update_object_md).toHaveBeenCalledWith({
+            bucket: BUCKET,
+            key: KEY,
+            obj_id: OBJ_ID,
+            restore_status: {
+                ongoing: false,
+                expiry_time: result.expires_on.getTime(),
+            },
+        });
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('re-initiates restore when previous expiry has passed', async () => {
+        const { ns_msc, archive_restore_object, object_sdk, update_object_md } = make_msc_fixture({
+            object_restore_info: {
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+                },
+            },
+        });
+
+        const result = await ns_msc.restore_object(params, object_sdk);
+
+        expect(result).toEqual({ accepted: true });
+        expect(update_object_md).toHaveBeenCalledWith(
+            expect.objectContaining({
+                restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
+            }),
+        );
+        expect(archive_restore_object).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears ongoing and rethrows when archive restore_object fails', async () => {
+        const archive_err = new Error('archive restore failed');
+        const { ns_msc, object_sdk, update_object_md } = make_msc_fixture({
+            archive_restore_impl: async () => {
+                throw archive_err;
+            },
+        });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(archive_err);
+        expect(update_object_md).toHaveBeenCalledTimes(2);
+        expect(update_object_md).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
+        }));
+        expect(update_object_md).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            restore_status: { ongoing: false },
+        }));
+    });
+
+    it('keeps ongoing when archive throws error RestoreAlreadyInProgress', async () => {
+        const { ns_msc, object_sdk, update_object_md } = make_msc_fixture({
+            archive_restore_impl: async () => {
+                throw new S3Error(S3Error.RestoreAlreadyInProgress);
+            },
+        });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            code: S3Error.RestoreAlreadyInProgress.code,
+        });
+        expect(update_object_md).toHaveBeenCalledTimes(1);
+        expect(update_object_md).toHaveBeenCalledWith(expect.objectContaining({
+            restore_status: expect.objectContaining({ ongoing: true }),
+        }));
+    });
+
+    it('allows client retry after failed archive initiate once ongoing is cleared', async () => {
+        const archive_err = new Error('archive restore failed');
+        const first = make_msc_fixture({
+            archive_restore_impl: async () => {
+                throw archive_err;
+            },
+        });
+        await expect(first.ns_msc.restore_object(params, first.object_sdk)).rejects.toBe(archive_err);
+        expect(first.update_object_md).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            restore_status: { ongoing: false },
+        }));
+
+        // After compensating clear: ongoing=false → new initiate is allowed.
+        const second = make_msc_fixture({
+            object_restore_info: {
+                restore_status: { ongoing: false },
+            },
+        });
+        const result = await second.ns_msc.restore_object(params, second.object_sdk);
+        expect(result).toEqual({ accepted: true });
+        expect(second.archive_restore_object).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates NO_SUCH_OBJECT when object is deleted or missing', async () => {
+        // get_object_restore_info → find_object_md → check_object_mode throws for
+        // missing, soft-deleted, or delete-marker objects.
+        const {
+            ns_msc,
+            object_sdk,
+            get_object_restore_info,
+            update_object_md,
+            archive_restore_object,
+        } = make_msc_fixture();
+        const no_such_object_err = new RpcError('NO_SUCH_OBJECT',
+            `No such object: bucket ${BUCKET} key ${KEY}`);
+        get_object_restore_info.mockRejectedValue(no_such_object_err);
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(no_such_object_err);
+        expect(update_object_md).not.toHaveBeenCalled();
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+});

--- a/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
@@ -1,0 +1,72 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const deep_archive_utils = require('../../../util/deep_archive_utils');
+
+describe('is_restore_active', () => {
+    const now = new Date('2026-06-01T00:00:00Z');
+
+    it('returns false when restore_status is missing', () => {
+        const res = deep_archive_utils.is_restore_active(undefined, now);
+        expect(res).toBe(false);
+    });
+
+    it('returns false when ongoing is true', () => {
+        const res = deep_archive_utils.is_restore_active({ ongoing: true, days: 7 }, now);
+        expect(res).toBe(false);
+    });
+
+    it('returns false when expiry_time is missing', () => {
+        const res = deep_archive_utils.is_restore_active({ ongoing: false }, now);
+        expect(res).toBe(false);
+    });
+
+    it('returns false when expiry is in the past', () => {
+        const res = deep_archive_utils.is_restore_active({
+            ongoing: false,
+            expiry_time: new Date('2020-01-01T00:00:00Z'),
+        }, now);
+        expect(res).toBe(false);
+    });
+
+    it('returns false when expiry_time equals now', () => {
+        const res = deep_archive_utils.is_restore_active({
+            ongoing: false,
+            expiry_time: now,
+        }, now);
+        expect(res).toBe(false);
+    });
+
+    it('returns true when ongoing is false and expiry is in the future', () => {
+        const res = deep_archive_utils.is_restore_active({
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z'),
+        }, now);
+        expect(res).toBe(true);
+    });
+
+    it('returns true when expiry_time is an epoch milliseconds', () => {
+        const res = deep_archive_utils.is_restore_active({
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(), // epoch milliseconds
+        }, now);
+        expect(res).toBe(true);
+    });
+
+    it('returns false when expiry_time is invalid', () => {
+        const res = deep_archive_utils.is_restore_active({
+            ongoing: false,
+            expiry_time: 'not-a-date',
+        }, now);
+        expect(res).toBe(false);
+    });
+});
+
+describe('compute_restore_expiry', () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+
+    it('adds days relative to now', () => {
+        const res = deep_archive_utils.compute_restore_expiry(7, now);
+        expect(res.toISOString()).toBe('2026-01-08T00:00:00.000Z');
+    });
+});

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -42,15 +42,44 @@ function is_remote_archive_object(obj, bucket) {
  */
 function throw_if_restore_incomplete(bucket_name, object_md) {
     if (!GLACIER_STORAGE_CLASSES.includes(object_md?.storage_class)) return;
-    const restore = object_md?.restore_status;
-    const expiry_time = restore?.expiry_time && new Date(restore.expiry_time);
-    const has_active_restore = Boolean(expiry_time) && !restore.ongoing && expiry_time > new Date();
-    if (has_active_restore) return;
+    const restore_status = object_md?.restore_status;
+    if (is_restore_active(restore_status)) return;
     // Don't try to read the object if it's not restored yet
-    dbg.warn('Object is not restored yet', bucket_name, object_md.key, object_md.storage_class, restore);
+    dbg.warn('Object is not restored yet', bucket_name, object_md.key, object_md.storage_class, object_md.restore_status);
     throw new S3Error(S3Error.InvalidObjectState);
 }
+
+/**
+ * Returns true when restore_status represents an active temporary restore
+ * (ongoing is false and expiry_time is in the future).
+ * @param {nb.RestoreStatus} [restore_status]
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+function is_restore_active(restore_status, now = new Date()) {
+    if (!restore_status || restore_status.ongoing ||
+        restore_status.expiry_time === undefined || restore_status.expiry_time === null) {
+        return false;
+    }
+    const expiry_time = new Date(restore_status.expiry_time);
+    if (Number.isNaN(expiry_time.getTime())) return false;
+    return expiry_time > now;
+}
+
+/**
+ * Computes restore expiry as now + days.
+ * @param {number} days
+ * @param {Date} [now]
+ * @returns {Date}
+ */
+function compute_restore_expiry(days, now = new Date()) {
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+    return new Date(now.getTime() + days * MS_PER_DAY);
+}
+
 
 exports.get_archive_key = get_archive_key;
 exports.is_remote_archive_object = is_remote_archive_object;
 exports.throw_if_restore_incomplete = throw_if_restore_incomplete;
+exports.is_restore_active = is_restore_active;
+exports.compute_restore_expiry = compute_restore_expiry;


### PR DESCRIPTION
### Describe the Problem
Implement the Object Restore API as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)
Note: In this PR the code changes are only about the API, it does not include the BG worker code changes.

### Explain the Changes
1. Extend the API and schema with `restore_status` and expand the `interface RestoreStatus` in file `nb.d.ts`.
Note: I chose not to reuse the JSON object of `restore_status` between the schema and the API since the type of the dates is different `idate` vs `date`.
2. Implement the `restore_object` in file `namespace_multi_storage_class.js` (noobaa 1 in the architecture).
3. Add helper functions in `deep_archive_utils.js`.
4. Implement the `restore_object` in file `namespace_s3.js` (noobaa 2 in the architecture).
5. Update the `object_server` functions `update_object_md` and `get_object_info` with the added property `restore_status`.
6. Fix the `upload_object` in file `namespace_s3.js` in the case of `PutObjectRequest` to contain the `StorageClass` (it was in `CopyObjectRequest`).
7. Fix the `read_object_md`  in file `namespace_s3.js` fallback to headobject (instead of getobject) in case of `InvalidObjectState` error (we had a TODO about it).
8. Add the mapping of the error `RestoreAlreadyInProgress`.
9. Fix the error message when the number of days is less than 1 to match the AWS message.
10. In the file `test_namespace_multi_storage_class.js`, edit the function `assert_archived_payload` so that it rejects on getobject on objects that have archive storage class.
11. In the file `namespace_s3.js` fix a few style issues I saw: camel-case variable name instead of snake-case variable name; use of optional chaining in catch clause on the err `err?.` removed.
12. Add AI-generated unit tests.

### Issues:
List of GAPs:
1. The PR does not contain the BG worker that is responsible for the actual archive.
2. The API implementation can have `TOCTOU race`; protecting it would need a lot of code changes (see [comment](https://github.com/noobaa/noobaa-core/pull/9880#discussion_r3663661142)).
3. Bucket policy permission tests was done only manually and we have not added in the unit tests, because in the existing test, we have the files:
- `test_deep_archive_via_s3.js` uses the s3_compatible as `namespace_nb` but it lacks the `restore_object` implementation.
- `test_s3_bucket_policy.js` was using only the STANDARD object.

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js`
2. `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`
5. `make run-single-test testpath=src/test/integration_tests/api/s3/test_deep_archive_via_s3.js`
6. `make run-single-test testpath=unit_tests/internal/test_namespace_multi_storage_class.js`

#### Manual Tests
Since the BG worker is not implemented, the manual test is limited, as the object will never be restored without the BG worker implementation.
In general (you can see the detailed steps in the [comment](https://github.com/noobaa/noobaa-core/pull/9880#issuecomment-5156956846) below).:
1. Setup noobaa system containerized: we will use the default backingstore
2. Setup noobaa NC (this would be the Namespacestore): Create an account and a bucket (this will be the target bucket)
3. Create namespacestore s3-compatible of noobaa NC
7. Create bucketclass for the defult backingstore with deep archive resource of the created namespacestore
8. Create OBC of the bucketclass
9. User AWS CLI client with the OBC credentials:
- Check the connection by listing the buckets (see only the OBC bucket)
- Call put object with storage class of `DEEPARCHIVE`.
- Call restore object on the archived object.

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `restore_status` to object metadata and exposed it in object info, including restore state and timing details.
  * Implemented object restore for Glacier-family storage classes, including proper handling of active/in-progress restores and expiry updates.

* **Bug Fixes**
  * Clearer error messaging when restore days is less than 1.
  * Improved translation of “restore already in progress” errors.

* **Tests**
  * Expanded unit and integration coverage for restore initiation/expiry logic and updated archival read expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->