### PR TITLE
S3 API compatibility | Multipart Upload | GetObject | Bug fixes

### DIFF
--- a/src/sdk/namespace_nb.js
+++ b/src/sdk/namespace_nb.js
@@ -137,24 +137,26 @@ class NamespaceNB {
             client: object_sdk.rpc_client,
             bucket: this.target_bucket,
         }, params);
+        _throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.object_io.upload_multipart(params);
     }
 
     list_multiparts(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
+        _throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.rpc_client.object.list_multiparts(params);
     }
 
     async complete_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
+        _throw_if_invalid_upload_id(params.obj_id);
         const reply = await object_sdk.rpc_client.object.complete_object_upload(params);
         return reply;
     }
 
     abort_object_upload(params, object_sdk) {
         if (this.target_bucket) params = _.defaults({ bucket: this.target_bucket }, params);
-        const upload_id = params.obj_id;
-        if (!upload_id || !object_id_regex.test(upload_id)) throw new S3Error(S3Error.NoSuchUpload);
+        _throw_if_invalid_upload_id(params.obj_id);
         return object_sdk.rpc_client.object.abort_object_upload(params);
     }
 
@@ -264,6 +266,15 @@ class NamespaceNB {
     async delete_uls() {
         throw new Error('TODO');
     }
+}
+
+/**
+ * Throw S3 NoSuchUpload when upload id is missing or not a valid ObjectId.
+ * Avoids RPC schema INVALID_SCHEMA_PARAMS for malformed UploadId values.
+ * @param {string} [upload_id]
+ */
+function _throw_if_invalid_upload_id(upload_id) {
+    if (!upload_id || !object_id_regex.test(upload_id)) throw new S3Error(S3Error.NoSuchUpload);
 }
 
 module.exports = NamespaceNB;

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -1,6 +1,8 @@
 /* Copyright (C) 2016 NooBaa */
 /* eslint-disable max-lines-per-function */
 /* eslint-disable no-invalid-this */
+/* eslint-disable max-lines */
+
 
 'use strict';
 const _ = require('lodash');
@@ -1491,6 +1493,40 @@ mocha.describe('s3_ops', function() {
             });
         });
 
+        mocha.it('should return NoSuchUpload for invalid multipart upload id', async function() {
+            // Data buckets only — validates NamespaceNB invalid UploadId handling.
+            // TODO - fix on other Namespace such as NamespaceS3
+            if (bucket_type !== 'regular') this.skip();
+            const key = 'test-nonexistent-upload';
+            const invalid_upload_id = '00000000-does-not-exist-00000000';
+
+            await assert_no_such_upload(() => s3.uploadPart({
+                Bucket: bucket_name,
+                Key: key,
+                UploadId: invalid_upload_id,
+                PartNumber: 1,
+                Body: 'part',
+            }));
+            await assert_no_such_upload(() => s3.listParts({
+                Bucket: bucket_name,
+                Key: key,
+                UploadId: invalid_upload_id,
+            }));
+            await assert_no_such_upload(() => s3.completeMultipartUpload({
+                Bucket: bucket_name,
+                Key: key,
+                UploadId: invalid_upload_id,
+                MultipartUpload: {
+                    Parts: [{ ETag: 'jkdsnfkndfsjknfdsk', PartNumber: 1 }],
+                },
+            }));
+            await assert_no_such_upload(() => s3.abortMultipartUpload({
+                Bucket: bucket_name,
+                Key: key,
+                UploadId: invalid_upload_id,
+            }));
+        });
+
         mocha.it('should list objects with text-file', async function() {
             this.timeout(60000);
             const ORIG_INLINE_MAX_SIZE = config.INLINE_MAX_SIZE;
@@ -1962,4 +1998,14 @@ function is_namespace_blob_bucket(bucket_type, remote_endpoint_type) {
 // so we would skip copy tests and deletions of objects created by copy
 function is_namespace_blob_mock(bucket_type, remote_endpoint_type) {
     return remote_endpoint_type === 'AZURE' && bucket_type === 'namespace' && !process.env.NEWAZUREPROJKEY;
+}
+
+async function assert_no_such_upload(fn) {
+    try {
+        await fn();
+        assert.fail('expected NoSuchUpload');
+    } catch (err) {
+        assert.strictEqual(test_utils.err_code(err), 'NoSuchUpload');
+        assert.strictEqual(err.$metadata.httpStatusCode, 404);
+    }
 }

--- a/src/test/unit_tests/util_functions_tests/test_http_utils.js
+++ b/src/test/unit_tests/util_functions_tests/test_http_utils.js
@@ -60,4 +60,42 @@ mocha.describe('http_utils', function() {
 
     });
 
+    mocha.describe('normalize_http_ranges', function() {
+
+        function normalize(range_header, size) {
+            return http_utils.normalize_http_ranges(
+                http_utils.parse_http_ranges(range_header),
+                size
+            );
+        }
+
+        function assert_416(range_header, size) {
+            try {
+                normalize(range_header, size);
+                assert.fail('expected 416 InvalidRange');
+            } catch (err) {
+                assert.strictEqual(err.ranges_code, 416);
+            }
+        }
+
+        mocha.it('should return 416 for range on empty object (AWS S3)', function() {
+            assert_416('bytes=0-99', 0);
+            assert_416('bytes=0-0', 0);
+            assert_416('bytes=0-', 0);
+        });
+
+        mocha.it('should return 416 when first-byte-pos is past the end', function() {
+            assert_416('bytes=100-200', 100);
+            assert_416('bytes=5-10', 5);
+        });
+
+        mocha.it('should clamp end and return a valid range when overlapping', function() {
+            const ranges = normalize('bytes=0-99', 100);
+            assert.deepStrictEqual(ranges, [{ start: 0, end: 100 }]);
+            const clamped = normalize('bytes=90-200', 100);
+            assert.deepStrictEqual(clamped, [{ start: 90, end: 100 }]);
+        });
+
+    });
+
 });

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -378,6 +378,9 @@ function _format_one_http_range({ start, end }) {
 }
 
 /**
+ * Normalize parsed HTTP ranges against entity size.
+ * Per RFC 7233 §2.1 / AWS S3, a range is satisfiable only if first-byte-pos < size;
+ * otherwise (including any range on a 0-byte object) return 416.
  * @param {Array} ranges array of {start,end} from parse_http_range
  * @param {Number} size entity size in bytes
  * @return {Array} Array of {start,end}
@@ -394,7 +397,7 @@ function normalize_http_ranges(ranges, size, throw_error_ranges = false) {
             }
             r.end = size;
         }
-        if (r.start < 0 || r.start > r.end) throw_ranges_error(416);
+        if (r.start < 0 || r.start > r.end || r.start >= size) throw_ranges_error(416);
     }
     if (ranges.length !== 1) throw_ranges_error(416);
     return ranges;


### PR DESCRIPTION

### Explain the Changes
1. **NamespaceNB.js** - Validate ObjectId format in NamespaceNB for upload-part, list-parts, complete, and abort. Malformed IDs now return S3 NoSuchUpload instead of RPC INVALID_SCHEMA_PARAMS (we expected objectid but when providing non mongo object id we got this invalid schema issue)

2. **http_utils.js** -  In normalize_http_ranges, treat first-byte-pos >= object size as unsatisfiable (RFC 7233 / AWS), including empty objects, so GET returns 416 InvalidRange instead of 206 with a bad Content-Range.
see RFC - 
https://datatracker.ietf.org/doc/html/rfc7233#section-2.1
```
   If a valid byte-range-set includes at least one byte-range-spec with
   a first-byte-pos that is less than the current length of the
   representation, or at least one suffix-byte-range-spec with a
   non-zero suffix-length, then the byte-range-set is satisfiable.
   Otherwise, the byte-range-set is unsatisfiable.
  ```

4. **Tests** - Coverage in test_s3_ops (invalid upload id) and test_http_utils (empty / past-EOF ranges).

### Issues: Fixed #xxx / Gap #xxx
1. Fixes https://redhat.atlassian.net/browse/DFBUGS-8009 and https://redhat.atlassian.net/browse/DFBUGS-8008

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart upload operations now consistently fail fast with **NoSuchUpload (404)** when the upload ID is missing or malformed.
  * Unsatisfiable HTTP byte-range requests, including requests for empty objects or ranges starting at/after the end, now return **416**.

* **Tests**
  * Added integration and unit coverage for invalid upload IDs and unsatisfiable byte ranges.

* **Documentation**
  * Updated range-validation guidance to reflect S3/RFC 7233 rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->