### PR TITLE
NC | lifecycle | Fixing delete filter for noncurrent versions

### DIFF
--- a/src/manage_nsfs/nc_lifecycle.js
+++ b/src/manage_nsfs/nc_lifecycle.js
@@ -300,27 +300,41 @@ class NCLifecycle {
                 op_func: async () => this.get_candidates(bucket_json, lifecycle_rule, object_sdk)
             });
 
-            if (candidates.delete_candidates?.length > 0) {
-                const expiration = lifecycle_rule.expiration ? this._get_expiration_time(lifecycle_rule.expiration) : 0;
-                const filter_func = lifecycle_utils.build_lifecycle_filter({filter: lifecycle_rule.filter, expiration});
-                dbg.log0('process_rule: calling delete_multiple_objects, num of objects to be deleted', candidates.delete_candidates.length);
-                const delete_res = await this._call_op_and_update_status({
-                    bucket_name,
-                    rule_id,
-                    op_name: TIMED_OPS.DELETE_MULTIPLE_OBJECTS,
-                    op_func: async () => object_sdk.delete_multiple_objects({
-                        bucket: bucket_json.name,
-                        objects: candidates.delete_candidates,
-                        filter_func
-                    })
-                });
-                if (should_notify) {
-                    await this.send_lifecycle_notifications(delete_res, candidates.delete_candidates, bucket_json, object_sdk);
-                }
-            }
+            // Expiration and noncurrent candidates must use different delete-time filters:
+            // Expiration re-checks Days/Date against create_time; noncurrent must not, or
+            // NoncurrentVersionExpiration would be blocked by Expiration.Days.
+            // Marker-only rules (expired_object_delete_marker) use expiration: 0 — same as candidate
+            // selection — because _get_expiration_time() returns -1 when neither days nor date is set.
+            // NoncurrentDays / newer_noncurrent_versions are applied only at candidate selection time.
+            const expiration_for_delete = (lifecycle_rule.expiration?.days || lifecycle_rule.expiration?.date) ?
+                this._get_expiration_time(lifecycle_rule.expiration) : 0;
+            await this._delete_candidates_with_filter({
+                bucket_name,
+                rule_id,
+                bucket_json,
+                object_sdk,
+                objects: candidates.delete_candidates,
+                filter_func: lifecycle_utils.build_lifecycle_filter({
+                    filter: lifecycle_rule.filter,
+                    expiration: expiration_for_delete,
+                }),
+                should_notify,
+            });
+            await this._delete_candidates_with_filter({
+                bucket_name,
+                rule_id,
+                bucket_json,
+                object_sdk,
+                objects: candidates.noncurrent_delete_candidates,
+                filter_func: lifecycle_utils.build_lifecycle_filter({
+                    filter: lifecycle_rule.filter,
+                    expiration: 0,
+                }),
+                should_notify,
+            });
 
             if (candidates.abort_mpu_candidates?.length > 0) {
-                dbg.log0('process_rule: calling delete_multiple_objects, num of mpu to be aborted', candidates.delete_candidates.length);
+                dbg.log0('process_rule: calling abort_mpus, num of mpu to be aborted', candidates.abort_mpu_candidates.length);
                 await this._call_op_and_update_status({
                     bucket_name,
                     rule_id,
@@ -330,6 +344,45 @@ class NCLifecycle {
             }
         } catch (err) {
             dbg.error('process_rule failed with error', err, err.code, err.message);
+        }
+    }
+
+    /**
+     * _delete_candidates_with_filter deletes lifecycle candidates using the given filter_func
+     * @param {{
+     * bucket_name: string,
+     * rule_id: string,
+     * bucket_json: Object,
+     * object_sdk: nb.ObjectSDK,
+     * objects: Object[],
+     * filter_func: Function,
+     * should_notify: boolean,
+     * }} params
+     * @returns {Promise<Void>}
+     */
+    async _delete_candidates_with_filter({
+        bucket_name,
+        rule_id,
+        bucket_json,
+        object_sdk,
+        objects,
+        filter_func,
+        should_notify,
+    }) {
+        if (!objects?.length) return;
+        dbg.log0('process_rule: calling delete_multiple_objects, num of objects to be deleted', objects.length);
+        const delete_res = await this._call_op_and_update_status({
+            bucket_name,
+            rule_id,
+            op_name: TIMED_OPS.DELETE_MULTIPLE_OBJECTS,
+            op_func: async () => object_sdk.delete_multiple_objects({
+                bucket: bucket_json.name,
+                objects,
+                filter_func,
+            })
+        });
+        if (should_notify) {
+            await this.send_lifecycle_notifications(delete_res, objects, bucket_json, object_sdk);
         }
     }
 
@@ -406,7 +459,11 @@ class NCLifecycle {
      * @reutrns {Promise<Object>}
      */
     async get_candidates(bucket_json, lifecycle_rule, object_sdk) {
-        const candidates = { abort_mpu_candidates: [], delete_candidates: [] };
+        const candidates = {
+            abort_mpu_candidates: [],
+            delete_candidates: [],
+            noncurrent_delete_candidates: [],
+        };
         const params = {versions_list: undefined};
         if (lifecycle_rule.expiration) {
             candidates.delete_candidates = await this.get_candidates_by_expiration_rule(lifecycle_rule, bucket_json,
@@ -422,13 +479,12 @@ class NCLifecycle {
             }
         }
         if (lifecycle_rule.noncurrent_version_expiration) {
-            const non_current_candidates = await this.get_candidates_by_noncurrent_version_expiration_rule(
+            candidates.noncurrent_delete_candidates = await this.get_candidates_by_noncurrent_version_expiration_rule(
                 lifecycle_rule,
                 bucket_json,
                 object_sdk,
                 params
             );
-            candidates.delete_candidates = candidates.delete_candidates.concat(non_current_candidates);
         }
         if (lifecycle_rule.abort_incomplete_multipart_upload) {
             candidates.abort_mpu_candidates = await this.get_candidates_by_abort_incomplete_multipart_upload_rule(

--- a/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
+++ b/src/test/unit_tests/nc/lifecycle/test_nc_lifecycle_posix_integration.test.js
@@ -622,6 +622,35 @@ describe('noobaa nc - lifecycle versioning ENABLED', () => {
             });
         });
 
+        it('nc lifecycle - versioning ENABLED - noncurrent expiration is not blocked by Expiration.Days', async () => {
+            // Regression: process_rule used to re-apply Expiration.Days (create_time age) on all deletes,
+            // which blocked NoncurrentVersionExpiration candidates aged only via nc_noncurrent_time.
+            const lifecycle_rule = [{
+                "id": "expiration days must not block noncurrent deletes",
+                "status": LIFECYCLE_RULE_STATUS_ENUM.ENABLED,
+                "filter": {
+                    "prefix": '',
+                },
+                "expiration": {
+                    "days": 30
+                },
+                "noncurrent_version_expiration": {
+                    "noncurrent_days": 1
+                }
+            }];
+            await object_sdk.set_bucket_lifecycle_configuration_rules({ name: test_bucket, rules: lifecycle_rule });
+
+            const res = await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await create_object(object_sdk, test_bucket, test_key1_regular, 100, false);
+            await update_version_xattr(test_bucket, test_key1_regular, res.version_id);
+
+            await exec_manage_cli(TYPES.LIFECYCLE, '', { disable_service_validation: 'true', disable_runtime_validation: 'true', config_root }, undefined, undefined);
+            const object_list = await object_sdk.list_object_versions({ bucket: test_bucket });
+            expect(object_list.objects.length).toBe(1);
+            expect(object_list.objects[0].is_latest).toBe(true);
+            expect(object_list.objects[0].version_id).not.toBe(res.version_id);
+        });
+
         it('nc lifecycle - versioning ENABLED - noncurrent expiration rule - expire older versions by number of days whith expire delete marker rule', async () => {
             const lifecycle_rule = [{
                 "id": "expire noncurrent versions after 3 days with size ",

--- a/src/util/lifecycle_utils.js
+++ b/src/util/lifecycle_utils.js
@@ -31,7 +31,7 @@ async function get_latest_nc_lifecycle_run_status(config_fs, options) {
 
 /**
  * get_lifecycle_object_info_for_filter returns an object that contains properties needed for filter check
- * based on list_objects/stat result 
+ * based on list_objects/stat result
  * @param {{key: String, create_time: Number, size: Number, tagging: Object}} entry list object entry
  * @returns {{key: String, age: Number, size: Number, tags: Object}}
  */
@@ -56,7 +56,7 @@ function get_file_age_days(mtime) {
 
 /**
  * file_matches_filter used for checking the filter before deletion
- * @param {{obj_info: { key: String, create_time: Number, size: Number, tagging: Object}, filter_func?: Function}} params 
+ * @param {{obj_info: { key: String, create_time: Number, size: Number, tagging: Object}, filter_func?: Function}} params
  * @returns {Boolean}
  */
 function file_matches_filter({obj_info, filter_func = undefined}) {


### PR DESCRIPTION
### Describe the Problem
process_rule built one filter that always included Expiration.Days (against create_time) and applied it to all delete candidates, including noncurrent ones.
noncurrent version could qualify under NoncurrentDays, then fail the delete filter because its create_time was still younger than Expiration.Days — and never get deleted.

### Explain the Changes
1. The fix keeps the two candidate lists separate and deletes noncurrent objects with only the prefix/tags/size filter, not Expiration.Days.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-9068 

### Testing Instructions:
1. Create a bucket with versioning and this lifecycle rules, for example:
```
"Rules": [
    {
      "ID": "expiration-must-not-block-noncurrent",
      "Filter": { "Prefix": "" },
      "Status": "Enabled",
      "Expiration": { "Days": 30 },
      "NoncurrentVersionExpiration": { "NoncurrentDays": 1 }
    }
]
```
2. Create two versions of the same key (latest stays current; first becomes noncurrent)
3. Wait one day
4. Run the lifecycle worker:
```noobaa-cli lifecycle --disable_runtime_validation --disable_service_validation```
5. Make sure only one version left(the latest):
aws s3api list-object-versions \
  --bucket <bucket> --prefix repro-key \
  --endpoint-url <noobaa-endpoint>
6. 



- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle expiration handling for current and noncurrent object versions.
  * Ensured noncurrent versions are evaluated using the correct expiration rules.
  * Fixed versioned-object cleanup so eligible older versions are removed while the latest version remains.
  * Improved reporting of multipart-upload candidates during lifecycle processing.

* **Tests**
  * Added regression coverage for versioned lifecycle expiration scenarios.

* **Style**
  * Cleaned up documentation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->