### PR TITLE
NC | Fixing get_object_lock_configuration for missing lock-configuration

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -654,7 +654,7 @@ function parse_to_camel_case(obj_lock, root_key) {
         }
         return variable;
     };
-    const reply = root_key ? { root_key: rename_keys(obj_lock) } : rename_keys(obj_lock);
+    const reply = root_key ? { [root_key]: rename_keys(obj_lock) } : rename_keys(obj_lock);
     return reply;
 }
 

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -936,6 +936,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
             const { name } = params;
             dbg.log0('BucketSpaceFS.get_object_lock_configuration: Bucket name', name);
             const bucket = await this.config_fs.get_bucket_by_name(name);
+            if (!bucket.object_lock_configuration ||
+                bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
+                throw new RpcError('OBJECT_LOCK_CONFIGURATION_NOT_FOUND_ERROR');
+            }
             return bucket.object_lock_configuration;
         } catch (error) {
             throw translate_error_codes(error, entity_enum.BUCKET);

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -991,6 +991,13 @@ mocha.describe('s3 worm', function() {
             await s3_owner.createBucket({ Bucket: EXISTING_BKT });
         });
 
+        mocha.it('should fail get Object Lock configuration when not enabled', async function() {
+            await assert_throws_async(s3_owner.getObjectLockConfiguration({
+                Bucket: EXISTING_BKT,
+            }), 'ObjectLockConfigurationNotFoundError',
+                'Object Lock configuration does not exist for this bucket');
+        });
+
         mocha.it('should put object before enabling lock', async function() {
             await s3_owner.putObject({
                 Bucket: EXISTING_BKT,


### PR DESCRIPTION
### Describe the Problem
`GetObjectLockConfiguration` on an NC bucket created without Object Lock returned `InternalError` instead of the AWS-aligned `ObjectLockConfigurationNotFoundError`.
BucketSpaceFS returned `undefined`, which then failed during XML reply serialization.

### Explain the Changes
1. Throw `OBJECT_LOCK_CONFIGURATION_NOT_FOUND_ERROR` from `BucketSpaceFS.get_object_lock_configuration` when Object Lock is missing or not `Enabled`
2. Fix `parse_to_camel_case` to use the provided root key (`ObjectLockConfiguration`) instead of the literal `root_key`
3. Add a `test_s3_worm` coverage for GET Object Lock on a bucket without lock configuration

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-8948
### Testing Instructions:
1. Create a bucket without Object Lock:

2. Call GetObjectLockConfiguration and verify the expected error:
`aws s3api get-object-lock-configuration --bucket [bucket-name]`
Expected: `ObjectLockConfigurationNotFoundError` and not `InternalError`

- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected S3 response properties to use the configured root key name.
  * Object Lock configuration requests now return the appropriate not-found error when Object Lock is not enabled.
* **Tests**
  * Added coverage confirming the expected error and message for buckets without Object Lock configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->