### PR TITLE
NC | CLI | Phone home addition

### DIFF
--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -21,6 +21,7 @@
     1. [Health](#health)
     2. [Metrics](#metrics)
     3. [Gather Logs](#gather-logs)
+    4. [Usage Stats](#usage-stats)
 9. [Upgrade](#upgrade)
     1. [Upgrade Start](#upgrade-start)
     2. [Upgrade Status](#upgrade-status)
@@ -502,6 +503,23 @@ noobaa-cli diagnose metrics
 
 The `gather-logs` command is used for extract NooBaa non containerized logs.
 Not implemented yet, running this command will fail with not implemented error.
+
+### Usage Stats
+
+The `usage-stats` command gathers aggregate phone-home style usage statistics for a NooBaa NC deployment.
+It scans the config directory and reports counts only (no resource names or secrets):
+
+- Accounts (total, anonymous, root account managers, bucket-creation enabled, default connection, with users)
+- IAM users (total)
+- Buckets and feature adoption (versioning, lifecycle, notifications, logging, bucket policy, encryption, website, CORS, object lock, public access block, tags, force_md5_etag)
+- Top-10 per-bucket rule/statement counts for lifecycle, notifications, CORS, and bucket policy (arrays of counts only, e.g. `lifecycle_top10_rules: [5, 5, 2, 1, 1]`)
+- Connections (total and by protocol)
+- Metadata (`noobaa_version`, `config_dir_version`, `hosts_count`, `collected_at`)
+
+#### Usage
+```sh
+noobaa-cli diagnose usage-stats [--config_root <path>]
+```
 
 ## Upgrade
 

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -512,6 +512,7 @@ It scans the config directory and reports counts only (no resource names or secr
 - Accounts (total, anonymous, root account managers, bucket-creation enabled, default connection, with users)
 - IAM users (total)
 - Buckets and feature adoption (versioning, lifecycle, notifications, logging, bucket policy, encryption, website, CORS, object lock, public access block, tags, force_md5_etag)
+- Top-10 per-bucket rule/statement counts for lifecycle, notifications, CORS, and bucket policy (arrays of counts only, e.g. `lifecycle_top10_rules: [5, 5, 2, 1, 1]`)
 - Connections (total and by protocol)
 
 #### Usage

--- a/docs/NooBaaNonContainerized/NooBaaCLI.md
+++ b/docs/NooBaaNonContainerized/NooBaaCLI.md
@@ -21,6 +21,7 @@
     1. [Health](#health)
     2. [Metrics](#metrics)
     3. [Gather Logs](#gather-logs)
+    4. [Usage Stats](#usage-stats)
 9. [Upgrade](#upgrade)
     1. [Upgrade Start](#upgrade-start)
     2. [Upgrade Status](#upgrade-status)
@@ -502,6 +503,21 @@ noobaa-cli diagnose metrics
 
 The `gather-logs` command is used for extract NooBaa non containerized logs.
 Not implemented yet, running this command will fail with not implemented error.
+
+### Usage Stats
+
+The `usage-stats` command gathers aggregate phone-home style usage statistics for a NooBaa NC deployment.
+It scans the config directory and reports counts only (no resource names or secrets):
+
+- Accounts (total, anonymous, root account managers, bucket-creation enabled, default connection, with users)
+- IAM users (total)
+- Buckets and feature adoption (versioning, lifecycle, notifications, logging, bucket policy, encryption, website, CORS, object lock, public access block, tags, force_md5_etag)
+- Connections (total and by protocol)
+
+#### Usage
+```sh
+noobaa-cli diagnose usage-stats [--config_root <path>]
+```
 
 ## Upgrade
 

--- a/src/manage_nsfs/diagnose.js
+++ b/src/manage_nsfs/diagnose.js
@@ -3,6 +3,7 @@
 
 const dbg = require('../util/debug_module')(__filename);
 const health = require('./health');
+const usage_stats = require('./usage_stats');
 const config = require('../../config');
 const http_utils = require('../util/http_utils');
 const buffer_utils = require('../util/buffer_utils');
@@ -28,6 +29,9 @@ async function manage_diagnose_operations(action, user_input, config_fs) {
             break;
         case DIAGNOSE_ACTIONS.METRICS:
             await gather_metrics();
+            break;
+        case DIAGNOSE_ACTIONS.USAGE_STATS:
+            await usage_stats.get_usage_stats(config_fs);
             break;
         default:
             throw_cli_error(ManageCLIError.InvalidAction);

--- a/src/manage_nsfs/manage_nsfs_cli_errors.js
+++ b/src/manage_nsfs/manage_nsfs_cli_errors.js
@@ -204,6 +204,12 @@ ManageCLIError.HealthStatusFailed = Object.freeze({
     http_code: 500,
 });
 
+ManageCLIError.UsageStatsFailed = Object.freeze({
+    code: 'UsageStatsFailed',
+    message: 'Usage stats request failed',
+    http_code: 500,
+});
+
 ////////////////////////
 //// ACCOUNT ERRORS ////
 ////////////////////////

--- a/src/manage_nsfs/manage_nsfs_cli_responses.js
+++ b/src/manage_nsfs/manage_nsfs_cli_responses.js
@@ -59,6 +59,12 @@ ManageCLIResponse.MetricsStatus = Object.freeze({
     status: {}
 });
 
+ManageCLIResponse.UsageStats = Object.freeze({
+    code: 'UsageStats',
+    message: 'Usage stats retrieved successfully',
+    status: {}
+});
+
 ///////////////////////////////
 // IPS WHITE LIST RESPONSES ///
 ///////////////////////////////

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -32,7 +32,8 @@ const GLACIER_ACTIONS = Object.freeze({
 const DIAGNOSE_ACTIONS = Object.freeze({
     HEALTH: 'health',
     GATHER_LOGS: 'gather-logs',
-    METRICS: 'metrics'
+    METRICS: 'metrics',
+    USAGE_STATS: 'usage-stats'
 });
 
 const UPGRADE_ACTIONS = Object.freeze({
@@ -79,7 +80,8 @@ const VALID_OPTIONS_GLACIER = {
 const VALID_OPTIONS_DIAGNOSE = {
     'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', 'all_connection_details', 'notif_storage_threshold', 'lifecycle', ...CLI_MUTUAL_OPTIONS]),
     'gather-logs': new Set([ CONFIG_ROOT_FLAG]),
-    'metrics': new Set([CONFIG_ROOT_FLAG])
+    'metrics': new Set([CONFIG_ROOT_FLAG]),
+    'usage-stats': new Set([CONFIG_ROOT_FLAG])
 };
 
 const VALID_OPTIONS_UPGRADE = {

--- a/src/manage_nsfs/manage_nsfs_constants.js
+++ b/src/manage_nsfs/manage_nsfs_constants.js
@@ -32,7 +32,8 @@ const GLACIER_ACTIONS = Object.freeze({
 const DIAGNOSE_ACTIONS = Object.freeze({
     HEALTH: 'health',
     GATHER_LOGS: 'gather-logs',
-    METRICS: 'metrics'
+    METRICS: 'metrics',
+    USAGE_STATS: 'usage-stats'
 });
 
 const UPGRADE_ACTIONS = Object.freeze({
@@ -79,7 +80,8 @@ const VALID_OPTIONS_GLACIER = {
 const VALID_OPTIONS_DIAGNOSE = {
     'health': new Set([ 'https_port', 'deployment_type', 'all_account_details', 'all_bucket_details', 'all_connection_details', 'notif_storage_threshold', 'lifecycle', ...CLI_MUTUAL_OPTIONS]),
     'gather-logs': new Set([ CONFIG_ROOT_FLAG]),
-    'metrics': new Set([CONFIG_ROOT_FLAG])
+    'metrics': new Set([CONFIG_ROOT_FLAG]),
+    'usage-stats': new Set([...CLI_MUTUAL_OPTIONS])
 };
 
 const VALID_OPTIONS_UPGRADE = {

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -359,6 +359,7 @@ List of actions supported:
     health
     gather-logs
     metrics
+    usage-stats
 
 `;
 
@@ -409,6 +410,24 @@ Help:
 Usage:
 
     noobaa-cli diagnose metrics
+
+`;
+
+const DIAGNOSE_USAGE_STATS_OPTIONS = `
+Help:
+
+    'usage-stats' is a noobaa-core command that will return aggregate usage statistics of the deployed NooBaa NC system.
+    The report includes account, IAM user, bucket feature and connection counts, plus top-10 rule/statement counts
+    for lifecycle, notifications, CORS and bucket policy. It also returns metadata fields: noobaa_version,
+    config_dir_version and hosts_count. No resource names or secrets are included.
+
+Usage:
+
+    noobaa-cli diagnose usage-stats [flags]
+
+Flags:
+
+    --config_root            <string>        (optional)          Set Configuration files path for Noobaa standalone NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
 
 `;
 
@@ -707,6 +726,9 @@ function print_help_diagnose(action) {
             break;
         case DIAGNOSE_ACTIONS.METRICS:
             process.stdout.write(DIAGNOSE_METRICS_OPTIONS.trimStart());
+            break;
+        case DIAGNOSE_ACTIONS.USAGE_STATS:
+            process.stdout.write(DIAGNOSE_USAGE_STATS_OPTIONS.trimStart());
             break;
         default:
             process.stdout.write(DIAGNOSE_OPTIONS.trimStart());

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -417,7 +417,8 @@ const DIAGNOSE_USAGE_STATS_OPTIONS = `
 Help:
 
     'usage-stats' is a noobaa-core command that will return aggregate usage statistics of the deployed NooBaa NC system.
-    The report includes account, IAM user, bucket feature and connection counts. No resource names or secrets are included.
+    The report includes account, IAM user, bucket feature and connection counts, plus top-10 rule/statement counts
+    for lifecycle, notifications, CORS and bucket policy. No resource names or secrets are included.
 
 Usage:
 

--- a/src/manage_nsfs/manage_nsfs_help_utils.js
+++ b/src/manage_nsfs/manage_nsfs_help_utils.js
@@ -359,6 +359,7 @@ List of actions supported:
     health
     gather-logs
     metrics
+    usage-stats
 
 `;
 
@@ -409,6 +410,23 @@ Help:
 Usage:
 
     noobaa-cli diagnose metrics
+
+`;
+
+const DIAGNOSE_USAGE_STATS_OPTIONS = `
+Help:
+
+    'usage-stats' is a noobaa-core command that will return aggregate usage statistics of the deployed NooBaa NC system.
+    The report includes account, IAM user, bucket feature and connection counts. No resource names or secrets are included.
+
+Usage:
+
+    noobaa-cli diagnose usage-stats [flags]
+
+Flags:
+
+    --debug                  <number>        (optional)          Use for increasing the log verbosity of usage-stats cli commands.
+    --config_root            <string>        (optional)          Set Configuration files path for Noobaa standalone NSFS. (default config.NSFS_NC_DEFAULT_CONF_DIR)
 
 `;
 
@@ -707,6 +725,9 @@ function print_help_diagnose(action) {
             break;
         case DIAGNOSE_ACTIONS.METRICS:
             process.stdout.write(DIAGNOSE_METRICS_OPTIONS.trimStart());
+            break;
+        case DIAGNOSE_ACTIONS.USAGE_STATS:
+            process.stdout.write(DIAGNOSE_USAGE_STATS_OPTIONS.trimStart());
             break;
         default:
             process.stdout.write(DIAGNOSE_OPTIONS.trimStart());

--- a/src/manage_nsfs/usage_stats.js
+++ b/src/manage_nsfs/usage_stats.js
@@ -1,0 +1,191 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const config = require('../../config');
+const pkg = require('../../package.json');
+const ManageCLIError = require('./manage_nsfs_cli_errors').ManageCLIError;
+const { ManageCLIResponse } = require('./manage_nsfs_cli_responses');
+const { throw_cli_error, write_stdout_response } = require('./manage_nsfs_cli_utils');
+
+/**
+ * get_usage_stats gathers aggregate NC usage statistics from ConfigFS and prints them.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<void>}
+ */
+async function get_usage_stats(config_fs) {
+    try {
+        const usage_stats = await collect_usage_stats(config_fs);
+        write_stdout_response(ManageCLIResponse.UsageStats, usage_stats);
+    } catch (err) {
+        dbg.warn('could not collect usage stats', err);
+        throw_cli_error({ ...ManageCLIError.UsageStatsFailed, cause: err });
+    }
+}
+
+/**
+ * collect_usage_stats scans ConfigFS and returns aggregate usage statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_usage_stats(config_fs) {
+    const system_data = await config_fs.get_system_config_file({ silent_if_missing: true });
+    const hosts_data = system_data ? config_fs.get_hosts_data(system_data) : {};
+
+    const [identity_stats, buckets, connections] = await Promise.all([
+        collect_identity_stats(config_fs),
+        collect_buckets_stats(config_fs),
+        collect_connections_stats(config_fs),
+    ]);
+
+    return {
+        collected_at: new Date().toISOString(),
+        noobaa_version: pkg.version,
+        config_dir_version: system_data?.config_directory?.config_dir_version || config_fs.config_dir_version,
+        hosts_count: Object.keys(hosts_data).length,
+        accounts: identity_stats.accounts,
+        users: identity_stats.users,
+        buckets,
+        connections,
+    };
+}
+
+/**
+ * collect_identity_stats returns aggregate account and IAM user statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<{accounts: object, users: object}>}
+ */
+async function collect_identity_stats(config_fs) {
+    const accounts = {
+        total: 0,
+        anonymous: 0,
+        root_account_managers: 0,
+        with_allow_bucket_creation: 0,
+        with_default_connection: 0,
+        with_users: 0,
+    };
+    const users = {
+        total: 0,
+    };
+
+    const account_names = await config_fs.list_accounts();
+    for (const account_name of account_names) {
+        try {
+            const account = await config_fs.get_account_by_name(account_name);
+            accounts.total += 1;
+            if (account.name === config.ANONYMOUS_ACCOUNT_NAME) {
+                accounts.anonymous += 1;
+                continue;
+            }
+            if (account.iam_operate_on_root_account) accounts.root_account_managers += 1;
+            if (account.allow_bucket_creation) accounts.with_allow_bucket_creation += 1;
+            if (account.default_connection) accounts.with_default_connection += 1;
+
+            if (!account._id) continue;
+            const usernames = await config_fs.list_users_under_account(account._id);
+            if (usernames.length > 0) {
+                users.total += usernames.length;
+                accounts.with_users += 1;
+            }
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read account ${account_name}`, err);
+        }
+    }
+    return { accounts, users };
+}
+
+/**
+ * collect_buckets_stats returns aggregate bucket and feature-usage statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_buckets_stats(config_fs) {
+    const features = {
+        versioning_enabled: 0,
+        versioning_suspended: 0,
+        lifecycle: 0,
+        notifications: 0,
+        logging: 0,
+        bucket_policy: 0,
+        encryption: 0,
+        website: 0,
+        cors: 0,
+        object_lock: 0,
+        public_access_block: 0,
+        tags: 0,
+        force_md5_etag: 0,
+    };
+    const stats = {
+        total: 0,
+        features,
+    };
+
+    const bucket_names = await config_fs.list_buckets();
+    for (const bucket_name of bucket_names) {
+        try {
+            const bucket = await config_fs.get_bucket_by_name(bucket_name);
+            stats.total += 1;
+            count_bucket_features(bucket, features);
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read bucket ${bucket_name}`, err);
+        }
+    }
+    return stats;
+}
+
+/**
+ * count_bucket_features increments feature counters for a single bucket config.
+ * @param {object} bucket
+ * @param {object} features
+ */
+function count_bucket_features(bucket, features) {
+    if (bucket.versioning === 'ENABLED') features.versioning_enabled += 1;
+    if (bucket.versioning === 'SUSPENDED') features.versioning_suspended += 1;
+    if (Array.isArray(bucket.lifecycle_configuration_rules) && bucket.lifecycle_configuration_rules.length > 0) {
+        features.lifecycle += 1;
+    }
+    if (Array.isArray(bucket.notifications) && bucket.notifications.length > 0) {
+        features.notifications += 1;
+    }
+    if (bucket.logging) features.logging += 1;
+    if (bucket.s3_policy) features.bucket_policy += 1;
+    if (bucket.encryption) features.encryption += 1;
+    if (bucket.website) features.website += 1;
+    if (Array.isArray(bucket.cors_configuration_rules) && bucket.cors_configuration_rules.length > 0) {
+        features.cors += 1;
+    }
+    if (bucket.object_lock_configuration?.object_lock_enabled === 'Enabled') {
+        features.object_lock += 1;
+    }
+    if (bucket.public_access_block) features.public_access_block += 1;
+    if (Array.isArray(bucket.tag) && bucket.tag.length > 0) features.tags += 1;
+    if (bucket.force_md5_etag === true) features.force_md5_etag += 1;
+}
+
+/**
+ * collect_connections_stats returns aggregate connection statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_connections_stats(config_fs) {
+    const stats = {
+        total: 0,
+        by_protocol: {},
+    };
+
+    const connection_names = await config_fs.list_connections();
+    for (const connection_name of connection_names) {
+        try {
+            const connection = await config_fs.get_connection_by_name(connection_name);
+            stats.total += 1;
+            const protocol = connection.notification_protocol || 'unknown';
+            stats.by_protocol[protocol] = (stats.by_protocol[protocol] || 0) + 1;
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read connection ${connection_name}`, err);
+        }
+    }
+    return stats;
+}
+
+exports.get_usage_stats = get_usage_stats;
+exports.collect_usage_stats = collect_usage_stats;

--- a/src/manage_nsfs/usage_stats.js
+++ b/src/manage_nsfs/usage_stats.js
@@ -1,0 +1,240 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const dbg = require('../util/debug_module')(__filename);
+const config = require('../../config');
+const pkg = require('../../package.json');
+const ManageCLIError = require('./manage_nsfs_cli_errors').ManageCLIError;
+const { ManageCLIResponse } = require('./manage_nsfs_cli_responses');
+const { throw_cli_error, write_stdout_response } = require('./manage_nsfs_cli_utils');
+
+/**
+ * get_usage_stats gathers aggregate NC usage statistics from ConfigFS and prints them.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<void>}
+ */
+async function get_usage_stats(config_fs) {
+    try {
+        const usage_stats = await collect_usage_stats(config_fs);
+        write_stdout_response(ManageCLIResponse.UsageStats, usage_stats);
+    } catch (err) {
+        dbg.warn('could not collect usage stats', err);
+        throw_cli_error({ ...ManageCLIError.UsageStatsFailed, cause: err });
+    }
+}
+
+/**
+ * collect_usage_stats scans ConfigFS and returns aggregate usage statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_usage_stats(config_fs) {
+    const system_data = await config_fs.get_system_config_file({ silent_if_missing: true });
+    const hosts_data = system_data ? config_fs.get_hosts_data(system_data) : {};
+
+    const [identity_stats, buckets, connections] = await Promise.all([
+        collect_identity_stats(config_fs),
+        collect_buckets_stats(config_fs),
+        collect_connections_stats(config_fs),
+    ]);
+
+    return {
+        collected_at: new Date().toISOString(),
+        noobaa_version: pkg.version,
+        config_dir_version: system_data?.config_directory?.config_dir_version || config_fs.config_dir_version,
+        hosts_count: Object.keys(hosts_data).length,
+        accounts: identity_stats.accounts,
+        users: identity_stats.users,
+        buckets,
+        connections,
+    };
+}
+
+/**
+ * collect_identity_stats returns aggregate account and IAM user statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<{accounts: object, users: object}>}
+ */
+async function collect_identity_stats(config_fs) {
+    const accounts = {
+        total: 0,
+        anonymous: 0,
+        root_account_managers: 0,
+        with_allow_bucket_creation: 0,
+        with_default_connection: 0,
+        with_users: 0,
+    };
+    const users = {
+        total: 0,
+    };
+
+    const account_names = await config_fs.list_accounts();
+    for (const account_name of account_names) {
+        try {
+            const account = await config_fs.get_account_by_name(account_name);
+            accounts.total += 1;
+            if (account.name === config.ANONYMOUS_ACCOUNT_NAME) {
+                accounts.anonymous += 1;
+                continue;
+            }
+            if (account.iam_operate_on_root_account) accounts.root_account_managers += 1;
+            if (account.allow_bucket_creation) accounts.with_allow_bucket_creation += 1;
+            if (account.default_connection) accounts.with_default_connection += 1;
+
+            if (!account._id) continue;
+            const usernames = await config_fs.list_users_under_account(account._id);
+            if (usernames.length > 0) {
+                users.total += usernames.length;
+                accounts.with_users += 1;
+            }
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read account ${account_name}`, err);
+        }
+    }
+    return { accounts, users };
+}
+
+const TOP_RULES_COUNT = 10;
+
+/**
+ * collect_buckets_stats returns aggregate bucket and feature-usage statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_buckets_stats(config_fs) {
+    const features = {
+        versioning_enabled: 0,
+        versioning_suspended: 0,
+        lifecycle: 0,
+        notifications: 0,
+        logging: 0,
+        bucket_policy: 0,
+        encryption: 0,
+        website: 0,
+        cors: 0,
+        object_lock: 0,
+        public_access_block: 0,
+        tags: 0,
+        force_md5_etag: 0,
+    };
+    const rule_counts = {
+        lifecycle: [],
+        notifications: [],
+        cors: [],
+        bucket_policy: [],
+    };
+    const stats = {
+        total: 0,
+        features,
+    };
+
+    const bucket_names = await config_fs.list_buckets();
+    for (const bucket_name of bucket_names) {
+        try {
+            const bucket = await config_fs.get_bucket_by_name(bucket_name);
+            stats.total += 1;
+            count_bucket_features(bucket, features, rule_counts);
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read bucket ${bucket_name}`, err);
+        }
+    }
+
+    features.lifecycle_top10_rules = top_counts(rule_counts.lifecycle, TOP_RULES_COUNT);
+    features.notifications_top10_rules = top_counts(rule_counts.notifications, TOP_RULES_COUNT);
+    features.cors_top10_rules = top_counts(rule_counts.cors, TOP_RULES_COUNT);
+    features.bucket_policy_top10_statements = top_counts(rule_counts.bucket_policy, TOP_RULES_COUNT);
+    return stats;
+}
+
+/**
+ * count_bucket_features increments feature counters for a single bucket config
+ * and records per-bucket rule/statement counts for top-N summaries.
+ * @param {object} bucket
+ * @param {object} features
+ * @param {{lifecycle: number[], notifications: number[], cors: number[], bucket_policy: number[]}} rule_counts
+ */
+function count_bucket_features(bucket, features, rule_counts) {
+    if (bucket.versioning === 'ENABLED') features.versioning_enabled += 1;
+    if (bucket.versioning === 'SUSPENDED') features.versioning_suspended += 1;
+
+    const lifecycle_rules_count = Array.isArray(bucket.lifecycle_configuration_rules) ?
+        bucket.lifecycle_configuration_rules.length : 0;
+    if (lifecycle_rules_count > 0) {
+        features.lifecycle += 1;
+        rule_counts.lifecycle.push(lifecycle_rules_count);
+    }
+
+    const notifications_count = Array.isArray(bucket.notifications) ? bucket.notifications.length : 0;
+    if (notifications_count > 0) {
+        features.notifications += 1;
+        rule_counts.notifications.push(notifications_count);
+    }
+
+    if (bucket.logging) features.logging += 1;
+
+    const bucket_policy_statements_count = Array.isArray(bucket.s3_policy?.Statement) ?
+        bucket.s3_policy.Statement.length : 0;
+    if (bucket.s3_policy) {
+        features.bucket_policy += 1;
+        if (bucket_policy_statements_count > 0) {
+            rule_counts.bucket_policy.push(bucket_policy_statements_count);
+        }
+    }
+
+    if (bucket.encryption) features.encryption += 1;
+    if (bucket.website) features.website += 1;
+
+    const cors_rules_count = Array.isArray(bucket.cors_configuration_rules) ?
+        bucket.cors_configuration_rules.length : 0;
+    if (cors_rules_count > 0) {
+        features.cors += 1;
+        rule_counts.cors.push(cors_rules_count);
+    }
+
+    if (bucket.object_lock_configuration?.object_lock_enabled === 'Enabled') {
+        features.object_lock += 1;
+    }
+    if (bucket.public_access_block) features.public_access_block += 1;
+    if (Array.isArray(bucket.tag) && bucket.tag.length > 0) features.tags += 1;
+    if (bucket.force_md5_etag === true) features.force_md5_etag += 1;
+}
+
+/**
+ * top_counts returns the highest counts in descending order, capped at limit.
+ * @param {number[]} counts
+ * @param {number} limit
+ * @returns {number[]}
+ */
+function top_counts(counts, limit) {
+    return counts
+        .sort((a, b) => b - a)
+        .slice(0, limit);
+}
+
+/**
+ * collect_connections_stats returns aggregate connection statistics.
+ * @param {import('../sdk/config_fs').ConfigFS} config_fs
+ * @returns {Promise<object>}
+ */
+async function collect_connections_stats(config_fs) {
+    const stats = {
+        total: 0,
+        by_protocol: {},
+    };
+
+    const connection_names = await config_fs.list_connections();
+    for (const connection_name of connection_names) {
+        try {
+            const connection = await config_fs.get_connection_by_name(connection_name);
+            stats.total += 1;
+            const protocol = connection.notification_protocol || 'unknown';
+            stats.by_protocol[protocol] = (stats.by_protocol[protocol] || 0) + 1;
+        } catch (err) {
+            dbg.warn(`usage_stats: failed to read connection ${connection_name}`, err);
+        }
+    }
+    return stats;
+}
+
+exports.get_usage_stats = get_usage_stats;
+exports.collect_usage_stats = collect_usage_stats;

--- a/src/manage_nsfs/usage_stats.js
+++ b/src/manage_nsfs/usage_stats.js
@@ -94,6 +94,8 @@ async function collect_identity_stats(config_fs) {
     return { accounts, users };
 }
 
+const TOP_RULES_COUNT = 10;
+
 /**
  * collect_buckets_stats returns aggregate bucket and feature-usage statistics.
  * @param {import('../sdk/config_fs').ConfigFS} config_fs
@@ -115,6 +117,12 @@ async function collect_buckets_stats(config_fs) {
         tags: 0,
         force_md5_etag: 0,
     };
+    const rule_counts = {
+        lifecycle: [],
+        notifications: [],
+        cors: [],
+        bucket_policy: [],
+    };
     const stats = {
         total: 0,
         features,
@@ -125,41 +133,83 @@ async function collect_buckets_stats(config_fs) {
         try {
             const bucket = await config_fs.get_bucket_by_name(bucket_name);
             stats.total += 1;
-            count_bucket_features(bucket, features);
+            count_bucket_features(bucket, features, rule_counts);
         } catch (err) {
             dbg.warn(`usage_stats: failed to read bucket ${bucket_name}`, err);
         }
     }
+
+    features.lifecycle_top10_rules = top_counts(rule_counts.lifecycle, TOP_RULES_COUNT);
+    features.notifications_top10_rules = top_counts(rule_counts.notifications, TOP_RULES_COUNT);
+    features.cors_top10_rules = top_counts(rule_counts.cors, TOP_RULES_COUNT);
+    features.bucket_policy_top10_statements = top_counts(rule_counts.bucket_policy, TOP_RULES_COUNT);
     return stats;
 }
 
 /**
- * count_bucket_features increments feature counters for a single bucket config.
+ * count_bucket_features increments feature counters for a single bucket config
+ * and records per-bucket rule/statement counts for top-N summaries.
  * @param {object} bucket
  * @param {object} features
+ * @param {{lifecycle: number[], notifications: number[], cors: number[], bucket_policy: number[]}} rule_counts
  */
-function count_bucket_features(bucket, features) {
+function count_bucket_features(bucket, features, rule_counts) {
     if (bucket.versioning === 'ENABLED') features.versioning_enabled += 1;
     if (bucket.versioning === 'SUSPENDED') features.versioning_suspended += 1;
-    if (Array.isArray(bucket.lifecycle_configuration_rules) && bucket.lifecycle_configuration_rules.length > 0) {
+
+    const lifecycle_rules_count = Array.isArray(bucket.lifecycle_configuration_rules) ?
+        bucket.lifecycle_configuration_rules.length : 0;
+    if (lifecycle_rules_count > 0) {
         features.lifecycle += 1;
+        rule_counts.lifecycle.push(lifecycle_rules_count);
     }
-    if (Array.isArray(bucket.notifications) && bucket.notifications.length > 0) {
+
+    const notifications_count = Array.isArray(bucket.notifications) ? bucket.notifications.length : 0;
+    if (notifications_count > 0) {
         features.notifications += 1;
+        rule_counts.notifications.push(notifications_count);
     }
+
     if (bucket.logging) features.logging += 1;
-    if (bucket.s3_policy) features.bucket_policy += 1;
+
+    const bucket_policy_statements_count = Array.isArray(bucket.s3_policy?.Statement) ?
+        bucket.s3_policy.Statement.length : 0;
+    if (bucket.s3_policy) {
+        features.bucket_policy += 1;
+        if (bucket_policy_statements_count > 0) {
+            rule_counts.bucket_policy.push(bucket_policy_statements_count);
+        }
+    }
+
     if (bucket.encryption) features.encryption += 1;
     if (bucket.website) features.website += 1;
-    if (Array.isArray(bucket.cors_configuration_rules) && bucket.cors_configuration_rules.length > 0) {
+
+    const cors_rules_count = Array.isArray(bucket.cors_configuration_rules) ?
+        bucket.cors_configuration_rules.length : 0;
+    if (cors_rules_count > 0) {
         features.cors += 1;
+        rule_counts.cors.push(cors_rules_count);
     }
+
     if (bucket.object_lock_configuration?.object_lock_enabled === 'Enabled') {
         features.object_lock += 1;
     }
     if (bucket.public_access_block) features.public_access_block += 1;
     if (Array.isArray(bucket.tag) && bucket.tag.length > 0) features.tags += 1;
     if (bucket.force_md5_etag === true) features.force_md5_etag += 1;
+}
+
+/**
+ * top_counts returns the highest counts in descending order, capped at limit.
+ * @param {number[]} counts
+ * @param {number} limit
+ * @returns {number[]}
+ */
+function top_counts(counts, limit) {
+    return counts
+        .slice()
+        .sort((a, b) => b - a)
+        .slice(0, limit);
 }
 
 /**

--- a/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
@@ -91,17 +91,38 @@ describe('noobaa cli - diagnose usage-stats', () => {
 
         const featured_bucket = await config_fs.get_bucket_by_name('bucket-featured');
         featured_bucket.versioning = 'ENABLED';
-        featured_bucket.lifecycle_configuration_rules = [{
-            id: 'rule1',
-            status: 'Enabled',
-            filter: { prefix: '' },
-            expiration: { days: 30 },
-        }];
-        featured_bucket.notifications = [{
-            id: ['notif1'],
-            event: ['s3:ObjectCreated:*'],
-            topic: ['conn1'],
-        }];
+        featured_bucket.lifecycle_configuration_rules = [
+            {
+                id: 'rule1',
+                status: 'Enabled',
+                filter: { prefix: '' },
+                expiration: { days: 30 },
+            },
+            {
+                id: 'rule2',
+                status: 'Enabled',
+                filter: { prefix: 'logs/' },
+                expiration: { days: 7 },
+            },
+            {
+                id: 'rule3',
+                status: 'Disabled',
+                filter: { prefix: 'tmp/' },
+                expiration: { days: 1 },
+            },
+        ];
+        featured_bucket.notifications = [
+            {
+                id: ['notif1'],
+                event: ['s3:ObjectCreated:*'],
+                topic: ['conn1'],
+            },
+            {
+                id: ['notif2'],
+                event: ['s3:ObjectRemoved:*'],
+                topic: ['conn1'],
+            },
+        ];
         featured_bucket.logging = {
             log_bucket: 'bucket-plain',
             log_prefix: 'logs/',
@@ -114,10 +135,16 @@ describe('noobaa cli - diagnose usage-stats', () => {
                 index_document: { suffix: 'index.html' },
             },
         };
-        featured_bucket.cors_configuration_rules = [{
-            allowed_origins: ['*'],
-            allowed_methods: ['GET'],
-        }];
+        featured_bucket.cors_configuration_rules = [
+            {
+                allowed_origins: ['*'],
+                allowed_methods: ['GET'],
+            },
+            {
+                allowed_origins: ['https://example.com'],
+                allowed_methods: ['PUT', 'POST'],
+            },
+        ];
         featured_bucket.object_lock_configuration = {
             object_lock_enabled: 'Enabled',
         };
@@ -137,6 +164,12 @@ describe('noobaa cli - diagnose usage-stats', () => {
         });
         const suspended_bucket = await config_fs.get_bucket_by_name('bucket-suspended');
         suspended_bucket.versioning = 'SUSPENDED';
+        suspended_bucket.lifecycle_configuration_rules = [{
+            id: 'rule1',
+            status: 'Enabled',
+            filter: { prefix: '' },
+            expiration: { days: 90 },
+        }];
         await config_fs.update_bucket_config_file(suspended_bucket);
 
         const connection_file = path.join(tmp_fs_path, 'conn1.json');
@@ -172,6 +205,7 @@ describe('noobaa cli - diagnose usage-stats', () => {
 
     it('diagnose usage-stats returns aggregate counts', async () => {
         const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.USAGE_STATS, { config_root });
+        console.log(res);
         const parsed = JSON.parse(res);
         expect(parsed.response.code).toBe(ManageCLIResponse.UsageStats.code);
 
@@ -198,7 +232,7 @@ describe('noobaa cli - diagnose usage-stats', () => {
         expect(reply.buckets.features).toEqual({
             versioning_enabled: 1,
             versioning_suspended: 1,
-            lifecycle: 1,
+            lifecycle: 2,
             notifications: 1,
             logging: 1,
             bucket_policy: 1,
@@ -209,6 +243,10 @@ describe('noobaa cli - diagnose usage-stats', () => {
             public_access_block: 1,
             tags: 1,
             force_md5_etag: 1,
+            lifecycle_top10_rules: [3, 1],
+            notifications_top10_rules: [2],
+            cors_top10_rules: [2],
+            bucket_policy_top10_statements: [1],
         });
 
         expect(reply.connections).toEqual({

--- a/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
@@ -1,0 +1,226 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+const fs = require('fs');
+const path = require('path');
+const fs_utils = require('../../../../util/fs_utils');
+const nb_native = require('../../../../util/nb_native');
+const { ConfigFS, SYMLINK_SUFFIX } = require('../../../../sdk/config_fs');
+const { TYPES, ACTIONS, DIAGNOSE_ACTIONS } = require('../../../../manage_nsfs/manage_nsfs_constants');
+const { ManageCLIResponse } = require('../../../../manage_nsfs/manage_nsfs_cli_responses');
+const {
+    TMP_PATH,
+    TEST_TIMEOUT,
+    exec_manage_cli,
+    set_nc_config_dir_in_config,
+    set_path_permissions_and_owner,
+    generate_s3_policy,
+} = require('../../../system_tests/test_utils');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_usage_stats');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const root_path = path.join(tmp_fs_path, 'root_path');
+const config_fs = new ConfigFS(config_root);
+const process_uid = process.getuid();
+const process_gid = process.getgid();
+
+describe('noobaa cli - diagnose usage-stats', () => {
+    const account_defaults = {
+        name: 'usage_stats_account',
+        new_buckets_path: path.join(root_path, 'new_buckets_path'),
+        uid: process_uid,
+        gid: process_gid,
+        access_key: 'GIGiFAnjaaE7OKD5N7hX',
+        secret_key: 'G2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+        allow_bucket_creation: 'true',
+    };
+
+    const account_iam_manager = {
+        name: 'usage_stats_iam_mgr',
+        new_buckets_path: path.join(root_path, 'new_buckets_path_iam'),
+        uid: process_uid,
+        gid: process_gid,
+        access_key: 'GIGiFAnjaaE7OKD5N8hY',
+        secret_key: 'G3BYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+        iam_operate_on_root_account: 'true',
+    };
+
+    const bucket_plain_path = path.join(root_path, 'bucket_plain');
+    const bucket_featured_path = path.join(root_path, 'bucket_featured');
+
+    beforeAll(async () => {
+        await fs_utils.folder_delete(tmp_fs_path);
+        await fs_utils.create_fresh_path(root_path);
+        await fs_utils.create_fresh_path(config_root);
+        set_nc_config_dir_in_config(config_root);
+
+        for (const account of [account_defaults, account_iam_manager]) {
+            await fs_utils.create_fresh_path(account.new_buckets_path);
+            await set_path_permissions_and_owner(account.new_buckets_path, account, 0o700);
+            const account_res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account });
+            expect(JSON.parse(account_res).response.code).toBe('AccountCreated');
+        }
+
+        const anon_res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, {
+            config_root,
+            anonymous: true,
+            uid: process_uid,
+            gid: process_gid,
+        });
+        expect(JSON.parse(anon_res).response.code).toBe('AccountCreated');
+
+        await fs_utils.create_fresh_path(bucket_plain_path);
+        await fs_utils.create_fresh_path(bucket_featured_path);
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-plain',
+            owner: account_defaults.name,
+            path: bucket_plain_path,
+        });
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-featured',
+            owner: account_defaults.name,
+            path: bucket_featured_path,
+            force_md5_etag: 'true',
+            bucket_policy: JSON.stringify(generate_s3_policy('*', 'bucket-featured', ['s3:*']).policy),
+        });
+
+        const featured_bucket = await config_fs.get_bucket_by_name('bucket-featured');
+        featured_bucket.versioning = 'ENABLED';
+        featured_bucket.lifecycle_configuration_rules = [{
+            id: 'rule1',
+            status: 'Enabled',
+            filter: { prefix: '' },
+            expiration: { days: 30 },
+        }];
+        featured_bucket.notifications = [{
+            id: ['notif1'],
+            event: ['s3:ObjectCreated:*'],
+            topic: ['conn1'],
+        }];
+        featured_bucket.logging = {
+            log_bucket: 'bucket-plain',
+            log_prefix: 'logs/',
+        };
+        featured_bucket.encryption = {
+            algorithm: 'AES256',
+        };
+        featured_bucket.website = {
+            website_configuration: {
+                index_document: { suffix: 'index.html' },
+            },
+        };
+        featured_bucket.cors_configuration_rules = [{
+            allowed_origins: ['*'],
+            allowed_methods: ['GET'],
+        }];
+        featured_bucket.object_lock_configuration = {
+            object_lock_enabled: 'Enabled',
+        };
+        featured_bucket.public_access_block = {
+            block_public_acls: true,
+        };
+        featured_bucket.tag = [{ key: 'env', value: 'test' }];
+        await config_fs.update_bucket_config_file(featured_bucket);
+
+        const suspended_path = path.join(root_path, 'bucket_suspended');
+        await fs_utils.create_fresh_path(suspended_path);
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-suspended',
+            owner: account_defaults.name,
+            path: suspended_path,
+        });
+        const suspended_bucket = await config_fs.get_bucket_by_name('bucket-suspended');
+        suspended_bucket.versioning = 'SUSPENDED';
+        await config_fs.update_bucket_config_file(suspended_bucket);
+
+        const connection_file = path.join(tmp_fs_path, 'conn1.json');
+        await fs.promises.writeFile(connection_file, JSON.stringify({
+            name: 'conn1',
+            notification_protocol: 'http',
+            agent_request_object: { host: 'localhost', port: 9999, timeout: 100 },
+            request_options_object: { auth: 'user:passw' },
+        }));
+        await exec_manage_cli(TYPES.CONNECTION, ACTIONS.ADD, {
+            config_root,
+            from_file: connection_file,
+        });
+
+        const account = await config_fs.get_account_by_name(account_defaults.name);
+        await config_fs.create_users_dir_if_missing(account._id);
+        const users_dir = config_fs.get_users_dir_path_by_id(account._id);
+        await nb_native().fs.symlink(
+            config_fs.fs_context,
+            '../../dummy_user_identity',
+            path.join(users_dir, `iam-user-1${SYMLINK_SUFFIX}`)
+        );
+        await nb_native().fs.symlink(
+            config_fs.fs_context,
+            '../../dummy_user_identity',
+            path.join(users_dir, `iam-user-2${SYMLINK_SUFFIX}`)
+        );
+    }, TEST_TIMEOUT);
+
+    afterAll(async () => {
+        await fs_utils.folder_delete(tmp_fs_path);
+    }, TEST_TIMEOUT);
+
+    it('diagnose usage-stats returns aggregate counts', async () => {
+        const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.USAGE_STATS, { config_root });
+        const parsed = JSON.parse(res);
+        expect(parsed.response.code).toBe(ManageCLIResponse.UsageStats.code);
+
+        const reply = parsed.response.reply;
+        expect(reply.noobaa_version).toBeDefined();
+        expect(reply.config_dir_version).toBeDefined();
+        expect(reply.collected_at).toBeDefined();
+        expect(typeof reply.hosts_count).toBe('number');
+
+        expect(reply.accounts).toEqual({
+            total: 3,
+            anonymous: 1,
+            root_account_managers: 1,
+            with_allow_bucket_creation: 2,
+            with_default_connection: 0,
+            with_users: 1,
+        });
+
+        expect(reply.users).toEqual({
+            total: 2,
+        });
+
+        expect(reply.buckets.total).toBe(3);
+        expect(reply.buckets.features).toEqual({
+            versioning_enabled: 1,
+            versioning_suspended: 1,
+            lifecycle: 1,
+            notifications: 1,
+            logging: 1,
+            bucket_policy: 1,
+            encryption: 1,
+            website: 1,
+            cors: 1,
+            object_lock: 1,
+            public_access_block: 1,
+            tags: 1,
+            force_md5_etag: 1,
+        });
+
+        expect(reply.connections).toEqual({
+            total: 1,
+            by_protocol: { http: 1 },
+        });
+
+        // Aggregate-only: no resource names should appear in the reply payload.
+        const reply_str = JSON.stringify(reply);
+        expect(reply_str).not.toContain(account_defaults.name);
+        expect(reply_str).not.toContain('bucket-featured');
+        expect(reply_str).not.toContain(account_defaults.access_key);
+        expect(reply_str).not.toContain(account_defaults.secret_key);
+    }, TEST_TIMEOUT);
+});

--- a/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
+++ b/src/test/integration_tests/nc/cli/test_nc_usage_stats.test.js
@@ -1,0 +1,264 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+// disabling init_rand_seed as it takes longer than the actual test execution
+process.env.DISABLE_INIT_RANDOM_SEED = 'true';
+
+const fs = require('fs');
+const path = require('path');
+const fs_utils = require('../../../../util/fs_utils');
+const nb_native = require('../../../../util/nb_native');
+const { ConfigFS, SYMLINK_SUFFIX } = require('../../../../sdk/config_fs');
+const { TYPES, ACTIONS, DIAGNOSE_ACTIONS } = require('../../../../manage_nsfs/manage_nsfs_constants');
+const { ManageCLIResponse } = require('../../../../manage_nsfs/manage_nsfs_cli_responses');
+const {
+    TMP_PATH,
+    TEST_TIMEOUT,
+    exec_manage_cli,
+    set_nc_config_dir_in_config,
+    set_path_permissions_and_owner,
+    generate_s3_policy,
+} = require('../../../system_tests/test_utils');
+
+const tmp_fs_path = path.join(TMP_PATH, 'test_nc_usage_stats');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const root_path = path.join(tmp_fs_path, 'root_path');
+const config_fs = new ConfigFS(config_root);
+const process_uid = process.getuid();
+const process_gid = process.getgid();
+
+describe('noobaa cli - diagnose usage-stats', () => {
+    const account_defaults = {
+        name: 'usage_stats_account',
+        new_buckets_path: path.join(root_path, 'new_buckets_path'),
+        uid: process_uid,
+        gid: process_gid,
+        access_key: 'GIGiFAnjaaE7OKD5N7hX',
+        secret_key: 'G2AYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+        allow_bucket_creation: 'true',
+    };
+
+    const account_iam_manager = {
+        name: 'usage_stats_iam_mgr',
+        new_buckets_path: path.join(root_path, 'new_buckets_path_iam'),
+        uid: process_uid,
+        gid: process_gid,
+        access_key: 'GIGiFAnjaaE7OKD5N8hY',
+        secret_key: 'G3BYaMpU3zRDcRFWmvzgQr9MoHIAsD+3oEXAMPLE',
+        iam_operate_on_root_account: 'true',
+    };
+
+    const bucket_plain_path = path.join(root_path, 'bucket_plain');
+    const bucket_featured_path = path.join(root_path, 'bucket_featured');
+
+    beforeAll(async () => {
+        await fs_utils.folder_delete(tmp_fs_path);
+        await fs_utils.create_fresh_path(root_path);
+        await fs_utils.create_fresh_path(config_root);
+        set_nc_config_dir_in_config(config_root);
+
+        for (const account of [account_defaults, account_iam_manager]) {
+            await fs_utils.create_fresh_path(account.new_buckets_path);
+            await set_path_permissions_and_owner(account.new_buckets_path, account, 0o700);
+            const account_res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, { config_root, ...account });
+            expect(JSON.parse(account_res).response.code).toBe('AccountCreated');
+        }
+
+        const anon_res = await exec_manage_cli(TYPES.ACCOUNT, ACTIONS.ADD, {
+            config_root,
+            anonymous: true,
+            uid: process_uid,
+            gid: process_gid,
+        });
+        expect(JSON.parse(anon_res).response.code).toBe('AccountCreated');
+
+        await fs_utils.create_fresh_path(bucket_plain_path);
+        await fs_utils.create_fresh_path(bucket_featured_path);
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-plain',
+            owner: account_defaults.name,
+            path: bucket_plain_path,
+        });
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-featured',
+            owner: account_defaults.name,
+            path: bucket_featured_path,
+            force_md5_etag: 'true',
+            bucket_policy: JSON.stringify(generate_s3_policy('*', 'bucket-featured', ['s3:*']).policy),
+        });
+
+        const featured_bucket = await config_fs.get_bucket_by_name('bucket-featured');
+        featured_bucket.versioning = 'ENABLED';
+        featured_bucket.lifecycle_configuration_rules = [
+            {
+                id: 'rule1',
+                status: 'Enabled',
+                filter: { prefix: '' },
+                expiration: { days: 30 },
+            },
+            {
+                id: 'rule2',
+                status: 'Enabled',
+                filter: { prefix: 'logs/' },
+                expiration: { days: 7 },
+            },
+            {
+                id: 'rule3',
+                status: 'Disabled',
+                filter: { prefix: 'tmp/' },
+                expiration: { days: 1 },
+            },
+        ];
+        featured_bucket.notifications = [
+            {
+                id: ['notif1'],
+                event: ['s3:ObjectCreated:*'],
+                topic: ['conn1'],
+            },
+            {
+                id: ['notif2'],
+                event: ['s3:ObjectRemoved:*'],
+                topic: ['conn1'],
+            },
+        ];
+        featured_bucket.logging = {
+            log_bucket: 'bucket-plain',
+            log_prefix: 'logs/',
+        };
+        featured_bucket.encryption = {
+            algorithm: 'AES256',
+        };
+        featured_bucket.website = {
+            website_configuration: {
+                index_document: { suffix: 'index.html' },
+            },
+        };
+        featured_bucket.cors_configuration_rules = [
+            {
+                allowed_origins: ['*'],
+                allowed_methods: ['GET'],
+            },
+            {
+                allowed_origins: ['https://example.com'],
+                allowed_methods: ['PUT', 'POST'],
+            },
+        ];
+        featured_bucket.object_lock_configuration = {
+            object_lock_enabled: 'Enabled',
+        };
+        featured_bucket.public_access_block = {
+            block_public_acls: true,
+        };
+        featured_bucket.tag = [{ key: 'env', value: 'test' }];
+        await config_fs.update_bucket_config_file(featured_bucket);
+
+        const suspended_path = path.join(root_path, 'bucket_suspended');
+        await fs_utils.create_fresh_path(suspended_path);
+        await exec_manage_cli(TYPES.BUCKET, ACTIONS.ADD, {
+            config_root,
+            name: 'bucket-suspended',
+            owner: account_defaults.name,
+            path: suspended_path,
+        });
+        const suspended_bucket = await config_fs.get_bucket_by_name('bucket-suspended');
+        suspended_bucket.versioning = 'SUSPENDED';
+        suspended_bucket.lifecycle_configuration_rules = [{
+            id: 'rule1',
+            status: 'Enabled',
+            filter: { prefix: '' },
+            expiration: { days: 90 },
+        }];
+        await config_fs.update_bucket_config_file(suspended_bucket);
+
+        const connection_file = path.join(tmp_fs_path, 'conn1.json');
+        await fs.promises.writeFile(connection_file, JSON.stringify({
+            name: 'conn1',
+            notification_protocol: 'http',
+            agent_request_object: { host: 'localhost', port: 9999, timeout: 100 },
+            request_options_object: { auth: 'user:passw' },
+        }));
+        await exec_manage_cli(TYPES.CONNECTION, ACTIONS.ADD, {
+            config_root,
+            from_file: connection_file,
+        });
+
+        const account = await config_fs.get_account_by_name(account_defaults.name);
+        await config_fs.create_users_dir_if_missing(account._id);
+        const users_dir = config_fs.get_users_dir_path_by_id(account._id);
+        await nb_native().fs.symlink(
+            config_fs.fs_context,
+            '../../dummy_user_identity',
+            path.join(users_dir, `iam-user-1${SYMLINK_SUFFIX}`)
+        );
+        await nb_native().fs.symlink(
+            config_fs.fs_context,
+            '../../dummy_user_identity',
+            path.join(users_dir, `iam-user-2${SYMLINK_SUFFIX}`)
+        );
+    }, TEST_TIMEOUT);
+
+    afterAll(async () => {
+        await fs_utils.folder_delete(tmp_fs_path);
+    }, TEST_TIMEOUT);
+
+    it('diagnose usage-stats returns aggregate counts', async () => {
+        const res = await exec_manage_cli(TYPES.DIAGNOSE, DIAGNOSE_ACTIONS.USAGE_STATS, { config_root });
+        console.log(res);
+        const parsed = JSON.parse(res);
+        expect(parsed.response.code).toBe(ManageCLIResponse.UsageStats.code);
+
+        const reply = parsed.response.reply;
+        expect(reply.noobaa_version).toBeDefined();
+        expect(reply.config_dir_version).toBeDefined();
+        expect(reply.collected_at).toBeDefined();
+        expect(typeof reply.hosts_count).toBe('number');
+
+        expect(reply.accounts).toEqual({
+            total: 3,
+            anonymous: 1,
+            root_account_managers: 1,
+            with_allow_bucket_creation: 2,
+            with_default_connection: 0,
+            with_users: 1,
+        });
+
+        expect(reply.users).toEqual({
+            total: 2,
+        });
+
+        expect(reply.buckets.total).toBe(3);
+        expect(reply.buckets.features).toEqual({
+            versioning_enabled: 1,
+            versioning_suspended: 1,
+            lifecycle: 2,
+            notifications: 1,
+            logging: 1,
+            bucket_policy: 1,
+            encryption: 1,
+            website: 1,
+            cors: 1,
+            object_lock: 1,
+            public_access_block: 1,
+            tags: 1,
+            force_md5_etag: 1,
+            lifecycle_top10_rules: [3, 1],
+            notifications_top10_rules: [2],
+            cors_top10_rules: [2],
+            bucket_policy_top10_statements: [1],
+        });
+
+        expect(reply.connections).toEqual({
+            total: 1,
+            by_protocol: { http: 1 },
+        });
+
+        // Aggregate-only: no resource names should appear in the reply payload.
+        const reply_str = JSON.stringify(reply);
+        expect(reply_str).not.toContain(account_defaults.name);
+        expect(reply_str).not.toContain('bucket-featured');
+        expect(reply_str).not.toContain(account_defaults.access_key);
+        expect(reply_str).not.toContain(account_defaults.secret_key);
+    }, TEST_TIMEOUT);
+});


### PR DESCRIPTION
### Describe the Problem
We want to start collecting noobaa usage statistics as part of scale phone home. We will do that by adding a new CLI command that can be run by phone home and also by the user if he wants to see what begin collected

### Explain the Changes
1. Add a new diagnose action `usage-stats` (`noobaa-cli diagnose usage-stats`) that scans ConfigFS and prints aggregate usage statistics
2. Report account counts (total, anonymous, root account managers, allow bucket creation, default connection, accounts with users)
3. Report IAM user total count
4. Report bucket total and feature adoption counts (versioning, lifecycle, notifications, logging, bucket policy, encryption, website, CORS, object lock, public access block, tags, force_md5_etag)
5. Report connection counts by protocol, plus NooBaa/config-dir version and hosts count
6. Add CLI help, response/error codes, docs, and an NC CLI integration test

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Create accounts, IAM users, buckets with various features enabled, and a connection
2. Run:
```noobaa-cli diagnose usage-stats```
Verify the JSON reply contains only aggregate counts (no account/bucket names or secrets)


- [x] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `diagnose usage-stats` command for aggregate metrics covering accounts, users, buckets, bucket features, rules, and connections.
  * Added support for the optional `--config_root` option.
  * Added help text and documentation describing the command and output.

* **Bug Fixes**
  * Improved error handling when usage statistics cannot be collected.

* **Tests**
  * Verified aggregate results exclude resource names and credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->