### PR TITLE
Keycloak | Implemeted IAM role cache lookup

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -1624,6 +1624,15 @@ module.exports = {
                 max_session_duration: {
                     type: 'integer'
                 },
+                owner_access_key: {
+                    $ref: 'common_api#/definitions/access_key'
+                },
+                iam_role_policies: {
+                    type: 'array',
+                    items: {
+                        $ref: 'common_api#/definitions/iam_user_policy',
+                    }
+                }
             }
         },
         user_accesskey_info: {

--- a/src/endpoint/iam/iam_utils.js
+++ b/src/endpoint/iam/iam_utils.js
@@ -84,24 +84,36 @@ function parse_role_arn(role_arn) {
 }
 
 /**
- * resolve_iam_role_by_arn resolves IAM role entity from a role ARN
+ * resolve_iam_role_by_arn resolves IAM role entity from a role ARN via iam_roles_cache
  * @param {string} role_arn
+ * @param {nb.BucketSpace} bucketspace
  * @returns {Promise<{iam_role?: object, account_id?: string, role_name?: string, error?: string}>}
  */
-async function resolve_iam_role_by_arn(role_arn) {
+async function resolve_iam_role_by_arn(role_arn, bucketspace) {
     const parsed = parse_role_arn(role_arn);
     if (parsed.error) return { error: parsed.error };
 
     const { account_id, role_name } = parsed;
-    // TODO: switch this role lookup to the IAM role cache, once cache support is implemented
-    // Lazy-load system_store so NC CLI startup does not pull it in
-    const system_store = require('../../server/system_services/system_store').get_instance();
-    const iam_roles_by_owner = system_store.data?.iam_roles_by_owner || {};
-    const account_roles = iam_roles_by_owner[account_id] || [];
-    const iam_role = _.find(account_roles, role => !role.deleted && role.name === role_name);
-    if (!iam_role) return { error: 'NO_SUCH_ROLE', account_id, role_name };
-
-    return { iam_role, account_id, role_name };
+    if (!bucketspace) {
+        return { error: 'NO_SUCH_ENTITY', account_id, role_name };
+    }
+    try {
+        // Lazy-load to avoid pulling object_sdk (and namespace_cache) into server paths
+        // that only need ARN helpers from this module .
+        const { iam_roles_cache } = require('../../sdk/object_sdk');
+        const iam_role = await iam_roles_cache.get_with_cache({
+            bucketspace,
+            role_name,
+            owner_account_id: String(account_id),
+        });
+        if (!iam_role) return { error: 'NO_SUCH_ROLE', account_id, role_name };
+        return { iam_role, account_id, role_name };
+    } catch (err) {
+        if (err.rpc_code === 'NO_SUCH_ENTITY' || err.rpc_code === 'NO_SUCH_ROLE') {
+            return { error: 'NO_SUCH_ROLE', account_id, role_name };
+        }
+        throw err;
+    }
 }
 
 /**
@@ -1295,13 +1307,14 @@ function _get_assumed_role_session_info(req) {
  * @param {object} account
  * @param {boolean} is_iam_user
  * @param {string} [assumed_role_arn]
+ * @param {nb.BucketSpace} [bucketspace]
  * @returns {Promise<object[]|null>} policies, or null if assumed role could not be resolved
  */
-async function _get_identity_policies(account, is_iam_user, assumed_role_arn) {
+async function _get_identity_policies(account, is_iam_user, assumed_role_arn, bucketspace) {
     if (is_iam_user) {
         return account.iam_user_policies || [];
     }
-    const resolved_role = await resolve_iam_role_by_arn(assumed_role_arn);
+    const resolved_role = await resolve_iam_role_by_arn(assumed_role_arn, bucketspace);
     if (!resolved_role.iam_role) return null;
     return resolved_role.iam_role.iam_role_policies || [];
 }
@@ -1336,7 +1349,8 @@ async function authorize_request_iam_policy_impl(req, method, bucket_name, servi
         principal_arn: assumed_role_arn,
     };
 
-    const iam_policies = await _get_identity_policies(account, is_iam_user, assumed_role_arn);
+    const iam_policies = await _get_identity_policies(
+        account, is_iam_user, assumed_role_arn, req.object_sdk?._get_bucketspace());
     if (iam_policies === null) {
         dbg.error('authorize_request_iam_policy: failed to resolve IAM role for assumed session token');
         return deny_result;

--- a/src/endpoint/sts/sts_rest.js
+++ b/src/endpoint/sts/sts_rest.js
@@ -238,8 +238,8 @@ function handle_error(req, res, err) {
  * @returns {Promise<Object>} - Assume role policy document
  */
 async function get_assume_role_policy(req) {
-    // TODO: Get the iam_role from cache
-    const resolved_role = await resolve_iam_role_by_arn(req.body.role_arn);
+    const resolved_role = await resolve_iam_role_by_arn(
+        req.body.role_arn, req.sts_sdk._get_bucketspace());
     return resolved_role.iam_role?.assume_role_policy_document;
 }
 

--- a/src/sdk/accountspace_nb.js
+++ b/src/sdk/accountspace_nb.js
@@ -169,7 +169,12 @@ class AccountSpaceNB {
     }
 
     async put_role_policy(params, account_sdk) {
-        return account_sdk.rpc_client.account.put_role_policy(params);
+        const result = await account_sdk.rpc_client.account.put_role_policy(params);
+        iam_roles_cache.invalidate({
+            role_name: params.role_name,
+            owner_account_id: String(account_sdk.requesting_account._id),
+        });
+        return result;
     }
 
     async get_role_policy(params, account_sdk) {
@@ -177,7 +182,12 @@ class AccountSpaceNB {
     }
 
     async delete_role_policy(params, account_sdk) {
-        return account_sdk.rpc_client.account.delete_role_policy(params);
+        const result = await account_sdk.rpc_client.account.delete_role_policy(params);
+        iam_roles_cache.invalidate({
+            role_name: params.role_name,
+            owner_account_id: String(account_sdk.requesting_account._id),
+        });
+        return result;
     }
 
     async list_role_policies(params, account_sdk) {

--- a/src/sdk/sts_sdk.js
+++ b/src/sdk/sts_sdk.js
@@ -69,20 +69,19 @@ class StsSDK {
     }
 
     async _assume_role(role_arn) {
-        const resolved_role = await resolve_iam_role_by_arn(role_arn);
+        const resolved_role = await resolve_iam_role_by_arn(role_arn, this._get_bucketspace());
         const iam_role = resolved_role.iam_role;
         if (!iam_role || resolved_role.error) {
             throw new RpcError('NO_SUCH_ROLE',
                 `No such Role found with name: ${resolved_role.role_name || 'unknown'} and account id : ${resolved_role.account_id || 'unknown'}`);
         }
-        const account = iam_role.owner;
-        dbg.log1('sts_sdk.get_assumed_role res', 'iam_role: ', iam_role.name);
+        dbg.log1('sts_sdk._assume_role:', 'iam_role:', iam_role.role_name);
         return {
             ...iam_role,
-            role_name: iam_role.name,
-            account_id: account._id.toString(),
-            access_key: account.access_keys[0].access_key.unwrap(),
-            assume_role_policy: iam_role.assume_role_policy,
+            role_name: iam_role.role_name,
+            account_id: String(resolved_role.account_id),
+            access_key: iam_role.owner_access_key.unwrap(),
+            assume_role_policy: iam_role.assume_role_policy_document
         };
     }
 

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1284,6 +1284,7 @@ function _get_iam_role_by_name_or_throw(account_roles, role_name) {
  * @returns {object}
  */
 function _return_iam_role_info(iam_role, account_id) {
+    const owner = iam_role.owner;
     return {
         role_id: iam_role._id.toString(),
         role_name: iam_role.name,
@@ -1293,6 +1294,8 @@ function _return_iam_role_info(iam_role, account_id) {
         assume_role_policy_document: iam_role.assume_role_policy_document,
         description: iam_role.description,
         max_session_duration: iam_role.max_session_duration,
+        owner_access_key: owner?.access_keys?.[0]?.access_key,
+        iam_role_policies: iam_role.iam_role_policies,
     };
 }
 


### PR DESCRIPTION
### Describe the Problem
Role lookup for STS still used system_store directly instead of the IAM role cache. 

### Explain the Changes
1. Resolve roles through `iam_roles_cache` instead of `system_store`.
2. Add `owner_access_key` to `role_info` API schema.
3. Populate `owner_access_key` when loading a role for the cache.
4. Update STS `_assume_role` to read cache-shaped role fields.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded IAM role info to include the owner’s access key (when available).
  * Added IAM role policies to role info responses.
* **Bug Fixes**
  * Improved assumed-role/STS IAM policy resolution with bucketspace-aware, cache-backed IAM role lookup and more consistent “not found” error normalization.
  * Updated assume-role resolution to return clearer role details (role name, account id, access key, assume-role policy).
  * Role policy changes now properly invalidate IAM role cache after updates (and during delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->