### PR TITLE
[Backport into 5.20] CI | Update GitHub actions (#9681) + reduce arm64/ppc64le build time (#9779)

### DIFF
--- a/.github/workflows/Validate-package-lock.yaml
+++ b/.github/workflows/Validate-package-lock.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -3,58 +3,12 @@ on: [pull_request]
 
 jobs:
   build-arm64-image:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      GIT_COMMIT: ${{ github.sha }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
-
-      # Cross-arch build: the job runs on amd64 (ubuntu-latest). We build container
-      # images for linux/arm64. Docker Buildx uses QEMU to emulate that architecture.
-      # The tonistiigi/binfmt image registers the right binary formats and emulators
-      # in the host kernel so "docker build --platform=linux/arm64" (via make) works.
-      - name: Enable emulation
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
-
-      - name: Get Current Date
-        id: date
-        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-
-      - name: Prepare Suffix
-        id: suffix
-        if: ${{ github.event.inputs.tag != '' }}
-        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-
-      - name: Prepare Tags
-        id: prep
-        run: |
-          DOCKER_BASE_IMAGE=noobaa/noobaa-base
-          DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
-          DOCKER_CORE_IMAGE=noobaa/noobaa-core
-          VERSION="${{ steps.date.outputs.date }}"
-          echo "::warning ${VERSION}"
-          BASE_TAGS="${DOCKER_BASE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
-          echo "::warning ${CORE_TAGS}"
-          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
-          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
-          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
-          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Build Builder Images
-        run: CONTAINER_PLATFORM=linux/arm64 make builder
-
-      - name: Build Base Images
-        run: CONTAINER_PLATFORM=linux/arm64 make base
-
-      - name: Build NooBaa Images
-        run: CONTAINER_PLATFORM=linux/arm64 make noobaa
+    uses: ./.github/workflows/build-noobaa-image-reusable.yaml
+    with:
+      container_platform: linux/arm64
+      platform_tag_suffix: -linux-arm64
+      make_target: noobaa
+      enable_binfmt: true

--- a/.github/workflows/build-arm64-image.yaml
+++ b/.github/workflows/build-arm64-image.yaml
@@ -12,7 +12,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/build-noobaa-image-reusable.yaml
+++ b/.github/workflows/build-noobaa-image-reusable.yaml
@@ -1,0 +1,220 @@
+name: Build Noobaa Image
+
+on:
+  workflow_call:
+    inputs:
+      container_platform:
+        description: 'Container platform e.g. linux/arm64; empty = native amd64'
+        type: string
+        default: ''
+      platform_tag_suffix:
+        description: 'Platform suffix for Quay tags e.g. -linux-arm64'
+        type: string
+        default: ''
+      make_target:
+        description: 'Final make target (tester or noobaa)'
+        type: string
+        default: 'noobaa'
+      upload_artifacts:
+        description: 'Upload noobaa and noobaa-tester docker image artifacts'
+        type: boolean
+        default: false
+      enable_binfmt:
+        description: 'Enable QEMU binfmt for cross-arch builds'
+        type: boolean
+        default: false
+      runs_on:
+        description: 'Runner label'
+        type: string
+        default: 'ubuntu-latest'
+
+jobs:
+  build-noobaa-image:
+    name: Build Noobaa Image
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Cross-arch builds on amd64 runners need QEMU binfmt so
+      # "docker build --platform=…" (via make) can emulate the target arch.
+      - name: Enable emulation
+        if: ${{ inputs.enable_binfmt }}
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
+
+      - name: Prepare Tags
+        id: prep
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          PLATFORM_TAG_SUFFIX: ${{ inputs.platform_tag_suffix }}
+        run: |
+          DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
+          DOCKER_BASE_IMAGE=noobaa/noobaa-base
+          if [[ -n "${GITHUB_BASE_REF}" ]]; then
+            BRANCH="${GITHUB_BASE_REF}"
+          else
+            BRANCH="${GITHUB_REF_NAME}"
+          fi
+          PLATFORM_SUFFIX="${PLATFORM_TAG_SUFFIX}"
+          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${BRANCH}${PLATFORM_SUFFIX}-"
+          BASE_TAGS="${DOCKER_BASE_IMAGE}:${BRANCH}${PLATFORM_SUFFIX}-"
+          EARLIEST_VERSION_PAST=20
+          echo "basetags=${BASE_TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "buildertags=${BUILDER_TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "pull_tries=${EARLIEST_VERSION_PAST}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check changed files
+        id: changed_files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: "\n"
+
+      - name: Should build noobaa base image
+        id: should_build_base
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
+        run: |
+          set -f
+          base_files=("package.json" "package-lock.json" "src/deploy/NVA_build/Base.Dockerfile" ".nvmrc" "src/native/fs/fs_napi.cpp")
+          output=false
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            if printf '%s\n' "${base_files[@]}" | grep -x -q "${file}"; then
+              echo "File ${file} has changed, building base image."
+              output=true
+              break
+            fi
+          done <<< "${ALL_CHANGED_FILES}"
+          echo "should_build=${output}" >> "${GITHUB_OUTPUT}"
+
+      - name: Pull noobaa-base image
+        id: pull_base_image
+        if: ${{ steps.should_build_base.outputs.should_build == 'false' }}
+        env:
+          PULL_TRIES: ${{ steps.prep.outputs.pull_tries }}
+          BASE_TAGS: ${{ steps.prep.outputs.basetags }}
+        run: |
+          output=false
+          for i in $(seq 0 "${PULL_TRIES}")
+          do
+            date=$(date -d "${i} days ago" +'%Y%m%d')
+            base_tag="quay.io/${BASE_TAGS}${date}"
+            echo "Trying to pull ${base_tag}"
+            docker pull "${base_tag}" || continue
+            echo "Successfully pulled ${base_tag} from quay.io"
+            docker tag "${base_tag}" noobaa-base
+            output=true
+            break
+          done
+          echo "pull_succeed=${output}" >> "${GITHUB_OUTPUT}"
+
+      - name: Pull noobaa-builder image
+        id: should_build_builder
+        if: ${{ steps.should_build_base.outputs.should_build == 'true' ||
+          steps.pull_base_image.outputs.pull_succeed == 'false' }}
+        env:
+          PULL_TRIES: ${{ steps.prep.outputs.pull_tries }}
+          BUILDER_TAGS: ${{ steps.prep.outputs.buildertags }}
+          ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
+        run: |
+          set -f
+          output=true
+          should_pull=true
+          builder_files=("src/deploy/NVA_build/builder.Dockerfile" ".nvmrc")
+          while IFS= read -r file; do
+            [[ -z "${file}" ]] && continue
+            if printf '%s\n' "${builder_files[@]}" | grep -x -q "${file}"; then
+              echo "File ${file} has changed, building builder image."
+              should_pull=false
+              break
+            fi
+          done <<< "${ALL_CHANGED_FILES}"
+          if [ "$should_pull" = true ]; then
+            for i in $(seq 0 "${PULL_TRIES}")
+            do
+              date=$(date -d "${i} days ago" +'%Y%m%d')
+              builder_tag="quay.io/${BUILDER_TAGS}${date}"
+              echo "Trying to pull ${builder_tag}"
+              docker pull "${builder_tag}" || continue
+              echo "Successfully pulled ${builder_tag} from quay.io"
+              docker tag "${builder_tag}" noobaa-builder
+              output=false
+              break
+            done
+          fi
+          echo "should_build=${output}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build noobaa-builder image
+        if: ${{ (steps.should_build_base.outputs.should_build == 'true' ||
+          steps.pull_base_image.outputs.pull_succeed == 'false') &&
+          steps.should_build_builder.outputs.should_build == 'true' }}
+        env:
+          PLATFORM: ${{ inputs.container_platform }}
+        run: |
+          if [[ -n "${PLATFORM}" ]]; then
+            CONTAINER_PLATFORM="${PLATFORM}" make builder
+          else
+            make builder
+          fi
+
+      - name: Build noobaa-base image
+        if: ${{ steps.should_build_base.outputs.should_build == 'true' ||
+          steps.pull_base_image.outputs.pull_succeed == 'false' }}
+        env:
+          PLATFORM: ${{ inputs.container_platform }}
+          SHOULD_BUILD_BUILDER: ${{ steps.should_build_builder.outputs.should_build }}
+        run: |
+          flags=""
+          if [ "${SHOULD_BUILD_BUILDER}" = 'false' ]; then
+            flags="-o builder"
+          fi
+          if [[ -n "${PLATFORM}" ]]; then
+            CONTAINER_PLATFORM="${PLATFORM}" make base ${flags}
+          else
+            make base ${flags}
+          fi
+
+      - name: Build noobaa image
+        env:
+          PLATFORM: ${{ inputs.container_platform }}
+          MAKE_TARGET: ${{ inputs.make_target }}
+        run: |
+          case "${MAKE_TARGET}" in
+            tester|noobaa) ;;
+            *)
+              echo "Invalid make_target: ${MAKE_TARGET}" >&2
+              exit 1
+              ;;
+          esac
+          if [[ -n "${PLATFORM}" ]]; then
+            CONTAINER_PLATFORM="${PLATFORM}" make "${MAKE_TARGET}" -o base
+          else
+            make "${MAKE_TARGET}" -o base
+          fi
+
+      - name: Create docker artifact
+        if: ${{ inputs.upload_artifacts }}
+        run: |
+          docker save --output noobaa.tar noobaa
+          docker save --output noobaa-tester.tar noobaa-tester
+
+      - name: Upload noobaa docker image
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: noobaa-image
+          path: noobaa.tar
+          retention-days: "1"
+
+      - name: Upload noobaa-tester docker image
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: noobaa-tester
+          path: noobaa-tester.tar
+          retention-days: "1"

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -3,58 +3,12 @@ on: [pull_request]
 
 jobs:
   build-ppc64le-image:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      GIT_COMMIT: ${{ github.sha }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
-
-      # Cross-arch build: the job runs on amd64 (ubuntu-latest). We build container
-      # images for linux/ppc64le. Docker Buildx uses QEMU to emulate that architecture.
-      # The tonistiigi/binfmt image registers the right binary formats and emulators
-      # in the host kernel so "docker build --platform=linux/ppc64le" (via make) works.
-      - name: Enable emulation
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
-
-      - name: Get Current Date
-        id: date
-        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-
-      - name: Prepare Suffix
-        id: suffix
-        if: ${{ github.event.inputs.tag != '' }}
-        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-
-      - name: Prepare Tags
-        id: prep
-        run: |
-          DOCKER_BASE_IMAGE=noobaa/noobaa-base
-          DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
-          DOCKER_CORE_IMAGE=noobaa/noobaa-core
-          VERSION="${{ steps.date.outputs.date }}"
-          echo "::warning ${VERSION}"
-          BASE_TAGS="${DOCKER_BASE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
-          echo "::warning ${CORE_TAGS}"
-          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
-          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
-          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
-          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Build Builder Images
-        run: CONTAINER_PLATFORM=linux/ppc64le make builder
-
-      - name: Build Base Images
-        run: CONTAINER_PLATFORM=linux/ppc64le make base
-
-      - name: Build NooBaa Images
-        run: CONTAINER_PLATFORM=linux/ppc64le make noobaa
+    uses: ./.github/workflows/build-noobaa-image-reusable.yaml
+    with:
+      container_platform: linux/ppc64le
+      platform_tag_suffix: -linux-ppc64le
+      make_target: noobaa
+      enable_binfmt: true

--- a/.github/workflows/build-ppc64le-image.yaml
+++ b/.github/workflows/build-ppc64le-image.yaml
@@ -12,7 +12,7 @@ jobs:
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/ceph-nsfs-s3-tests.yaml
+++ b/.github/workflows/ceph-nsfs-s3-tests.yaml
@@ -11,13 +11,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/ceph-s3-tests.yaml
+++ b/.github/workflows/ceph-s3-tests.yaml
@@ -11,13 +11,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/jest-unit-tests.yaml
+++ b/.github/workflows/jest-unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Jest Unit Test
         run: |

--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -8,16 +8,34 @@ on:
       tag:
         description: 'Additional tag for the build (such as alpha, beta, etc.) - Optional'
         default: ''
+      architecture:
+        description: 'Architecture to build and publish'
+        type: choice
+        options:
+          - amd64
+          - arm64
+          - ppc64le
+          - all
+        default: amd64
 
 jobs:
   manual-build-and-publish-image:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.architecture == 'all' && '[{"arch":"amd64","container_platform":"","platform_tag_suffix":"","enable_binfmt":false},{"arch":"arm64","container_platform":"linux/arm64","platform_tag_suffix":"-linux-arm64","enable_binfmt":true},{"arch":"ppc64le","container_platform":"linux/ppc64le","platform_tag_suffix":"-linux-ppc64le","enable_binfmt":true}]' || inputs.architecture == 'arm64' && '[{"arch":"arm64","container_platform":"linux/arm64","platform_tag_suffix":"-linux-arm64","enable_binfmt":true}]' || inputs.architecture == 'ppc64le' && '[{"arch":"ppc64le","container_platform":"linux/ppc64le","platform_tag_suffix":"-linux-ppc64le","enable_binfmt":true}]' || '[{"arch":"amd64","container_platform":"","platform_tag_suffix":"","enable_binfmt":false}]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
+          persist-credentials: false
+
+      - name: Enable emulation
+        if: ${{ matrix.enable_binfmt }}
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Get Current Date
         id: date
@@ -26,25 +44,31 @@ jobs:
       - name: Prepare Suffix
         id: suffix
         if: ${{ github.event.inputs.tag != '' }}
-        run: echo suffix="-${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: echo "suffix=-${INPUT_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Prepare Tags
         id: prep
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.branch }}
+          VERSION: ${{ steps.date.outputs.date }}
+          PLATFORM_SUFFIX: ${{ matrix.platform_tag_suffix }}
+          TAG_SUFFIX: ${{ steps.suffix.outputs.suffix }}
         run: |
           DOCKER_BASE_IMAGE=noobaa/noobaa-base
           DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
           DOCKER_CORE_IMAGE=noobaa/noobaa-core
-          VERSION="${{ steps.date.outputs.date }}"
           echo "::warning ${VERSION}"
-          BASE_TAGS="${DOCKER_BASE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_TAGS="${DOCKER_CORE_IMAGE}:${{ github.event.inputs.branch }}-${VERSION}${{ steps.suffix.outputs.suffix }}"
-          CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${{ github.event.inputs.branch }}-latest"
+          BASE_TAGS="${DOCKER_BASE_IMAGE}:${INPUT_BRANCH}${PLATFORM_SUFFIX}-${VERSION}${TAG_SUFFIX}"
+          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${INPUT_BRANCH}${PLATFORM_SUFFIX}-${VERSION}${TAG_SUFFIX}"
+          CORE_TAGS="${DOCKER_CORE_IMAGE}:${INPUT_BRANCH}${PLATFORM_SUFFIX}-${VERSION}${TAG_SUFFIX}"
+          CORE_OCS_DEV_TAG="ocs-dev/noobaa-core:${INPUT_BRANCH}-latest"
           echo "::warning ${CORE_TAGS}"
-          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
-          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
-          echo "coretags=${CORE_TAGS}" >> $GITHUB_OUTPUT
-          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> $GITHUB_OUTPUT
+          echo "basetags=${BASE_TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "buildertags=${BUILDER_TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "coretags=${CORE_TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "ocsdevlatest=${CORE_OCS_DEV_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.GHACTIONSDOCKERHUB }} | docker login -u ${{ secrets.GHACTIONSDOCKERHUBNAME }} --password-stdin
@@ -53,7 +77,12 @@ jobs:
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONSDOCKERHUBNAME }}
         run: |
-            make noobaa
+            platform="${{ matrix.container_platform }}"
+            if [[ -n "$platform" ]]; then
+              CONTAINER_PLATFORM="$platform" make noobaa
+            else
+              make noobaa
+            fi
             docker tag noobaa-base ${{ steps.prep.outputs.basetags }}
             docker push ${{ steps.prep.outputs.basetags }}
             docker tag noobaa-builder ${{ steps.prep.outputs.buildertags }}
@@ -76,13 +105,21 @@ jobs:
             docker push quay.io/${{ steps.prep.outputs.coretags }}
 
       - name: Push to ocs-dev as latest
+        if: ${{ matrix.arch == 'amd64' }}
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONQUAYNAME }}
         run: |
           docker login -u="${{ secrets.OCSDEVCIUSER }}" -p="${{ secrets.OCSDEVCITOKEN }}" quay.io
           docker tag ${{ steps.prep.outputs.coretags }} quay.io/${{ steps.prep.outputs.ocsdevlatest }} 
           docker push quay.io/${{ steps.prep.outputs.ocsdevlatest }}
-          
+
+  notify-operator:
+    needs: manual-build-and-publish-image
+    if: |
+      (inputs.architecture == 'amd64' || inputs.architecture == 'all') &&
+      needs.manual-build-and-publish-image.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
       - name: Sleep for 180 seconds
         run: sleep 180s
         shell: bash
@@ -94,6 +131,3 @@ jobs:
           repo: noobaa/noobaa-operator
           token: ${{ secrets.GHACCESSTOKEN }}
           inputs: '{ "branch": "${{ github.event.inputs.branch }}", "tag": "${{ github.event.inputs.tag }}" }'
-      
-
-            

--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/mint-nc-tests.yaml
+++ b/.github/workflows/mint-nc-tests.yaml
@@ -12,13 +12,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/mint-tests.yaml
+++ b/.github/workflows/mint-tests.yaml
@@ -11,13 +11,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/nc_unit.yml
+++ b/.github/workflows/nc_unit.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Nightly Tests
         run: |

--- a/.github/workflows/postgres-unit-tests.yaml
+++ b/.github/workflows/postgres-unit-tests.yaml
@@ -11,10 +11,10 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -22,12 +22,12 @@ jobs:
       - name: Set branch
         run: echo "BRANCH=${{ github.event.inputs.base_branch }}" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH }}
       - name: Fetch all tags
         run: git fetch --force --tags
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
       - name: Release NooBaa Core Image

--- a/.github/workflows/rpm-build-and-install-test-base.yaml
+++ b/.github/workflows/rpm-build-and-install-test-base.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
      

--- a/.github/workflows/rpm-build-base.yaml
+++ b/.github/workflows/rpm-build-base.yaml
@@ -31,7 +31,7 @@ jobs:
       rpm_full_path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
      
@@ -79,7 +79,7 @@ jobs:
           echo "rpm_full_path=${RPM_FULL_PATH}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}
           path: ${{ steps.finalize_full_rpm_path.outputs.rpm_full_path }}

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -1,13 +1,12 @@
 name: Run PR Tests
 on: [pull_request, workflow_dispatch]
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
-    actions: read         # download-artifact
-    contents: read        # required for actions/checkout
+  actions: read # download-artifact
+  contents: read # required for actions/checkout
 jobs:
-
   run-sanity-tests:
     needs: build-noobaa-image
     uses: ./.github/workflows/sanity.yaml
@@ -54,113 +53,7 @@ jobs:
 
   build-noobaa-image:
     name: Build Noobaa Image
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Prepare Tags
-        id: prep
-        run: |
-          DOCKER_BUILDER_IMAGE=noobaa/noobaa-builder
-          DOCKER_BASE_IMAGE=noobaa/noobaa-base
-          if [[ -n "${{github.base_ref}}" ]]; then
-            #on pull request, use target branch
-            BRANCH=${{github.base_ref}}
-          else
-            #on dispach, use the current branch
-            BRANCH=${{github.ref_name}}
-          fi
-          BUILDER_TAGS="${DOCKER_BUILDER_IMAGE}:${BRANCH}-"
-          BASE_TAGS="${DOCKER_BASE_IMAGE}:${BRANCH}-"
-          EARLIEST_VERSION_PAST=20
-          echo "basetags=${BASE_TAGS}" >> $GITHUB_OUTPUT
-          echo "buildertags=${BUILDER_TAGS}" >> $GITHUB_OUTPUT
-          echo "pull_tries=${EARLIEST_VERSION_PAST}" >> $GITHUB_OUTPUT
-
-      - name: Check changed files
-        id: changed_files
-        uses: tj-actions/changed-files@v47
-
-      - name: Should build noobaa base image
-        id: should_build_base
-        run: |
-          base_files=("package.json" "src/deploy/NVA_build/Base.Dockerfile" ".nvmrc" "src/native/fs/fs_napi.cpp")
-          output=false
-          for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
-            if printf '%s\n' "${base_files[@]}" | grep -x -q "$file"; then
-              echo "File ${file} has changed, building base image."
-              output=true
-              break;
-            fi
-          done
-          echo "should_build=${output}" >> $GITHUB_OUTPUT
-
-      - name: Pull noobaa-base image
-        id: pull_base_image
-        if: ${{ steps.should_build_base.outputs.should_build == 'false' }}
-        run: |
-          output=false
-          for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
-          do
-            date=$(date -d "${i} days ago" +'%Y%m%d')
-            base_tag="quay.io/${{ steps.prep.outputs.basetags }}${date}"
-            echo "Trying to pull ${base_tag}"
-            docker pull ${base_tag} || continue
-            echo "Successfully pulled ${base_tag} from quay.io"
-            docker tag ${base_tag} noobaa-base
-            output=true
-            break
-          done
-          echo "pull_succeed=${output}" >> $GITHUB_OUTPUT
-
-      - name: Pull noobaa-builder image
-        id: should_build_builder
-        if: ${{steps.should_build_base.outputs.should_build == 'true' ||
-          steps.pull_base_image.outputs.pull_succeed == 'false'}}
-        run: |
-          output=true
-          for i in $(seq 0 ${{ steps.prep.outputs.pull_tries }})
-          do
-            date=$(date -d "${i} days ago" +'%Y%m%d')
-            builder_tag="quay.io/${{ steps.prep.outputs.buildertags }}${date}"
-            echo "Trying to pull ${builder_tag}"
-            docker pull ${builder_tag} || continue
-            echo "Successfully pulled ${builder_tag} from quay.io"
-            docker tag ${builder_tag} noobaa-builder
-            output=false
-            break
-          done
-          echo "should_build=${output}" >> $GITHUB_OUTPUT 
-
-      - name: Build noobaa-base image
-        if: ${{steps.should_build_base.outputs.should_build == 'true' ||
-          steps.pull_base_image.outputs.pull_succeed == 'false'}}
-        run: |
-          if [ "${{ steps.should_build_builder.outputs.should_build }}" = 'false' ]; then
-            flags="-o builder"
-          fi
-          make base ${flags}
-
-      - name: Build noobaa and tester images
-        run: make tester -o base
-
-      - name: create docker artifact
-        run: |
-          docker save --output noobaa.tar noobaa
-          docker save --output noobaa-tester.tar noobaa-tester
-
-      - name: Upload noobaa docker image
-        uses: actions/upload-artifact@v7
-        with:
-          name: noobaa-image
-          path: noobaa.tar
-          retention-days: "1"
-
-      - name: Upload noobaa-tester docker image
-        uses: actions/upload-artifact@v7
-        with:
-          name: noobaa-tester
-          path: noobaa-tester.tar
-          retention-days: "1"
+    uses: ./.github/workflows/build-noobaa-image-reusable.yaml
+    with:
+      make_target: tester
+      upload_artifacts: true

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Tags
         id: prep
@@ -81,7 +81,7 @@ jobs:
 
       - name: Check changed files
         id: changed_files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v47
 
       - name: Should build noobaa base image
         id: should_build_base
@@ -152,14 +152,14 @@ jobs:
           docker save --output noobaa-tester.tar noobaa-tester
 
       - name: Upload noobaa docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: noobaa-image
           path: noobaa.tar
           retention-days: "1"
 
       - name: Upload noobaa-tester docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: noobaa-tester
           path: noobaa-tester.tar

--- a/.github/workflows/sanity-ssl.yaml
+++ b/.github/workflows/sanity-ssl.yaml
@@ -11,10 +11,10 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -11,10 +11,10 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     # Handle non exempted issues
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         exempt-issue-labels: 'Type:Enhancement, Type:Question, Type:Technical Debt'
         exempt-all-milestones: true
@@ -37,7 +37,7 @@ jobs:
         close-issue-message: 'This issue is stale and had no activity for too long - it will now be closed.'
 
   # Handle exempted issues
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
 
         days-before-stale: 180        

--- a/.github/workflows/test-aws-sdk-clients.yaml
+++ b/.github/workflows/test-aws-sdk-clients.yaml
@@ -13,7 +13,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
@@ -26,7 +26,7 @@ jobs:
 
       - name: Message Slack Webhook
         if: ${{ !success() }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACKWEBHOOKURL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/upload-rpm-to-aws.yaml
+++ b/.github/workflows/upload-rpm-to-aws.yaml
@@ -13,12 +13,12 @@
       timeout-minutes: 90
       steps:
         - name: Download artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v8
           with:
             name: ${{ inputs.rpm_full_path }}
 
         - name: Setup AWS CLI
-          uses: aws-actions/configure-aws-credentials@v4
+          uses: aws-actions/configure-aws-credentials@v6
           with:
             aws-access-key-id: ${{ secrets.NEWAWSPROJKEY }}
             aws-secret-access-key: ${{ secrets.NEWAWSPROJSECRET }}

--- a/.github/workflows/warp-nc-tests.yaml
+++ b/.github/workflows/warp-nc-tests.yaml
@@ -12,13 +12,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/warp-tests.yaml
+++ b/.github/workflows/warp-tests.yaml
@@ -11,13 +11,13 @@ jobs:
       contents: read        # required for actions/checkout
     steps:
       - name: Checkout noobaa-core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'noobaa/noobaa-core'
           path: 'noobaa-core'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: noobaa-tester
           path: /tmp

--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -14,4 +14,4 @@ jobs:
           workflow: Manual Build Dispatch
           repo: noobaa/noobaa-core
           token: ${{ secrets.GHACCESSTOKEN }}
-          inputs: '{ "branch": "master", "tag": "" }' 
+          inputs: '{ "branch": "master", "tag": "", "architecture": "all" }'


### PR DESCRIPTION
### Explain the Changes
Backport of:
1. https://github.com/noobaa/noobaa-core/pull/9681 — Update all GitHub actions to the latest
2. https://github.com/noobaa/noobaa-core/pull/9779 — CI | Reducing build time of arm64 and ppc64le

Two commits kept in order (oldest first):
1. Update all GitHub actions to the latest (cherry-picked from ca88c08675c3907ca36bcdd1837feac6162bee41)
2. CI | Reducing build time of arm64 and ppc64le (cherry-picked from bb710fbdf082e49bb893729dd81795a632b7e4b5)

## Test plan
- [ ] CI passes on this PR
- [ ] arm64 / ppc64le image jobs use the reusable workflow and pull base when possible
- [ ] Manual Build Dispatch still works for the release branch