### PR TITLE
[GLACIER] Add support for glacier versioning

### DIFF
--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -495,29 +495,22 @@ class TapeCloudGlacier extends Glacier {
     }
 
     /**
-     * encode_log takes string of data and escapes all the backslash and newline
-     * characters
-     * @example 
-     * // /Users/noobaa/data/buc/obj\nfile => /Users/noobaa/data/buc/obj\\nfile
-     * // /Users/noobaa/data/buc/obj\file => /Users/noobaa/data/buc/obj\\file
+     * encode_log appends log delim to the data
      * @param {string} data 
      * @returns {string}
      */
     encode_log(data) {
-        const encoded = data.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
-        return `${TapeCloudGlacier.LOG_DELIM}${encoded}`;
+        return `${TapeCloudGlacier.LOG_DELIM}${data}`;
     }
 
     /**
-     * 
+     * decode_log removes the log delim prefix from the entry
      * @param {string} data 
      * @returns {string}
      */
     decode_log(data) {
         if (!data.startsWith(TapeCloudGlacier.LOG_DELIM)) return data;
-        return data.substring(TapeCloudGlacier.LOG_DELIM.length)
-            .replace(/\\n/g, '\n')
-            .replace(/\\\\/g, '\\');
+        return data.substring(TapeCloudGlacier.LOG_DELIM.length);
     }
 
     // ============= PRIVATE FUNCTIONS =============

--- a/src/sdk/glacier_tapecloud.js
+++ b/src/sdk/glacier_tapecloud.js
@@ -232,26 +232,48 @@ class TapeCloudGlacier extends Glacier {
     async stage_migrate(fs_context, log_file, failure_recorder) {
         dbg.log2('TapeCloudGlacier.stage_migrate starting for', log_file.log_path);
 
-        // Wrap failure recorder to make sure we correctly encode the entries
-        // before appending them to the failure log
-        const encoded_failure_recorder = async failure => failure_recorder(this.encode_log(failure));
-
         try {
             await log_file.collect(Glacier.MIGRATE_STAGE_WAL_NAME, async (entry, batch_recorder) => {
-                entry = this.decode_log(entry);
+                const log_entry = this._parse_wal_entry(entry);
+                let file_path = log_entry.file_path;
 
                 let entry_fh;
                 let should_migrate = true;
                 try {
-                    entry_fh = await nb_native().fs.open(fs_context, entry);
-                    const stat = await entry_fh.stat(fs_context, {
+                    entry_fh = await nb_native().fs.open(fs_context, file_path);
+                    let stat = await entry_fh.stat(fs_context, {
                         xattr_get_keys: [
                             Glacier.XATTR_RESTORE_REQUEST,
                             Glacier.XATTR_RESTORE_EXPIRY,
                             Glacier.STORAGE_CLASS_XATTR,
                         ],
                     });
-                    should_migrate = await this.should_migrate(fs_context, entry, stat);
+
+                    // If the file at file_path was replaced by a later PUT, the
+                    // recorded version may have moved to .versions/. Verify inode
+                    // and resolve the versioned path when there is a mismatch.
+                    if (log_entry.inode && Number(stat.ino) !== log_entry.inode) {
+                        await entry_fh.close(fs_context);
+                        entry_fh = null;
+
+                        const version_path = path.join(
+                            path.dirname(file_path),
+                            '.versions',
+                            path.basename(file_path) + '_' + log_entry.version
+                        );
+
+                        entry_fh = await nb_native().fs.open(fs_context, version_path);
+                        stat = await entry_fh.stat(fs_context, {
+                            xattr_get_keys: [
+                                Glacier.XATTR_RESTORE_REQUEST,
+                                Glacier.XATTR_RESTORE_EXPIRY,
+                                Glacier.STORAGE_CLASS_XATTR,
+                            ],
+                        });
+                        file_path = version_path;
+                    }
+
+                    should_migrate = await this.should_migrate(fs_context, file_path, stat);
                 } catch (err) {
                     await entry_fh?.close(fs_context);
 
@@ -261,14 +283,14 @@ class TapeCloudGlacier extends Glacier {
                     }
 
                     dbg.log0(
-                        'adding log entry', entry,
+                        'adding log entry', file_path,
                         'to failure recorder due to error', err,
                     );
 
                     // Can't really do anything if this fails - provider
                     // needs to make sure that appropriate error handling
                     // is being done there
-                    await encoded_failure_recorder(entry);
+                    await failure_recorder(entry);
                     return;
                 }
 
@@ -278,14 +300,14 @@ class TapeCloudGlacier extends Glacier {
                 // Mark the file staged
                 try {
                     await entry_fh.replacexattr(fs_context, { [Glacier.XATTR_STAGE_MIGRATE]: Date.now().toString() });
-                    await batch_recorder(this.encode_log(entry));
+                    await batch_recorder(JSON.stringify({ ...log_entry, file_path }));
                 } catch (error) {
                     dbg.error('failed to mark the entry migrate staged', error);
 
                     // Can't really do anything if this fails - provider
                     // needs to make sure that appropriate error handling
                     // is being done there
-                    await encoded_failure_recorder(entry);
+                    await failure_recorder(entry);
                 } finally {
                     await entry_fh?.close(fs_context);
                 }
@@ -321,11 +343,11 @@ class TapeCloudGlacier extends Glacier {
             // where some files have migrated and some have not as that is
             // not important for staging/un-staging.
             await log_file.collect_and_process(async entry => {
-                entry = this.decode_log(entry);
+                const { file_path } = JSON.parse(entry);
 
                 let fh;
                 try {
-                    fh = await nb_native().fs.open(fs_context, entry);
+                    fh = await nb_native().fs.open(fs_context, file_path);
                     await fh.replacexattr(fs_context, {}, Glacier.XATTR_STAGE_MIGRATE);
                 } catch (error) {
                     if (error.code === 'ENOENT') {
@@ -333,12 +355,12 @@ class TapeCloudGlacier extends Glacier {
                         return;
                     }
 
-                    dbg.error('failed to remove stage marker:', error, 'for:', entry);
+                    dbg.error('failed to remove stage marker:', error, 'for:', file_path);
 
                     // Add the enty to the failure log - This could be wasteful as it might
                     // add entries which have already been migrated but this is a better
                     // retry.
-                    await encoded_failure_recorder(entry);
+                    await encoded_failure_recorder(file_path);
                 } finally {
                     await fh?.close(fs_context);
                 }
@@ -360,17 +382,14 @@ class TapeCloudGlacier extends Glacier {
     async stage_restore(fs_context, log_file, failure_recorder) {
         dbg.log2('TapeCloudGlacier.stage_restore starting for', log_file.log_path);
 
-        // Wrap failure recorder to make sure we correctly encode the entries
-        // before appending them to the failure log
-        const encoded_failure_recorder = async failure => failure_recorder(this.encode_log(failure));
-
         try {
             await log_file.collect(Glacier.RESTORE_STAGE_WAL_NAME, async (entry, batch_recorder) => {
-                entry = this.decode_log(entry);
+                const log_entry = this._parse_wal_entry(entry);
+                const file_path = log_entry.file_path;
 
                 let fh;
                 try {
-                    fh = await nb_native().fs.open(fs_context, entry);
+                    fh = await nb_native().fs.open(fs_context, file_path);
                     const stat = await fh.stat(fs_context, {
                         xattr_get_keys: [
                             Glacier.XATTR_RESTORE_REQUEST,
@@ -379,7 +398,7 @@ class TapeCloudGlacier extends Glacier {
                         ],
                     });
 
-                    const should_restore = await Glacier.should_restore(fs_context, entry, stat);
+                    const should_restore = await Glacier.should_restore(fs_context, file_path, stat);
                     if (!should_restore) {
                         // Skip this file
                         return;
@@ -394,9 +413,9 @@ class TapeCloudGlacier extends Glacier {
                     // 3. If we read corrupt value then either the file is getting staged or is
                     // getting un-staged - In either case we must requeue.
                     if (stat.xattr[Glacier.XATTR_STAGE_MIGRATE]) {
-                        await encoded_failure_recorder(entry);
+                        await failure_recorder(entry);
                     } else {
-                        await batch_recorder(this.encode_log(entry));
+                        await batch_recorder(JSON.stringify({ ...log_entry, file_path }));
                     }
                 } catch (error) {
                     if (error.code === 'ENOENT') {
@@ -405,10 +424,10 @@ class TapeCloudGlacier extends Glacier {
                     }
 
                     dbg.log0(
-                        'adding log entry', entry,
+                        'adding log entry', file_path,
                         'to failure recorder due to error', error,
                     );
-                    await encoded_failure_recorder(entry);
+                    await failure_recorder(entry);
                 } finally {
                     await fh?.close(fs_context);
                 }
@@ -452,10 +471,10 @@ class TapeCloudGlacier extends Glacier {
             // We will iterate through the entire log file iff and we get a success message from
             // the recall call.
             if (success) {
-                await log_file.collect_and_process(async (entry_path, batch_recorder) => {
-                    entry_path = this.decode_log(entry_path);
-                    dbg.log2('TapeCloudGlacier.restore.batch - entry:', entry_path);
-                    await this._finalize_restore(fs_context, entry_path, encoded_failure_recorder);
+                await log_file.collect_and_process(async (entry, batch_recorder) => {
+                    const { file_path } = JSON.parse(entry);
+                    dbg.log2('TapeCloudGlacier.restore.batch - entry:', file_path);
+                    await this._finalize_restore(fs_context, file_path, encoded_failure_recorder);
                 });
             }
 
@@ -518,6 +537,21 @@ class TapeCloudGlacier extends Glacier {
         return data.substring(TapeCloudGlacier.LOG_DELIM.length)
             .replace(/\\n/g, '\n')
             .replace(/\\\\/g, '\\');
+    }
+
+    /**
+     * _parse_wal_entry attempts to parse a WAL entry as JSON (new format).
+     * Falls back to legacy path-only format via decode_log when JSON
+     * parsing fails, ensuring backward compatibility with pre-upgrade WAL records.
+     * @param {string} entry
+     * @returns {{ file_path: string, inode?: number, version?: string, bucket?: string, key?: string }}
+     */
+    _parse_wal_entry(entry) {
+        try {
+            return JSON.parse(entry);
+        } catch (_) {
+            return { file_path: this.decode_log(entry) };
+        }
     }
 
     // ============= PRIVATE FUNCTIONS =============

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1388,8 +1388,7 @@ class NamespaceFS {
         const is_disabled_dir_content = this._is_directory_content(file_path, params.key) && this._is_versioning_disabled();
 
         const stat = await target_file.stat(fs_context);
-        const file_path_stat = config.NSFS_GLACIER_DMAPI_ENABLE_TAPE_RECLAIM &&
-            await nb_native().fs.stat(fs_context, file_path).catch(_.noop);
+        const file_path_stat = await nb_native().fs.stat(fs_context, file_path).catch(_.noop);
         this._verify_encryption(params.encryption, this._get_encryption_info(stat));
 
         const copy_xattr = params.copy_source && params.xattr_copy;
@@ -1426,7 +1425,7 @@ class NamespaceFS {
             });
 
             if (s3_utils.GLACIER_STORAGE_CLASSES.includes(params.storage_class)) {
-                await this.append_to_migrate_wal(file_path);
+                await this.append_to_migrate_wal(fs_context, file_path, file_path_stat);
             }
         }
         if (params.tagging) {
@@ -1444,7 +1443,7 @@ class NamespaceFS {
         dbg.log1('NamespaceFS._finish_upload:', open_mode, file_path, upload_path, fs_xattr);
 
         if (!same_inode && !part_upload) {
-            if (file_path_stat) {
+            if (config.NSFS_GLACIER_DMAPI_ENABLE_TAPE_RECLAIM) {
                 await this.append_to_reclaim_wal(fs_context, file_path, file_path_stat);
             }
 
@@ -4086,16 +4085,22 @@ class NamespaceFS {
         await this.append_to_migrate_wal(file_path);
     }
 
-    async append_to_migrate_wal(entry) {
+    async append_to_migrate_wal(fs_context, entry, stat) {
         if (!config.NSFS_GLACIER_LOGS_ENABLED) return;
 
-        await NamespaceFS.migrate_wal.append(Glacier.getBackend().encode_log(entry));
+        await NamespaceFS.migrate_wal.append(Glacier.getBackend().encode_log(JSON.stringify({
+            file_path: entry,
+            inode: stat.ino,
+        })));
     }
 
-    async append_to_restore_wal(entry) {
+    async append_to_restore_wal(fs_context, entry, stat) {
         if (!config.NSFS_GLACIER_LOGS_ENABLED) return;
 
-        await NamespaceFS.restore_wal.append(Glacier.getBackend().encode_log(entry));
+        await NamespaceFS.restore_wal.append(Glacier.getBackend().encode_log(JSON.stringify({
+            file_path: entry,
+            inode: stat.ino,
+        })));
     }
 
     /**

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -130,6 +130,22 @@ function _get_version_id_by_stat({ ino, mtimeNsBigint }) {
     return 'mtime-' + mtimeNsBigint.toString(36) + '-ino-' + ino.toString(36);
 }
 
+/**
+ * @param {string} file_path
+ * @param {{ bucket: string, key: string }} params
+ * @param {nb.NativeFSStats} stat
+ * @returns {string}
+ */
+function _build_glacier_log_entry(file_path, params, stat) {
+    return JSON.stringify({
+        bucket: params.bucket,
+        key: params.key,
+        version: _get_version_id_by_stat(stat),
+        inode: Number(stat.ino),
+        file_path,
+    });
+}
+
 function _is_version_or_null_in_file_name(filename) {
     const is_version_object = _is_version_object(filename);
     if (!is_version_object) {
@@ -1185,7 +1201,7 @@ class NamespaceFS {
             // Force-evict on full-object reads, or when the caller requested glacier_force_evict
             // (e.g. 1-byte restore-worker GET). Platform config is still enforced inside.
             if (params.glacier_force_evict || (start === 0 && end >= stat.size)) {
-                await this._glacier_force_expire_on_get(fs_context, file_path, file, stat);
+                await this._glacier_force_expire_on_get(fs_context, file_path, file, stat, params);
             }
 
             await file.close(fs_context);
@@ -1428,7 +1444,7 @@ class NamespaceFS {
             });
 
             if (s3_utils.GLACIER_STORAGE_CLASSES.includes(params.storage_class)) {
-                await this.append_to_migrate_wal(file_path);
+                await this.append_to_migrate_wal(file_path, params, stat);
             }
         }
         if (params.tagging) {
@@ -2612,7 +2628,7 @@ class NamespaceFS {
                 // First add it to the log and then add the extended attribute as if we fail after
                 // this point then the restore request can be triggered again without issue but
                 // the reverse doesn't works.
-                await this.append_to_restore_wal(file_path);
+                await this.append_to_restore_wal(file_path, params, stat);
 
                 restore_attrs[Glacier.XATTR_RESTORE_REQUEST] = params.days.toString();
                 await file.replacexattr(fs_context, restore_attrs);
@@ -4077,7 +4093,7 @@ class NamespaceFS {
      * @param {nb.NativeFile} file
      * @param {nb.NativeFSStats} stat
      */
-    async _glacier_force_expire_on_get(fs_context, file_path, file, stat) {
+    async _glacier_force_expire_on_get(fs_context, file_path, file, stat, params) {
         if (!config.NSFS_GLACIER_FORCE_EXPIRE_ON_GET) return;
 
         const storage_class = s3_utils.parse_storage_class(stat.xattr[Glacier.STORAGE_CLASS_XATTR]);
@@ -4089,19 +4105,31 @@ class NamespaceFS {
             [Glacier.XATTR_RESTORE_EXPIRY]: new Date(0).toISOString()
         }, Glacier.XATTR_RESTORE_REQUEST);
 
-        await this.append_to_migrate_wal(file_path);
+        await this.append_to_migrate_wal(file_path, params, stat);
     }
 
-    async append_to_migrate_wal(entry) {
+    /**
+     * @param {string} file_path
+     * @param {{ bucket: string, key: string }} params
+     * @param {nb.NativeFSStats} stat
+     */
+    async append_to_migrate_wal(file_path, params, stat) {
         if (!config.NSFS_GLACIER_LOGS_ENABLED) return;
 
-        await NamespaceFS.migrate_wal.append(Glacier.getBackend().encode_log(entry));
+        const log_entry = _build_glacier_log_entry(file_path, params, stat);
+        await NamespaceFS.migrate_wal.append(log_entry);
     }
 
-    async append_to_restore_wal(entry) {
+    /**
+     * @param {string} file_path
+     * @param {{ bucket: string, key: string }} params
+     * @param {nb.NativeFSStats} stat
+     */
+    async append_to_restore_wal(file_path, params, stat) {
         if (!config.NSFS_GLACIER_LOGS_ENABLED) return;
 
-        await NamespaceFS.restore_wal.append(Glacier.getBackend().encode_log(entry));
+        const log_entry = _build_glacier_log_entry(file_path, params, stat);
+        await NamespaceFS.restore_wal.append(log_entry);
     }
 
     /**

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -129,7 +129,7 @@ mocha.describe('nsfs_glacier', function() {
 	});
 
 	glacier_ns._is_storage_class_supported = async () => true;
-    glacier_ns._glacier_force_expire_on_get = async (ctx, file_path, file, stat) => {
+    glacier_ns._glacier_force_expire_on_get = async (ctx, file_path, file, stat, params) => {
         // The idea is that the fs_context is derived from object_sdk in namespace_fs
         // which kind of makes it per request. This observation mixed with the mocked
         // object_sdk itself allows to perform assertions without serializing the glacier_ns
@@ -220,12 +220,17 @@ mocha.describe('nsfs_glacier', function() {
             await NamespaceFS.migrate_wal._process(async file => {
                 const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
                 await file.collect_and_process(async entry => {
-                    if (entry.endsWith(`${upload_key}`)) {
+                    const log_entry = JSON.parse(entry);
+                    if (log_entry.key === upload_key) {
                         found = true;
+
+                        assert.strictEqual(log_entry.bucket, upload_bkt);
+                        assert.strictEqual(typeof log_entry.version, 'string');
+                        assert.strictEqual(typeof log_entry.inode, 'number');
 
                         // Not only should the file exist, it should be ready for
                         // migration as well
-                        assert(backend.should_migrate(fs_context, entry));
+                        assert(backend.should_migrate(fs_context, log_entry.file_path));
                     }
                 });
 
@@ -234,6 +239,73 @@ mocha.describe('nsfs_glacier', function() {
             });
 
             assert(found);
+        });
+
+        mocha.it('stage_migrate should resolve versioned path when object is overwritten before staging', async function() {
+            // eslint-disable-next-line no-invalid-this
+            this.timeout(10000);
+
+            const version_key = 'version_overwrite_test_key';
+            const data = crypto.randomBytes(100);
+
+            await glacier_ns.upload_object({
+                bucket: upload_bkt,
+                key: version_key,
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                xattr,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            }, dummy_object_sdk);
+
+            // Extract the WAL entry for this object
+            let wal_entry;
+            await NamespaceFS.migrate_wal._process(async file => {
+                await file.collect_and_process(async entry => {
+                    const parsed = JSON.parse(entry);
+                    if (parsed.key === version_key) {
+                        wal_entry = parsed;
+                    }
+                });
+                return false;
+            });
+            assert(wal_entry, 'WAL entry should exist for the uploaded object');
+
+            const original_path = wal_entry.file_path;
+            const versions_dir = path.join(path.dirname(original_path), '.versions');
+            const versioned_path = path.join(
+                versions_dir,
+                path.basename(original_path) + '_' + wal_entry.version
+            );
+
+            // Simulate a versioned overwrite: move old file to .versions/
+            // and create a replacement file at the original path
+            await fs.mkdir(versions_dir, { recursive: true });
+            await fs.rename(original_path, versioned_path);
+            await fs.writeFile(original_path, crypto.randomBytes(200));
+
+            // Run migration staging and capture which paths get staged
+            const staged_paths = [];
+            const version_backend = get_patched_backend();
+            version_backend._migrate = async staged_file => {
+                const content = await fs.readFile(staged_file, 'utf-8');
+                for (const line of content.split('\n')) {
+                    if (line.trim()) {
+                        staged_paths.push(JSON.parse(line).file_path);
+                    }
+                }
+                return true;
+            };
+
+            const fs_context = glacier_ns.prepare_fs_context(dummy_object_sdk);
+            await version_backend.perform(fs_context, "MIGRATION");
+
+            assert(
+                staged_paths.some(p => p === versioned_path),
+                `Expected versioned path to be staged, staged: ${staged_paths}`
+            );
+            assert(
+                !staged_paths.some(p => p === original_path),
+                `Expected original (replacement) path NOT to be staged`
+            );
         });
 
         mocha.it('restore-object should successfully restore', async function() {


### PR DESCRIPTION
### Describe the Problem
  NooBaa's Glacier (DEEP_ARCHIVE) APIs only supported RestoreObject and migration for non-versioned objects. When an object was overwritten before the migration worker ran, the WAL entry pointed to a stale path and the original version was silently skipped.

  ### Explain the Changes
  1. Changed WAL log format from plain file paths to JSON entries containing bucket, key, version, inode, and file_path — enabling version-aware migration and restore.
  2. `stage_migrate` now detects inode mismatches between the WAL entry and the file on disk, and resolves the versioned path under `.versions/` when the object has been overwritten.
  3. `_parse_wal_entry` provides backward compatibility by falling back to legacy `decode_log` when JSON parsing fails.
  4. Fixed test `_migrate` mock that incorrectly trimmed the `LOG_DELIM` leading space before calling `decode_log`, causing path comparison failures.

  ### Issues: Fixed #xxx / Gap #xxx
  1. N/A

  ### Testing Instructions:
  1. `node ./node_modules/.bin/mocha src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js`

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced migration and restore tracking for more reliable Glacier operations.
  * Improved recovery when files are overwritten, ensuring the correct file version is migrated or restored.
  * Glacier force-expiry can now be explicitly requested for partial reads.
  * Improved handling of S3 boolean headers.

* **Bug Fixes**
  * Object-lock retention and legal-hold violations now return the appropriate access-denied error.
  * Invalid multipart upload entity tags now return the correct error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->