### PR TITLE
Fixing iam_stats to use his own schema instead of op_stats

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1333,6 +1333,42 @@ module.exports = {
             }
         },
 
+        iam_stats: {
+            type: 'object',
+            properties: {
+                create_user: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                get_user: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                delete_user: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                update_user: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                list_users: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                create_access_key: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                get_access_key_last_used: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                update_access_key: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                delete_access_key: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+                list_access_keys: {
+                    $ref: 'common_api#/definitions/op_stats_val'
+                },
+            }
+        },
+
         fs_workers_stats: {
             type: 'object',
             properties: {

--- a/src/api/stats_api.js
+++ b/src/api/stats_api.js
@@ -161,7 +161,7 @@ module.exports = {
                                 $ref: 'common_api#/definitions/op_stats'
                             },
                             iam_stats: {
-                                $ref: 'common_api#/definitions/op_stats'
+                                $ref: 'common_api#/definitions/iam_stats'
                             },
                             fs_workers_stats: {
                                 $ref: 'common_api#/definitions/fs_workers_stats'


### PR DESCRIPTION
### Describe the Problem
Used op_stats schema used for s3 ops instead of new iam_stats that will be used for iam_stats

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reporting operation statistics for IAM user and access-key actions.

- **Bug Fixes**
  - Improved validation of IAM statistics submitted through the NSFS statistics update API.
  - Ensured IAM-specific metrics are checked against the correct schema for more accurate and reliable statistics updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->