### PR TITLE
block bucket delete when Object Lock protected objects remain

### DIFF
--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -49,7 +49,15 @@ class BucketsReclaimer {
                     dbg.log0(`bucket ${bucket.name} is not empty yet`);
                 }
             } catch (err) {
-                dbg.error(`got error when trying to empty and delete bucket ${bucket.name} :`, err);
+                // Object Lock safety invariant: reclaim/unordered deletion independently
+                // refuses to remove protected objects. Object Lock cannot be bypassed;
+                // bucket deletion may fail here and require a retry after unlock/expiry.
+                if (err && err.rpc_code === 'UNAUTHORIZED') {
+                    dbg.error(`bucket_reclaimer: bucket ${bucket.name} has Object Lock protected objects; ` +
+                        `refusing to empty/delete. Remove legal hold / wait for retention, then retry delete.`, err);
+                } else {
+                    dbg.error(`got error when trying to empty and delete bucket ${bucket.name} :`, err);
+                }
                 has_errors = true;
             }
         }));

--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -49,9 +49,8 @@ class BucketsReclaimer {
                     dbg.log0(`bucket ${bucket.name} is not empty yet`);
                 }
             } catch (err) {
-                // Object Lock safety invariant: reclaim/unordered deletion independently
-                // refuses to remove protected objects. Object Lock cannot be bypassed;
-                // bucket deletion may fail here and require a retry after unlock/expiry.
+                // Do not delete Object Lock protected objects. If any are still locked,
+                // stop here; unlock or wait, then retry delete.
                 if (err && err.rpc_code === 'UNAUTHORIZED') {
                     dbg.error(`bucket_reclaimer: bucket ${bucket.name} has Object Lock protected objects; ` +
                         `refusing to empty/delete. Remove legal hold / wait for retention, then retry delete.`, err);

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1365,6 +1365,38 @@ class MDStore {
             .then(obj => Boolean(obj));
     }
 
+    /**
+     * True when the bucket still has at least one object protected by Object Lock
+     * (legal hold ON, or retention with retain_until_date in the future).
+     * Mode (GOVERNANCE / COMPLIANCE) is intentionally not checked: bucket/OBC
+     * delete never bypasses Governance, so any future retain-until blocks.
+     * Used to fail-closed bucket/OBC delete and reclaim wipe paths.
+     * @param {nb.ID|string} bucket_id
+     * @returns {Promise<boolean>}
+     */
+    async has_any_locked_objects_in_bucket(bucket_id) {
+        const table_name = this._objects.name;
+        const query = `
+            SELECT EXISTS (
+                SELECT 1
+                FROM ${table_name}
+                WHERE data->>'bucket' = $1
+                    AND (data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)
+                    AND (
+                        data->'lock_settings'->'legal_hold'->>'status' = 'ON'
+                        OR (data->'lock_settings'->'retention'->>'retain_until_date')::timestamptz
+                            > CURRENT_TIMESTAMP
+                    )
+            ) AS has_locked;
+        `;
+        const result = await db_client.instance().executeSQL(
+            query,
+            [String(bucket_id)],
+            { preferred_pool: this._postgres_pool }
+        );
+        return Boolean(result.rows[0] && result.rows[0].has_locked);
+    }
+
     has_any_uploads_for_bucket(bucket_id) {
         return this._objects.findOne({
                 bucket: bucket_id,

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1366,11 +1366,9 @@ class MDStore {
     }
 
     /**
-     * True when the bucket still has at least one object protected by Object Lock
-     * (legal hold ON, or retention with retain_until_date in the future).
-     * Mode (GOVERNANCE / COMPLIANCE) is intentionally not checked: bucket/OBC
-     * delete never bypasses Governance, so any future retain-until blocks.
-     * Used to fail-closed bucket/OBC delete and reclaim wipe paths.
+     * Returns true if the bucket has any locked object
+     * (legal hold ON, or retention date still in the future).
+     * Used before bucket/OBC delete so locked data is not removed.
      * @param {nb.ID|string} bucket_id
      * @returns {Promise<boolean>}
      */

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1287,6 +1287,14 @@ async function delete_multiple_objects_by_filter(req) {
  * This function is inteded to use in the case of a bucket deletion
  * where we want to delete all the objects in the bucket but we don't
  * care about the order in which they are deleted or the versioning, etc.
+ *
+ * Object Lock safety invariant:
+ * Every path capable of deleting objects independently enforces Object Lock.
+ * Therefore, even if a protected object is committed after the pre-delete
+ * validation due to an in-flight request, subsequent reclaim or unordered
+ * deletion will refuse to remove it. This guarantees that Object Lock
+ * protection cannot be bypassed, though bucket deletion may fail and
+ * require a retry.
  * @param {*} req
  */
 async function delete_multiple_objects_unordered(req) {
@@ -1294,6 +1302,17 @@ async function delete_multiple_objects_unordered(req) {
     const bucket_id = req.bucket._id;
     const limit = req.rpc_params.limit;
     dbg.log0(`delete_multiple_objects_unordered: bucket=${req.bucket.name} limit=${limit}`);
+
+    // Independently enforce Object Lock on this wipe path (see safety invariant).
+    const has_locked_objects = await MDStore.instance().has_any_locked_objects_in_bucket(bucket_id);
+    if (has_locked_objects) {
+        dbg.error('delete_multiple_objects_unordered: refusing to wipe bucket with Object Lock protected objects',
+            req.bucket.name);
+        throw new RpcError(
+            'UNAUTHORIZED',
+            'Cannot delete bucket objects: one or more objects are protected by Object Lock (retention or legal hold)'
+        );
+    }
 
     // find the objects - no need to paginate explicitly because
     // find_objects will ensure that it does not return any object

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1288,13 +1288,9 @@ async function delete_multiple_objects_by_filter(req) {
  * where we want to delete all the objects in the bucket but we don't
  * care about the order in which they are deleted or the versioning, etc.
  *
- * Object Lock safety invariant:
- * Every path capable of deleting objects independently enforces Object Lock.
- * Therefore, even if a protected object is committed after the pre-delete
- * validation due to an in-flight request, subsequent reclaim or unordered
- * deletion will refuse to remove it. This guarantees that Object Lock
- * protection cannot be bypassed, though bucket deletion may fail and
- * require a retry.
+ * Also checks Object Lock: do not wipe locked objects. Bucket delete
+ * marks the bucket deleting first so new uploads are blocked; this path
+ * still refuses if any locked object is present.
  * @param {*} req
  */
 async function delete_multiple_objects_unordered(req) {
@@ -1303,7 +1299,7 @@ async function delete_multiple_objects_unordered(req) {
     const limit = req.rpc_params.limit;
     dbg.log0(`delete_multiple_objects_unordered: bucket=${req.bucket.name} limit=${limit}`);
 
-    // Independently enforce Object Lock on this wipe path (see safety invariant).
+    // Stop if any object in the bucket is still locked.
     const has_locked_objects = await MDStore.instance().has_any_locked_objects_in_bucket(bucket_id);
     if (has_locked_objects) {
         dbg.error('delete_multiple_objects_unordered: refusing to wipe bucket with Object Lock protected objects',
@@ -1324,11 +1320,35 @@ async function delete_multiple_objects_unordered(req) {
         key: undefined,
     });
 
+    // Re-check the batch before soft-delete (narrow race with an in-flight
+    // upload that passed load_bucket before the deleting fence).
+    if (objects.some(obj => _is_object_lock_active(obj))) {
+        dbg.error('delete_multiple_objects_unordered: refusing to wipe locked objects in batch',
+            req.bucket.name);
+        throw new RpcError(
+            'UNAUTHORIZED',
+            'Cannot delete bucket objects: one or more objects are protected by Object Lock (retention or legal hold)'
+        );
+    }
+
     // delete the objects
     await MDStore.instance().remove_objects_and_unset_latest(objects);
 
     const bucket_has_objects = await MDStore.instance().has_any_objects_for_bucket(bucket_id);
     return { is_empty: !bucket_has_objects };
+}
+
+/**
+ * True when Object Lock still protects this object version (no governance bypass).
+ * @param {object} obj
+ * @param {Date} [now]
+ */
+function _is_object_lock_active(obj, now = new Date()) {
+    const lock = obj && obj.lock_settings;
+    if (!lock) return false;
+    if (lock.legal_hold && lock.legal_hold.status === 'ON') return true;
+    if (!lock.retention || !lock.retention.retain_until_date) return false;
+    return new Date(lock.retention.retain_until_date) > now;
 }
 
 // Sets the "deleted" field for all Object MDs with `upload_started: { $exists: true } and create_time < expiration threshold
@@ -2499,6 +2519,7 @@ exports.calc_retention = calc_retention;
 
 if (process.env.NODE_ENV === 'test') {
     exports.__testing = {
-        update_bulk_delete_results
+        update_bulk_delete_results,
+        _is_object_lock_active,
     };
 }

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1061,17 +1061,9 @@ async function delete_bucket_and_objects(req) {
     const original_name = bucket.name.unwrap();
     const now = new Date();
 
-    // Object Lock safety invariant:
-    // Every path capable of deleting objects independently enforces Object Lock.
-    // Therefore, even if a protected object is committed after the pre-delete
-    // validation due to an in-flight request, subsequent reclaim or unordered
-    // deletion will refuse to remove it. This guarantees that Object Lock
-    // protection cannot be bypassed, though bucket deletion may fail and
-    // require a retry.
-    //
-    // Fence writes before the Object Lock check. Once deleting is set (and the
-    // bucket is renamed), load_bucket() rejects new PutObject / complete_upload
-    // against the original name.
+    // Mark deleting first so new uploads are blocked, then check Object Lock.
+    // If locked objects exist, undo only *this* delete attempt (match deleting=now)
+    // so a concurrent newer delete is not cleared by our rollback.
     await system_store.make_changes({
         update: {
             buckets: [{
@@ -1084,8 +1076,6 @@ async function delete_bucket_and_objects(req) {
         }
     });
 
-    // Object Lock: fail closed after the write fence. If any object is still
-    // protected, rollback deleting so the bucket is not left Terminating.
     if (!bucket.namespace) {
         const has_locked_objects = await MDStore.instance().has_any_locked_objects_in_bucket(bucket._id);
         if (has_locked_objects) {
@@ -1094,7 +1084,10 @@ async function delete_bucket_and_objects(req) {
             await system_store.make_changes({
                 update: {
                     buckets: [{
-                        _id: bucket._id,
+                        $find: {
+                            _id: bucket._id,
+                            deleting: now,
+                        },
                         $set: {
                             name: original_name,
                         },

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1058,21 +1058,58 @@ async function update_buckets(req) {
 
 async function delete_bucket_and_objects(req) {
     const bucket = find_bucket(req);
-
+    const original_name = bucket.name.unwrap();
     const now = new Date();
-    // mark the bucket as deleting. it will be excluded from system_store indexes
-    // rename the bucket to prevent collisions if the a new bucket with the same name is created immediately.
+
+    // Object Lock safety invariant:
+    // Every path capable of deleting objects independently enforces Object Lock.
+    // Therefore, even if a protected object is committed after the pre-delete
+    // validation due to an in-flight request, subsequent reclaim or unordered
+    // deletion will refuse to remove it. This guarantees that Object Lock
+    // protection cannot be bypassed, though bucket deletion may fail and
+    // require a retry.
+    //
+    // Fence writes before the Object Lock check. Once deleting is set (and the
+    // bucket is renamed), load_bucket() rejects new PutObject / complete_upload
+    // against the original name.
     await system_store.make_changes({
         update: {
             buckets: [{
                 _id: bucket._id,
                 $set: {
-                    name: `${bucket.name.unwrap()}-deleting-${now.getTime()}`,
+                    name: `${original_name}-deleting-${now.getTime()}`,
                     deleting: now
                 }
             }]
         }
     });
+
+    // Object Lock: fail closed after the write fence. If any object is still
+    // protected, rollback deleting so the bucket is not left Terminating.
+    if (!bucket.namespace) {
+        const has_locked_objects = await MDStore.instance().has_any_locked_objects_in_bucket(bucket._id);
+        if (has_locked_objects) {
+            dbg.error('delete_bucket_and_objects: bucket has Object Lock protected objects',
+                original_name);
+            await system_store.make_changes({
+                update: {
+                    buckets: [{
+                        _id: bucket._id,
+                        $set: {
+                            name: original_name,
+                        },
+                        $unset: {
+                            deleting: 1,
+                        }
+                    }]
+                }
+            });
+            throw new RpcError(
+                'UNAUTHORIZED',
+                'Cannot delete bucket: one or more objects are protected by Object Lock (retention or legal hold)'
+            );
+        }
+    }
 
     if (bucket.replication_policy_id) {
         // delete replication from replication collection
@@ -1088,7 +1125,7 @@ async function delete_bucket_and_objects(req) {
         level: 'info',
         system: req.system._id,
         bucket: bucket._id,
-        desc: `The bucket "${bucket.name.unwrap()}" and its content were deleted by ${req_account}`,
+        desc: `The bucket "${original_name}" and its content were deleted by ${req_account}`,
     });
 }
 

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -1038,4 +1038,124 @@ mocha.describe('s3 worm', function() {
             }), 'AccessDenied', is_nc_coretest ? 'Access Denied because object protected by object lock.' : 'Access Denied');
         });
     });
+
+    mocha.describe('delete_bucket_and_objects with Object Lock', function() {
+        // OBC wipe uses containerized delete_bucket_and_objects + MD store.
+        // NC coretest has no equivalent RPC path.
+        const BKT_RETENTION = 'worm-obc-delete-retention';
+        const BKT_LEGAL = 'worm-obc-delete-legalhold';
+        const BKT_PLAIN = 'worm-obc-delete-plain';
+        const KEY = 'obc-lock-obj';
+        const config = require('../../../../config');
+        let prev_worm;
+
+        mocha.before(async function() {
+            if (is_nc_coretest) {
+                this.skip(); // eslint-disable-line no-invalid-this
+            }
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(60000);
+            prev_worm = config.WORM_ENABLED;
+            config.WORM_ENABLED = true;
+
+            await s3_owner.createBucket({ Bucket: BKT_RETENTION, ObjectLockEnabledForBucket: true });
+            await s3_owner.createBucket({ Bucket: BKT_LEGAL, ObjectLockEnabledForBucket: true });
+            await s3_owner.createBucket({ Bucket: BKT_PLAIN, ObjectLockEnabledForBucket: true });
+        });
+
+        mocha.after(async function() {
+            if (is_nc_coretest) return;
+            config.WORM_ENABLED = prev_worm;
+            for (const name of [BKT_RETENTION, BKT_LEGAL, BKT_PLAIN]) {
+                try {
+                    await rpc_client.bucket.delete_bucket_and_objects({ name });
+                } catch (err) {
+                    // ignore - bucket may already be gone or still locked
+                }
+                try {
+                    await rpc_client.bucket.delete_bucket({ name });
+                } catch (err) {
+                    // ignore
+                }
+            }
+        });
+
+        mocha.it('should fail delete when an object has active retention', async function() {
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(30000);
+            const put_res = await s3_owner.putObject({
+                Bucket: BKT_RETENTION,
+                Key: KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'COMPLIANCE',
+                ObjectLockRetainUntilDate: tomorrow,
+            });
+            assert.ok(put_res.VersionId);
+
+            try {
+                await rpc_client.bucket.delete_bucket_and_objects({ name: BKT_RETENTION });
+                assert.fail('expected delete_bucket_and_objects to fail for locked objects');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'UNAUTHORIZED');
+                assert.match(err.message, /Object Lock/);
+            }
+
+            // Rollback must leave the bucket usable under its original name.
+            const bucket_info = await rpc_client.bucket.read_bucket({ name: BKT_RETENTION });
+            const retention_bucket_name = bucket_info.name.unwrap ?
+                bucket_info.name.unwrap() : bucket_info.name;
+            assert.strictEqual(retention_bucket_name, BKT_RETENTION);
+        });
+
+        mocha.it('should fail delete when an object has legal hold', async function() {
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(30000);
+            const put_res = await s3_owner.putObject({
+                Bucket: BKT_LEGAL,
+                Key: KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+            });
+            await s3_owner.putObjectLegalHold({
+                Bucket: BKT_LEGAL,
+                Key: KEY,
+                VersionId: put_res.VersionId,
+                LegalHold: { Status: 'ON' },
+            });
+
+            try {
+                await rpc_client.bucket.delete_bucket_and_objects({ name: BKT_LEGAL });
+                assert.fail('expected delete_bucket_and_objects to fail for legal hold');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'UNAUTHORIZED');
+                assert.match(err.message, /Object Lock/);
+            }
+
+            const bucket_info = await rpc_client.bucket.read_bucket({ name: BKT_LEGAL });
+            const legal_bucket_name = bucket_info.name.unwrap ?
+                bucket_info.name.unwrap() : bucket_info.name;
+            assert.strictEqual(legal_bucket_name, BKT_LEGAL);
+        });
+
+        mocha.it('should allow delete when no objects are locked', async function() {
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(30000);
+            await s3_owner.putObject({
+                Bucket: BKT_PLAIN,
+                Key: KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+            });
+
+            await rpc_client.bucket.delete_bucket_and_objects({ name: BKT_PLAIN });
+
+            try {
+                await rpc_client.bucket.read_bucket({ name: BKT_PLAIN });
+                assert.fail('expected bucket to be marked deleting / renamed');
+            } catch (err) {
+                assert.strictEqual(err.rpc_code, 'NO_SUCH_BUCKET');
+            }
+        });
+    });
 });

--- a/src/test/unit_tests/internal/test_delete_bucket_object_lock.test.js
+++ b/src/test/unit_tests/internal/test_delete_bucket_object_lock.test.js
@@ -81,6 +81,48 @@ describe('Object Lock protection for bucket delete / reclaim', () => {
             expect(reply).toEqual({ is_empty: true });
             expect(MDStore.instance().remove_objects_and_unset_latest).toHaveBeenCalledWith(objects);
         });
+
+        test('throws when a locked object appears in the delete batch', async () => {
+            const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            const objects = [{
+                _id: 'obj1',
+                key: 'locked',
+                lock_settings: {
+                    retention: {
+                        mode: 'COMPLIANCE',
+                        retain_until_date: tomorrow,
+                    }
+                }
+            }];
+            const mock_req = {
+                system: {
+                    _id: 'system_id_123',
+                    buckets_by_name: {
+                        'test-bucket': {
+                            _id: BUCKET_ID,
+                            name: new SensitiveString('test-bucket'),
+                        }
+                    }
+                },
+                rpc_params: {
+                    bucket: new SensitiveString('test-bucket'),
+                    limit: 1000,
+                },
+            };
+
+            jest.spyOn(MDStore, 'instance').mockReturnValue({
+                has_any_locked_objects_in_bucket: jest.fn().mockResolvedValue(false),
+                find_objects: jest.fn().mockResolvedValue(objects),
+                remove_objects_and_unset_latest: jest.fn(),
+                has_any_objects_for_bucket: jest.fn(),
+            });
+
+            await expect(object_server.delete_multiple_objects_unordered(mock_req))
+                .rejects.toMatchObject({
+                    rpc_code: 'UNAUTHORIZED',
+                });
+            expect(MDStore.instance().remove_objects_and_unset_latest).not.toHaveBeenCalled();
+        });
     });
 
     describe('delete_bucket_and_objects', () => {
@@ -115,12 +157,17 @@ describe('Object Lock protection for bucket delete / reclaim', () => {
                     rpc_code: 'UNAUTHORIZED',
                 });
 
-            // 1) fence writes (set deleting + rename), 2) rollback on lock
+            // 1) fence writes (set deleting + rename), 2) rollback only this fence
             expect(make_changes).toHaveBeenCalledTimes(2);
-            expect(make_changes.mock.calls[0][0].update.buckets[0].$set.deleting).toBeInstanceOf(Date);
+            const fence_deleting = make_changes.mock.calls[0][0].update.buckets[0].$set.deleting;
+            expect(fence_deleting).toBeInstanceOf(Date);
             expect(make_changes.mock.calls[0][0].update.buckets[0].$set.name)
                 .toMatch(/^test-bucket-deleting-\d+$/);
             expect(make_changes.mock.calls[1][0].update.buckets[0]).toMatchObject({
+                $find: {
+                    _id: BUCKET_ID,
+                    deleting: fence_deleting,
+                },
                 $set: { name: 'test-bucket' },
                 $unset: { deleting: 1 },
             });

--- a/src/test/unit_tests/internal/test_delete_bucket_object_lock.test.js
+++ b/src/test/unit_tests/internal/test_delete_bucket_object_lock.test.js
@@ -1,0 +1,163 @@
+/* Copyright (C) 2026 NooBaa */
+
+'use strict';
+
+const SensitiveString = require('../../../util/sensitive_string');
+const { MDStore } = require('../../../server/object_services/md_store');
+const object_server = require('../../../server/object_services/object_server');
+const bucket_server = require('../../../server/system_services/bucket_server');
+const system_store = require('../../../server/system_services/system_store').get_instance();
+const Dispatcher = require('../../../server/notifications/dispatcher');
+
+const BUCKET_ID = '507f1f77bcf86cd799439011';
+
+describe('Object Lock protection for bucket delete / reclaim', () => {
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('delete_multiple_objects_unordered', () => {
+
+        test('throws when bucket has Object Lock protected objects', async () => {
+            const mock_req = {
+                system: {
+                    _id: 'system_id_123',
+                    buckets_by_name: {
+                        'test-bucket': {
+                            _id: BUCKET_ID,
+                            name: new SensitiveString('test-bucket'),
+                        }
+                    }
+                },
+                rpc_params: {
+                    bucket: new SensitiveString('test-bucket'),
+                    limit: 1000,
+                },
+            };
+
+            jest.spyOn(MDStore, 'instance').mockReturnValue({
+                has_any_locked_objects_in_bucket: jest.fn().mockResolvedValue(true),
+                find_objects: jest.fn(),
+                remove_objects_and_unset_latest: jest.fn(),
+                has_any_objects_for_bucket: jest.fn(),
+            });
+
+            await expect(object_server.delete_multiple_objects_unordered(mock_req))
+                .rejects.toMatchObject({
+                    rpc_code: 'UNAUTHORIZED',
+                });
+
+            expect(MDStore.instance().find_objects).not.toHaveBeenCalled();
+            expect(MDStore.instance().remove_objects_and_unset_latest).not.toHaveBeenCalled();
+        });
+
+        test('deletes objects when none are Object Lock protected', async () => {
+            const objects = [{ _id: 'obj1', key: 'a' }];
+            const mock_req = {
+                system: {
+                    _id: 'system_id_123',
+                    buckets_by_name: {
+                        'test-bucket': {
+                            _id: BUCKET_ID,
+                            name: new SensitiveString('test-bucket'),
+                        }
+                    }
+                },
+                rpc_params: {
+                    bucket: new SensitiveString('test-bucket'),
+                    limit: 1000,
+                },
+            };
+
+            jest.spyOn(MDStore, 'instance').mockReturnValue({
+                has_any_locked_objects_in_bucket: jest.fn().mockResolvedValue(false),
+                find_objects: jest.fn().mockResolvedValue(objects),
+                remove_objects_and_unset_latest: jest.fn().mockResolvedValue(undefined),
+                has_any_objects_for_bucket: jest.fn().mockResolvedValue(false),
+            });
+
+            const reply = await object_server.delete_multiple_objects_unordered(mock_req);
+            expect(reply).toEqual({ is_empty: true });
+            expect(MDStore.instance().remove_objects_and_unset_latest).toHaveBeenCalledWith(objects);
+        });
+    });
+
+    describe('delete_bucket_and_objects', () => {
+
+        test('marks deleting first, then rolls back when locked objects exist', async () => {
+            const bucket = {
+                _id: BUCKET_ID,
+                name: new SensitiveString('test-bucket'),
+            };
+            const mock_req = {
+                system: {
+                    _id: 'system_id_123',
+                    buckets_by_name: {
+                        'test-bucket': bucket,
+                    }
+                },
+                rpc_params: {
+                    name: new SensitiveString('test-bucket'),
+                },
+                account: {
+                    email: new SensitiveString('admin@noobaa.io'),
+                },
+            };
+
+            jest.spyOn(MDStore, 'instance').mockReturnValue({
+                has_any_locked_objects_in_bucket: jest.fn().mockResolvedValue(true),
+            });
+            const make_changes = jest.spyOn(system_store, 'make_changes').mockResolvedValue(undefined);
+
+            await expect(bucket_server.delete_bucket_and_objects(mock_req))
+                .rejects.toMatchObject({
+                    rpc_code: 'UNAUTHORIZED',
+                });
+
+            // 1) fence writes (set deleting + rename), 2) rollback on lock
+            expect(make_changes).toHaveBeenCalledTimes(2);
+            expect(make_changes.mock.calls[0][0].update.buckets[0].$set.deleting).toBeInstanceOf(Date);
+            expect(make_changes.mock.calls[0][0].update.buckets[0].$set.name)
+                .toMatch(/^test-bucket-deleting-\d+$/);
+            expect(make_changes.mock.calls[1][0].update.buckets[0]).toMatchObject({
+                $set: { name: 'test-bucket' },
+                $unset: { deleting: 1 },
+            });
+        });
+
+        test('leaves bucket deleting when no locked objects exist', async () => {
+            const bucket = {
+                _id: BUCKET_ID,
+                name: new SensitiveString('test-bucket'),
+            };
+            const mock_req = {
+                system: {
+                    _id: 'system_id_123',
+                    buckets_by_name: {
+                        'test-bucket': bucket,
+                    }
+                },
+                rpc_params: {
+                    name: new SensitiveString('test-bucket'),
+                },
+                account: {
+                    email: new SensitiveString('admin@noobaa.io'),
+                },
+            };
+
+            jest.spyOn(MDStore, 'instance').mockReturnValue({
+                has_any_locked_objects_in_bucket: jest.fn().mockResolvedValue(false),
+            });
+            const make_changes = jest.spyOn(system_store, 'make_changes').mockResolvedValue(undefined);
+            jest.spyOn(Dispatcher, 'instance').mockReturnValue({
+                activity: jest.fn(),
+            });
+
+            await bucket_server.delete_bucket_and_objects(mock_req);
+
+            expect(make_changes).toHaveBeenCalledTimes(1);
+            expect(make_changes.mock.calls[0][0].update.buckets[0].$set.deleting).toBeInstanceOf(Date);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fail closed on OBC/bucket wipe when any object still has Object Lock protection (legal hold or active retention).
- Fence writes by marking the bucket deleting before the lock check; roll back that fence if protected objects are found.
- Independently refuse unordered reclaim deletion of locked objects so Object Lock cannot be bypassed.
## Test plan
- [ ] Unit tests: `npx jest src/test/unit_tests/internal/test_delete_bucket_object_lock.test.js --forceExit`
- [ ] Delete OBC/bucket with no locked objects → succeeds
- [ ] Delete OBC/bucket with retention or legal hold → fails with clear Object Lock error; bucket not left Terminating
- [ ] After unlock / retention expiry, retry delete → succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket and object deletion now respects Object Lock protections.
  * Deletion is rejected when objects have active legal holds or unexpired retention periods, preventing protected data from being removed.
  * Failed bucket deletions correctly restore the bucket’s prior state, including when lock validation encounters an error.
  * Unlocked objects and buckets continue to be deleted successfully, with accurate bucket availability and activity records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->