### PR TITLE
CI | fix Quay label rebuild to FROM local image

### DIFF
--- a/.github/workflows/manual-full-build.yaml
+++ b/.github/workflows/manual-full-build.yaml
@@ -96,19 +96,26 @@ jobs:
       - name: Push Docker Images to Quay
         env:
           DOCKERHUB_OWNER: ${{ secrets.GHACTIONQUAYNAME }}
+          CONTAINER_PLATFORM: ${{ matrix.container_platform }}
         run: |
             # Label Quay images before push: expire after 365d, and record short commit SHA
             # (org.opencontainers.image.revision) for scheduled release-branch publish gating.
             # ocs-dev latest tags intentionally omit expiry (rolling operator wiring tag).
+            # FROM must use the local image name (not quay.io/...) so BuildKit does not try
+            # to pull a tag that has not been published yet (breaks arm64/ppc64le).
             IMAGE_REVISION="$(git rev-parse --short=7 HEAD)"
+            platform_args=()
+            if [[ -n "${CONTAINER_PLATFORM}" ]]; then
+              platform_args=(--platform "${CONTAINER_PLATFORM}")
+            fi
             for tag in \
               "${{ steps.prep.outputs.basetags }}" \
               "${{ steps.prep.outputs.buildertags }}" \
               "${{ steps.prep.outputs.coretags }}"
             do
               quay_tag="quay.io/${tag}"
-              docker tag "${tag}" "${quay_tag}"
-              echo "FROM ${quay_tag}" | docker build \
+              echo "FROM ${tag}" | docker build \
+                "${platform_args[@]}" \
                 --label "quay.expires-after=365d" \
                 --label "org.opencontainers.image.revision=${IMAGE_REVISION}" \
                 -t "${quay_tag}" -


### PR DESCRIPTION
## Summary
- Fixes arm64/ppc64le Quay publish failure after the expiry/revision label step
- `docker build` was using `FROM quay.io/...`, so BuildKit tried to pull a tag that did not exist yet
- Use the local image name in `FROM`, and pass `--platform` for cross-arch label rebuilds

## Context
Bootstrap `manual-full-build` after #9920: amd64 Quay publish succeeded; arm64/ppc64le failed on Push Docker Images to Quay with `quay.io/...: not found`.

## Test plan
- [ ] Re-dispatch Manual Build for `architecture: arm64` and `ppc64le` on master (and 5.20–5.22)
- [ ] Confirm Quay tags `*-linux-arm64-YYYYMMDD` / `*-linux-ppc64le-YYYYMMDD` exist with `quay.expires-after=365d` and `org.opencontainers.image.revision`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-platform container image builds and publishing.
  * Ensured builds use the correct locally tagged images as sources.
  * Preserved image metadata labeling and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->