### PR TITLE
Block account deletion when owned roles remain

### DIFF
--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -1219,6 +1219,11 @@ function _verify_can_delete_account(req, account_to_delete) {
             dbg.log2('account', account_to_delete.name.unwrap(), 'account has users');
             throw new RpcError('FORBIDDEN', 'Cannot delete account that is owner of IAM users');
         }
+        const account_roles = _list_active_iam_roles_for_account(account_to_delete._id);
+        if (account_roles.length > 0) {
+            dbg.log2('account', account_to_delete.name.unwrap(), 'account has roles');
+            throw new RpcError('FORBIDDEN', 'Cannot delete account that is owner of IAM roles');
+        }
     }
 }
 

--- a/src/test/integration_tests/api/sts/test_sts.js
+++ b/src/test/integration_tests/api/sts/test_sts.js
@@ -105,7 +105,6 @@ mocha.describe('STS tests', function() {
 
     /** @type {import('@aws-sdk/client-iam').IAMClient} */
     let iam_client_b;
-    const iam_role_name = 'IamCreatedRole1';
     let user_b_keys;
 
     mocha.before(async function() {
@@ -212,13 +211,13 @@ mocha.describe('STS tests', function() {
     mocha.after(async function() {
         const self = this; // eslint-disable-line no-invalid-this
         self.timeout(60000);
+        await iam_client_b.send(new DeleteRolePolicyCommand({
+            RoleName: role_b, PolicyName: 'Role_B_S3Access',
+        }));
+        await iam_client_b.send(new DeleteRoleCommand({ RoleName: role_b }));
         for (const email of accounts) {
             await rpc_client.account.delete_account({ email });
         }
-
-        try {
-            await iam_client_b.send(new DeleteRoleCommand({ RoleName: iam_role_name }));
-        } catch (_err) { /* ignore */ }
     });
 
     mocha.it('user a assume role of admin - should be rejected', async function() {
@@ -484,6 +483,10 @@ mocha.describe('Session token tests', function() {
         self.timeout(60000);
 
         await accounts[0].s3.deleteBucket({ Bucket: alice2_buck });
+        await accounts[0].iam.send(new DeleteRolePolicyCommand({
+            RoleName: role_alice, PolicyName: 'Role_A_S3Access',
+        }));
+        await accounts[0].iam.send(new DeleteRoleCommand({ RoleName: role_alice }));
         for (const account of accounts) {
             await rpc_client.account.delete_account({ email: account.email });
         }


### PR DESCRIPTION
### Describe the Problem
Accounts that still own IAM roles can be deleted, leaving orphaned roles.

### Explain the Changes
1. Block account deletion when the account still owns active IAM roles.

### Issues: Fixed #xxx / Gap #xxx
1. EPIC: https://redhat.atlassian.net/browse/MCGI-330

### Testing Instructions:
1.  Try deleting the account owned the iam role.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Account deletion is now blocked when the account owns active IAM roles.
* A clear forbidden response is returned when deletion cannot proceed.
* IAM role policies are cleaned up correctly during account and role deletion workflows, improving cleanup reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->