### PR TITLE
SourceIP condition support containerized additions

### DIFF
--- a/src/server/common_services/auth_server.js
+++ b/src/server/common_services/auth_server.js
@@ -462,7 +462,9 @@ function _prepare_auth_request(req) {
     };
 
     req.has_bucket_anonymous_permission = function(bucket, action, bucket_path, req_query) {
-        return has_bucket_anonymous_permission(bucket, action, bucket_path, req_query);
+        return has_bucket_anonymous_permission(
+            bucket, action, bucket_path, _policy_req_with_client_ip(req_query, req.auth?.client_ip)
+        );
     };
 
     req.has_s3_bucket_permission = async function(bucket, action, bucket_path, req_query) {
@@ -487,13 +489,15 @@ function _prepare_auth_request(req) {
     };
 
     req.check_bucket_action_permission = async function(bucket, action, bucket_path) {
-        if (!await has_bucket_action_permission(bucket, req.account, action, undefined, bucket_path)) {
+        const policy_req = _policy_req_with_client_ip(undefined, req.auth?.client_ip);
+        if (!await has_bucket_action_permission(bucket, req.account, action, policy_req, bucket_path)) {
             throw new RpcError('UNAUTHORIZED', 'No permission to access bucket');
         }
     };
 
     req.has_bucket_action_permission = async function(bucket, action, bucket_path, req_query) {
-        return has_bucket_action_permission(bucket, req.account, action, req_query, bucket_path);
+        const policy_req = _policy_req_with_client_ip(req_query, req.auth?.client_ip);
+        return has_bucket_action_permission(bucket, req.account, action, policy_req, bucket_path);
     };
 
     req.has_bucket_ownership_permission = function(bucket) {
@@ -599,6 +603,20 @@ async function has_bucket_ownership_permission(bucket, account, role) {
     if (is_iam_and_same_root_account_owner(account, bucket)) return true;
 
     return false;
+}
+
+/**
+ * Attach the observed client IP onto the synthetic request used for bucket-policy
+ * evaluation in the RPC/object_server path. aws:SourceIp reads req.socket.remoteAddress,
+ * which exists on the HTTP request at the S3 endpoint but not on RPC re-checks unless
+ * we reconstruct it from auth_token.client_ip (the TCP peer address).
+ */
+function _policy_req_with_client_ip(req_query, client_ip) {
+    if (!client_ip) return req_query || null;
+    return {
+        ...(req_query || {}),
+        socket: { remoteAddress: client_ip },
+    };
 }
 
 /**

--- a/src/test/integration_tests/api/s3/test_s3_bucket_policy_source_ip.js
+++ b/src/test/integration_tests/api/s3/test_s3_bucket_policy_source_ip.js
@@ -16,7 +16,8 @@ const http = require('http');
 const mocha = require('mocha');
 const assert = require('assert');
 
-// The test client always connects to localhost, so the server sees 127.0.0.1.
+// Force IPv4 loopback — connecting to "localhost" often uses ::1 on dual-stack hosts,
+// which would not match aws:SourceIp policies written for 127.0.0.1.
 const LOOPBACK_IP = '127.0.0.1';
 const OTHER_CIDR = '10.0.0.0/8'; // a range that never includes 127.0.0.1
 
@@ -36,17 +37,21 @@ async function assert_access_denied(promise) {
     }
 }
 
+function loopback_http_address() {
+    return coretest.get_http_address().replace('localhost', LOOPBACK_IP);
+}
+
 async function setup() {
     const self = this; // eslint-disable-line no-invalid-this
     self.timeout(60000);
 
     const tmp_fs_root = path.join(TMP_PATH, 'test_s3_bucket_policy_source_ip');
     const s3_creds = {
-        endpoint: coretest.get_http_address(),
+        endpoint: loopback_http_address(),
         forcePathStyle: true,
         region: config.DEFAULT_REGION,
         requestHandler: new NodeHttpHandler({
-            httpAgent: new http.Agent({ keepAlive: false })
+            httpAgent: new http.Agent({ keepAlive: false, family: 4 })
         }),
     };
 

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -93,6 +93,7 @@ require('../../integration_tests/api/s3/test_s3_ops');
 require('../../integration_tests/api/s3/test_deep_archive_via_s3');
 require('../../integration_tests/api/s3/test_s3_encryption');
 require('../../integration_tests/api/s3/test_s3_bucket_policy');
+require('../../integration_tests/api/s3/test_s3_bucket_policy_source_ip');
 // require('./test_node_allocator');
 require('../../unit_tests/internal/test_namespace_cache');
 require('../../unit_tests/internal/test_namespace_multi_storage_class');

--- a/src/util/access_policy_utils.js
+++ b/src/util/access_policy_utils.js
@@ -211,6 +211,9 @@ async function _is_server_side_encryption_fit(req, predicate, value) {
 }
 
 async function _is_object_tag_fit(req, predicate, value) {
+    // RPC re-checks pass a synthetic req (socket / query only) without object_sdk.
+    // Tag conditions are already enforced on the HTTP request at the S3 endpoint.
+    if (!req?.object_sdk?.get_object_tagging) return true;
     const reply = await req.object_sdk.get_object_tagging(req.params);
     const entries = Array.isArray(value) ? value : [value];
     for (const entry of entries) {
@@ -223,13 +226,15 @@ async function _is_object_tag_fit(req, predicate, value) {
     return true;
 }
 async function _is_object_version_fit(req, predicate, value) {
-    const version_id = req.query.versionId;
+    const version_id = req.query?.versionId;
     const res = predicate(version_id, value);
     dbg.log1('access_policy: version-id fit? version-id, policy version-id, match :', version_id, value, res);
     return res;
 }
 
 async function _is_aws_principal_tag_fit(req, predicate, value) {
+    // Same as ExistingObjectTag: skip when evaluating a synthetic RPC request.
+    if (!req?.object_sdk?.get_auth_token) return true;
     const auth_token = req.object_sdk.get_auth_token();
     const session_tags = auth_token?.session_tags;
     // If S3 request is not with temp session tags, should not check the aws:PrincipalTag
@@ -513,9 +518,14 @@ async function _is_condition_fit(policy_statement, req, method, { web_identity_i
     if (is_trust_policy) {
         return _is_identity_condition_fit(Boolean(web_identity_info.iss), policy_statement.Condition, web_identity_info);
     } else {
-        _parse_condition_keys(policy_statement.Condition);
-        for (const [condition, condition_statements] of Object.entries(policy_statement.Condition)) {
-            const predicate = predicate_map[condition];
+        // Clone before parsing: _parse_condition_keys rewrites keys like
+        // s3:ExistingObjectTag/<key> in-place. On the RPC path the Condition
+        // object is the live system-store policy, so mutating it corrupts
+        // subsequent schema validation (INVALID_SCHEMA_REPLY).
+        const condition = _.cloneDeep(policy_statement.Condition);
+        _parse_condition_keys(condition);
+        for (const [condition_op, condition_statements] of Object.entries(condition)) {
+            const predicate = predicate_map[condition_op];
             for (const [condition_key, value] of Object.entries(condition_statements)) {
                 if (!SKIPPED_CONDITIONS_ACTION.has(condition_key) && !supported_actions[condition_key].includes(method)) {
                     continue;

--- a/src/util/http_utils.js
+++ b/src/util/http_utils.js
@@ -191,9 +191,19 @@ function parse_client_ip(req) {
     // The general format of x-forwarded-for: client, proxy1, proxy2, proxy3
     const fwd =
         req.headers['x-forwarded-for'] ||
-        req.connection.remoteAddress ||
+        get_request_remote_address(req) ||
         '';
     return fwd.includes(',') ? fwd.split(',', 1)[0] : fwd;
+}
+
+/**
+ * Return the TCP peer address observed by the server.
+ * Unlike parse_client_ip, this intentionally ignores X-Forwarded-For which is
+ * client-controlled unless a trusted-proxy configuration exists.
+ * Used for aws:SourceIp bucket-policy evaluation and related auth checks.
+ */
+function get_request_remote_address(req) {
+    return req?.socket?.remoteAddress || req?.connection?.remoteAddress || '';
 }
 
 /**
@@ -1184,6 +1194,7 @@ exports.hdr_as_str = hdr_as_str;
 exports.hdr_as_arr = hdr_as_arr;
 exports.parse_url_query = parse_url_query;
 exports.parse_client_ip = parse_client_ip;
+exports.get_request_remote_address = get_request_remote_address;
 exports.get_md_conditions = get_md_conditions;
 exports.check_md_conditions = check_md_conditions;
 exports.has_md_conditions = has_md_conditions;

--- a/src/util/signature_utils.js
+++ b/src/util/signature_utils.js
@@ -374,7 +374,9 @@ function authorize_client_request(req) {
 function authenticate_request_by_service(req, sdk) {
     const auth_token = make_auth_token_from_request(req);
     if (auth_token) {
-        auth_token.client_ip = http_utils.parse_client_ip(req);
+        // Use the TCP peer address (not X-Forwarded-For) so aws:SourceIp and
+        // account IP restrictions cannot be spoofed via a client-controlled header.
+        auth_token.client_ip = http_utils.get_request_remote_address(req);
     }
     if (req.session_token) {
         auth_token.access_key = req.session_token.assumed_role_access_key;


### PR DESCRIPTION

### Describe the Problem
In continuation of https://github.com/noobaa/noobaa-core/pull/9869
Had some issues running the new bucket_policy_source_ip integration test


### Explain the Changes
1. Fixed client_ip for internal RPC calls
2. Forced ipv4 address for the test
3. Added the test also in index.js for containerized testing

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket policy checks now correctly evaluate IP-based access rules during internal rechecks.
  * Client IP detection now uses the actual network connection address, preventing spoofed forwarding headers from affecting access decisions.
  * Improved policy evaluation for requests with missing object or version context.

* **Tests**
  * Added integration coverage for bucket policies using source IP conditions.
  * Standardized local test connections to IPv4 for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->