### PR TITLE
Return account ARN in read_account reply

### DIFF
--- a/src/api/account_api.js
+++ b/src/api/account_api.js
@@ -1413,6 +1413,9 @@ module.exports = {
                         $ref: 'common_api#/definitions/access_keys'
                     }
                 },
+                arn: {
+                    type: 'string'
+                },
                 has_s3_access: {
                     type: 'boolean'
                 },

--- a/src/server/system_services/account_server.js
+++ b/src/server/system_services/account_server.js
@@ -22,6 +22,7 @@ const { ClientSecretCredential } = require("@azure/identity");
 const noobaa_s3_client = require('../../sdk/noobaa_s3_client/noobaa_s3_client');
 const account_util = require('./../../util/account_util');
 const iam_utils = require('../../endpoint/iam/iam_utils');
+const access_policy_utils = require('../../util/access_policy_utils');
 const { IAM_ACTIONS, IAM_DEFAULT_PATH, ACCESS_KEY_STATUS_ENUM,
      MAX_TAGS, MAX_NUMBER_OF_IAM_ROLES, DEFAULT_MAX_SESSION_DURATION_SECS } = require('../../endpoint/iam/iam_constants');
 
@@ -1047,6 +1048,7 @@ function get_account_info(account, include_connection_cache) {
     if (account.owner) {
         info.owner = account_util.get_owner_account_id(account);
     }
+    info.arn = access_policy_utils.get_policy_principal_arn(account);
     info.iam_path = account.iam_path;
     if (account.next_password_change) {
         info.next_password_change = account.next_password_change.getTime();


### PR DESCRIPTION
### Describe the Problem
`read_account` does not return the account `ARN`, so callers cannot use a stable IAM principal identifier from that API.

### Explain the Changes
1. Include arn in the `read_account` reply via `get_policy_principal_arn`.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account information now includes the account’s policy principal ARN.
  * Account details responses expose this ARN for integrations and administrative workflows.
  * This identifier is available alongside existing account details, making it easier to reference the account’s associated access policy principal in supported tools and services.
  * The ARN is provided as a standard string value in account information responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->