### PR TITLE
allow removing GOVERNANCE retention with empty Retention body

### DIFF
--- a/src/endpoint/s3/ops/s3_put_object_retention.js
+++ b/src/endpoint/s3/ops/s3_put_object_retention.js
@@ -10,26 +10,31 @@ const s3_utils = require('../s3_utils');
 async function put_object_retention(req) {
     // TODO: may require at the future Content-MD5 support
     if (!req.body.Retention) throw new S3Error(S3Error.MalformedXML);
-    const mode = req.body.Retention.Mode[0];
-    let retain_until_date = req.body.Retention.RetainUntilDate[0];
-    if (!mode && !retain_until_date) throw new S3Error(S3Error.AccessDenied);
-    if (!mode || !retain_until_date) throw new S3Error(S3Error.MalformedXML);
-    retain_until_date = new Date(req.body.Retention.RetainUntilDate[0]);
 
-    const bypass_governance = req.headers['x-amz-bypass-governance-retention'] && req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE';
+    const bypass_governance = req.headers['x-amz-bypass-governance-retention'] &&
+        req.headers['x-amz-bypass-governance-retention'].toUpperCase() === 'TRUE';
 
-    if (s3_utils._is_valid_retention(mode, retain_until_date)) {
-        await req.object_sdk.put_object_retention({
-            bucket: req.params.bucket,
-            key: req.params.key,
-            version_id: s3_utils.parse_version_id(req.query.versionId),
-            bypass_governance,
-            retention: {
-                mode,
-                retain_until_date,
-            }
-        });
+    const mode = req.body.Retention.Mode && req.body.Retention.Mode[0];
+    const retain_until_date_str = req.body.Retention.RetainUntilDate && req.body.Retention.RetainUntilDate[0];
+
+    let retention;
+    if (!mode && !retain_until_date_str) {
+        retention = {};
+    } else if (!mode || !retain_until_date_str) {
+        throw new S3Error(S3Error.MalformedXML);
+    } else {
+        const retain_until_date = new Date(retain_until_date_str);
+        if (!s3_utils._is_valid_retention(mode, retain_until_date)) return;
+        retention = { mode, retain_until_date };
     }
+
+    await req.object_sdk.put_object_retention({
+        bucket: req.params.bucket,
+        key: req.params.key,
+        version_id: s3_utils.parse_version_id(req.query.versionId),
+        bypass_governance,
+        retention,
+    });
 }
 
 module.exports = {

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -84,8 +84,10 @@ const XATTR_DIR_CONTENT = XATTR_NOOBAA_INTERNAL_PREFIX + 'dir_content';
 const XATTR_NON_CURRENT_TIMESTASMP = XATTR_NOOBAA_INTERNAL_PREFIX + 'non_current_timestamp';
 const XATTR_TAG = XATTR_NOOBAA_INTERNAL_PREFIX + 'tag.';
 const XATTR_LEGAL_HOLD = XATTR_NOOBAA_INTERNAL_PREFIX + 'legal_hold';
-const XATTR_RETENTION_MODE = XATTR_NOOBAA_INTERNAL_PREFIX + 'retention_mode';
-const XATTR_RETENTION_DATE = XATTR_NOOBAA_INTERNAL_PREFIX + 'retention_date';
+// prefix used by set_fs_xattr_op to clear all retention xattrs by prefix
+const XATTR_RETENTION_PREFIX = XATTR_NOOBAA_INTERNAL_PREFIX + 'retention_';
+const XATTR_RETENTION_MODE = XATTR_RETENTION_PREFIX + 'mode';
+const XATTR_RETENTION_DATE = XATTR_RETENTION_PREFIX + 'date';
 const HIDDEN_VERSIONS_PATH = '.versions';
 const NULL_VERSION_ID = 'null';
 const NULL_VERSION_SUFFIX = '_' + NULL_VERSION_ID;
@@ -2399,24 +2401,29 @@ class NamespaceFS {
     /**
      * check if the object retention lock settings can be updated to the new retention settings. if not, will throw AccessDenied error
      * the rules are:
-     * 1. if the new retention is longer than the current retention, it can be updated (can increase retention time)
-     * 2. if the new retention is shorter than the current retention, it cannot be updated and will throw error, unless the user has bypass_governance permission and the current retention mode is GOVERNANCE
+     * 1. if new_retention is omitted/empty, retention is being cleared — same bypass rules as delete protection
+     * 2. if the new retention is longer than the current retention, it can be updated (can increase retention time)
+     * 3. if the new retention is shorter than the current retention, it cannot be updated and will throw error, unless the user has bypass_governance permission and the current retention mode is GOVERNANCE
      * @param {Object} current_retention - current object retention lock settings
-     * @param {Object} new_retention - new object retention lock settings
+     * @param {Object} [new_retention] - new object retention lock settings; omit/empty to clear retention
      * @param {boolean} bypass_governance - if true, and user has permission to use this flag, will allow to bypass governance mode retention lock. compliance mode retention lock cannot be bypassed.
      * @throws {S3Error.AccessDenied} if the object is protected by object lock and the user does not have permission to bypass the lock
      */
     _compare_object_retention(fs_context, current_retention, new_retention, bypass_governance) {
-        if (current_retention) {
-            const retain_until_date = new Date(current_retention.retain_until_date);
-            const new_date = new Date(new_retention.retain_until_date);
-            //can always increase retention time when mode is unchanged
-            if (new_date >= retain_until_date && new_retention.mode === current_retention.mode) return;
-            bypass_governance = bypass_governance && this._has_bypass_governance_permission(fs_context);
-            if (current_retention.mode === 'COMPLIANCE' ||
-                (current_retention.mode === 'GOVERNANCE' && !bypass_governance)) {
-                throw new S3Error(S3Error.AccessDeniedObjectLocked);
-            }
+        if (!current_retention) return;
+        // empty retention object means clear — enforce bypass rules before removing
+        if (!new_retention.mode && !new_retention.retain_until_date) {
+            this._check_object_retention(fs_context, current_retention, bypass_governance);
+            return;
+        }
+        const retain_until_date = new Date(current_retention.retain_until_date);
+        const new_date = new Date(new_retention.retain_until_date);
+        //can always increase retention time when mode is unchanged
+        if (new_date >= retain_until_date && new_retention.mode === current_retention.mode) return;
+        bypass_governance = bypass_governance && this._has_bypass_governance_permission(fs_context);
+        if (current_retention.mode === 'COMPLIANCE' ||
+            (current_retention.mode === 'GOVERNANCE' && !bypass_governance)) {
+            throw new S3Error(S3Error.AccessDeniedObjectLocked);
         }
     }
 
@@ -2518,14 +2525,19 @@ class NamespaceFS {
         const fs_context = this.prepare_fs_context(object_sdk);
         const file_path = await this._find_version_path(fs_context, params, true);
         await this._check_path_in_bucket_boundaries(fs_context, file_path);
+        const is_clear = !params.retention.mode && !params.retention.retain_until_date;
         try {
             const stat = await nb_native().fs.stat(fs_context, file_path);
             const current_retention = this._get_retention_mode_from_xattr(stat.xattr);
             this._compare_object_retention(fs_context, current_retention, params.retention, params.bypass_governance);
-            const fs_xattr = {};
-            fs_xattr[XATTR_RETENTION_MODE] = params.retention.mode;
-            fs_xattr[XATTR_RETENTION_DATE] = params.retention.retain_until_date.toISOString();
-            await this.set_fs_xattr_op(fs_context, file_path, fs_xattr, undefined);
+            if (is_clear) {
+                await this.set_fs_xattr_op(fs_context, file_path, undefined, XATTR_RETENTION_PREFIX);
+            } else {
+                const fs_xattr = {};
+                fs_xattr[XATTR_RETENTION_MODE] = params.retention.mode;
+                fs_xattr[XATTR_RETENTION_DATE] = params.retention.retain_until_date.toISOString();
+                await this.set_fs_xattr_op(fs_context, file_path, fs_xattr, undefined);
+            }
         } catch (err) {
             dbg.error(`NamespaceFS.put_object_retention: failed for file ${file_path} with error: `, err);
             throw native_fs_utils.translate_error_codes(err, native_fs_utils.entity_enum.OBJECT);

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -193,7 +193,6 @@ async function get_object_tagging(req) {
     };
 }
 
-
 /**
  *
  * delete_object_tagging
@@ -346,17 +345,30 @@ async function put_object_retention(req) {
     if (!req.bucket.object_lock_configuration || req.bucket.object_lock_configuration.object_lock_enabled !== 'Enabled') {
         throw new RpcError('INVALID_REQUEST');
     }
-    const current_retention = info.lock_settings?.retention;
     const new_retention = req.rpc_params.retention;
+    const is_clear = !new_retention.mode && !new_retention.retain_until_date;
+    const current_retention = info.lock_settings?.retention;
     _throw_if_retention_update_forbidden({
         key: obj.key,
         obj_id: info.obj_id,
         current_retention,
-        new_retention,
+        new_retention: is_clear ? undefined : new_retention,
         bypass_governance: Boolean(req.rpc_params.bypass_governance),
     });
     const legal_hold_status = info.lock_settings?.legal_hold?.status;
     const legal_hold = legal_hold_status ? { status: legal_hold_status } : undefined;
+    if (is_clear) {
+        if (legal_hold) {
+            await MDStore.instance().update_object_by_id(
+                obj._id, { lock_settings: { legal_hold } }, undefined, undefined
+            );
+        } else {
+            await MDStore.instance().update_object_by_id(
+                obj._id, undefined, { lock_settings: 1 }, undefined
+            );
+        }
+        return;
+    }
     await MDStore.instance().update_object_by_id(
         obj._id, {
             lock_settings: {
@@ -495,7 +507,6 @@ async function _complete_multipart_upload(req) {
     if (req.rpc_params.last_modified_time) {
         set_updates.last_modified_time = new Date(req.rpc_params.last_modified_time);
     }
-
 
     await _put_object_handle_latest_with_retries({ req, put_obj: obj, set_updates, unset_updates });
 
@@ -646,7 +657,6 @@ async function _complete_simple_upload(req) {
     };
 }
 
-
 async function update_bucket_counters({ system, bucket_name, content_type, read_count, write_count }) {
     const bucket = system.buckets_by_name[bucket_name.unwrap()];
     if (!bucket || bucket.deleting) return;
@@ -658,8 +668,6 @@ async function update_bucket_counters({ system, bucket_name, content_type, read_
         write_count,
     });
 }
-
-
 
 /**
  *
@@ -839,7 +847,6 @@ async function get_mapping(req) {
     return { chunks: res_chunks.map(chunk => chunk.to_api()) };
 }
 
-
 /**
  *
  * PUT_MAPPING
@@ -928,7 +935,6 @@ async function read_object_mapping(req) {
         chunks: chunks.map(chunk => chunk.to_api()),
     };
 }
-
 
 /**
  *

--- a/src/test/integration_tests/api/s3/test_s3_worm.js
+++ b/src/test/integration_tests/api/s3/test_s3_worm.js
@@ -566,6 +566,68 @@ mocha.describe('s3 worm', function() {
         });
     });
 
+    mocha.describe('clear GOVERNANCE retention with empty Retention', function() {
+        const CLEAR_RET_KEY = 'clear-retention-test';
+        let clear_ret_version_id;
+
+        mocha.it('should create object with GOVERNANCE retention', async function() {
+            const shortDate = new Date();
+            shortDate.setSeconds(shortDate.getSeconds() + 60);
+            const res = await s3_owner.putObject({
+                Bucket: BKT1,
+                Key: CLEAR_RET_KEY,
+                Body: file_body,
+                ContentType: 'text/plain',
+                ObjectLockMode: 'GOVERNANCE',
+                ObjectLockRetainUntilDate: shortDate
+            });
+            clear_ret_version_id = res.VersionId;
+            assert.ok(res.VersionId);
+        });
+
+        mocha.it('should fail to clear retention without bypass flag', async function() {
+            await assert_throws_async(s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: CLEAR_RET_KEY,
+                VersionId: clear_ret_version_id,
+                Retention: {},
+            }), 'AccessDenied', 'Access Denied because object protected by object lock.');
+        });
+
+        mocha.it('should clear GOVERNANCE retention with bypass flag', async function() {
+            const res = await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: CLEAR_RET_KEY,
+                VersionId: clear_ret_version_id,
+                Retention: {},
+                BypassGovernanceRetention: true,
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+
+        mocha.it('should confirm retention is cleared', async function() {
+            await assert_throws_async(s3_owner.getObjectRetention({
+                Bucket: BKT1,
+                Key: CLEAR_RET_KEY,
+                VersionId: clear_ret_version_id,
+            }), 'NoSuchObjectLockConfiguration', 'The specified object does not have a ObjectLock configuration');
+        });
+
+        mocha.it('should be able to set retention again after clearing', async function() {
+            const newDate = new Date();
+            newDate.setDate(newDate.getDate() + 1);
+            const res = await s3_owner.putObjectRetention({
+                Bucket: BKT1,
+                Key: CLEAR_RET_KEY,
+                VersionId: clear_ret_version_id,
+                Retention: { Mode: 'GOVERNANCE', RetainUntilDate: newDate },
+            });
+            delete res.$metadata;
+            assert.deepEqual(res, {});
+        });
+    });
+
     mocha.describe('legal hold toggle (on/off)', function() {
         const LEGAL_HOLD_TOGGLE_KEY = 'legal-hold-toggle-test';
         let legal_hold_toggle_version_id;


### PR DESCRIPTION
## Summary
- [DFBUGS-8949](https://redhat.atlassian.net/browse/DFBUGS-8949)
- PutObjectRetention with `--retention '{}'` (empty `<Retention/>` XML) crashed with `TypeError: Cannot read properties of undefined (reading '0')` which surfaced as `InternalError` to the client.
- Root cause: the handler unconditionally accessed `.Mode[0]` and `.RetainUntilDate[0]` without null checks, and had no codepath for clearing retention.
- Fix adds safe property access, an "empty Retention = clear retention" path at the S3 endpoint, namespace_fs, and object_server layers, and makes the `retention` RPC param optional.

## Tested on live cluster

Verified on a remote IBM Cloud OpenShift cluster (`shirshfe-5ibm05.ibmcloud2.qe.rh-ocs.com`, amd64, RHCOS 10.2) by hot-patching JS files into the running endpoint pod:

| # | Test | Expected | Result |
|---|------|----------|--------|
| 1 | Clear GOVERNANCE retention with `--bypass-governance-retention --retention '{}'` | Success (was InternalError before fix) | **PASS** |
| 2 | `get-object-retention` after clearing | `NoSuchObjectLockConfiguration` | **PASS** |
| 3 | Re-apply GOVERNANCE retention (normal set path) | Success | **PASS** |
| 4 | Verify retention was set correctly | Shows GOVERNANCE mode + date | **PASS** |
| 5 | Clear retention WITHOUT bypass (GOVERNANCE active) | `AccessDenied` | **PASS** |
| 6 | Clear retention WITH bypass | Success | **PASS** |
| 7 | Confirm retention removed | `NoSuchObjectLockConfiguration` | **PASS** |

## Test plan

- [x] `aws s3api put-object-retention --retention '{}' --bypass-governance-retention` on a GOVERNANCE-locked object succeeds
- [x] `get-object-retention` after clearing returns `NoSuchObjectLockConfiguration`
- [x] Clearing without `--bypass-governance-retention` on active GOVERNANCE retention returns `AccessDenied`
- [x] Normal set-retention flow (Mode + RetainUntilDate) still works
- [ ] Clearing COMPLIANCE retention (even with bypass) returns `AccessDenied`
- [ ] Legal hold is preserved when retention is cleared
- [ ] Unit/integration tests in `test_s3_worm.js` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for clearing object retention using an empty retention request.
  * Added authorization checks when clearing, shortening, or changing retention settings.
  * Preserved legal holds when clearing retention and improved retention mode transitions.
* **Bug Fixes**
  * Improved handling of missing or empty retention fields.
  * Prevented invalid partial retention requests while maintaining existing date validation.
* **Tests**
  * Added coverage for clearing governance retention, bypass authorization, and switching retention modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->