### PR TITLE
DEEP_ARCHIVE | BG Worker Restore - With `GetObject` (Only Small Object and No MPU)

### DIFF
--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -314,6 +314,17 @@ function create_archive_ns_from_info(ns_info) {
 }
 
 /**
+ * Returns a cached NamespaceS3 for the bucket's deep-archive resource.
+ * @param {string} bucket_id
+ * @returns {Promise<NamespaceS3|undefined>}
+ */
+async function get_archive_ns_for_bucket(bucket_id) {
+    const ns_info = get_archive_ns_info_for_bucket(bucket_id);
+    if (!ns_info) return;
+    return archive_ns_cache.get_with_cache({ nsr_id: ns_info.id, ns_info });
+}
+
+/**
  * Deletes remote archive keys for objects of one bucket.
  * Archive keys are unique per object target_bucket/noobaa_storage/bucket_id/obj_id
  * therefore, no need to specify a specific version).
@@ -367,12 +378,11 @@ async function delete_archive_objects(req) {
 async function check_archive_restore_status(req) {
     const { bucket_id, obj_id } = req.rpc_params;
     const archive_key = get_archive_key(bucket_id, obj_id);
-    const ns_info = get_archive_ns_info_for_bucket(bucket_id);
-    if (!ns_info) {
+    const archive_ns = await get_archive_ns_for_bucket(bucket_id);
+    if (!archive_ns) {
         dbg.error(`bucket ${bucket_id} has no archive namespace for restore check`, archive_key);
         throw new Error(`bucket ${bucket_id} has no archive namespace`);
     }
-    const archive_ns = await archive_ns_cache.get_with_cache({ nsr_id: ns_info.id, ns_info });
 
     try {
         const object_md = await archive_ns.read_object_md({
@@ -392,6 +402,35 @@ async function check_archive_restore_status(req) {
     }
 }
 
+/**
+ * Opens a GetObject stream for the object's deep-archive key.
+ * Call this in-process (require + function call), not via rpc_client.archive.
+ * Archive RPC replies are JSON only and cannot carry a live Node.js Readable,
+ * so the restore worker streams bytes by calling this helper in the same process.
+ * @param {{ bucket_id: string|nb.ID, obj_id: string|nb.ID, size: number }} params
+ * @returns {Promise<import('stream').Readable>}
+ */
+async function read_archive_object_stream({ bucket_id, obj_id, size }) {
+    const archive_key = get_archive_key(bucket_id, obj_id);
+    const archive_ns = await get_archive_ns_for_bucket(bucket_id);
+    if (!archive_ns) {
+        dbg.error(`bucket ${bucket_id} has no archive namespace for read`, archive_key);
+        throw new Error(`bucket ${bucket_id} has no archive namespace`);
+    }
+
+    try {
+        return await archive_ns.read_object_stream({
+            bucket: archive_ns.get_bucket(),
+            key: archive_key,
+            size,
+        }, undefined);
+    } catch (err) {
+        dbg.error('read_archive_object_stream failed', archive_key, err);
+        throw err;
+    }
+}
+
 exports.archive_object = archive_object;
 exports.delete_archive_objects = delete_archive_objects;
 exports.check_archive_restore_status = check_archive_restore_status;
+exports.read_archive_object_stream = read_archive_object_stream;

--- a/src/server/bg_services/restore_worker.js
+++ b/src/server/bg_services/restore_worker.js
@@ -7,17 +7,30 @@ const MDStore = require('../object_services/md_store').MDStore;
 const system_store = require('../system_services/system_store').get_instance();
 const system_utils = require('../utils/system_utils');
 const auth_server = require('../common_services/auth_server');
+const server_rpc = require('../server_rpc');
 const deep_archive_utils = require('../../util/deep_archive_utils');
+const { destroy_source_stream } = require('../../util/object_utils');
+const ObjectIO = require('../../sdk/object_io');
+const map_deleter = require('../object_services/map_deleter');
+const archive_server = require('./archive_server');
 const P = require('../../util/promise');
 
 class RestoreWorker {
 
-    constructor({ name, client }) {
+    /**
+     * @param {{ name: string }} params
+     */
+    constructor({ name }) {
         this.name = name;
-        this.client = client;
         this.marker = undefined;
+        this.object_io = new ObjectIO(); // for writing STANDARD restore copies
     }
 
+    /**
+     * Polls objects with restore_status.ongoing and completes restores whose
+     * archive copy is ready by writing a temporary STANDARD copy and updating MD
+     * @returns {Promise<number|undefined>} Delay in ms until the next batch
+     */
     async run_batch() {
         if (!this._can_run()) return;
 
@@ -44,6 +57,10 @@ class RestoreWorker {
         return next_marker ? config.RESTORE_WORKER_BATCH_DELAY : config.RESTORE_WORKER_EMPTY_DELAY;
     }
 
+    /**
+     * True when system_store is loaded and the system is not in maintenance
+     * @returns {boolean}
+     */
     _can_run() {
         if (!system_store.is_finished_initial_load) {
             dbg.log0('RestoreWorker: system_store did not finish initial load');
@@ -56,6 +73,11 @@ class RestoreWorker {
         return true;
     }
 
+    /**
+     * Builds one admin rpc_client for the batch and handles each ongoing object
+     * @param {nb.ObjectMD[]} ongoing_objects
+     * @returns {Promise<{ has_errors: boolean }>}
+     */
     async _handle_ongoing_restores(ongoing_objects) {
         const system = system_store.data.systems[0];
         const auth_token = auth_server.make_auth_token({
@@ -63,11 +85,12 @@ class RestoreWorker {
             account_id: system.owner._id,
             role: 'admin',
         });
+        const rpc_client = server_rpc.rpc.new_client({ auth_token });
 
         let has_errors = false;
         await P.map_with_concurrency(config.RESTORE_WORKER_CONCURRENCY, ongoing_objects, async obj => {
             try {
-                await this._handle_object_restore(obj, auth_token);
+                await this._handle_object_restore(obj, rpc_client);
             } catch (err) {
                 dbg.error(`RestoreWorker: failed handling object ${obj.key} ${obj._id}:`, err);
                 has_errors = true;
@@ -77,29 +100,199 @@ class RestoreWorker {
         return { has_errors };
     }
 
-    async _handle_object_restore(obj, auth_token) {
+    /**
+     * Checks archive restore status and writes the STANDARD restore copy when ready
+     * @param {nb.ObjectMD} obj
+     * @param {nb.APIClient} rpc_client
+     */
+    async _handle_object_restore(obj, rpc_client) {
         const bucket = system_store.data.get_by_id(obj.bucket);
         if (!deep_archive_utils.is_remote_archive_object(obj, bucket)) {
             dbg.warn('RestoreWorker: skipping non-remote-archive object', obj.key, obj._id, obj.storage_class);
             return;
         }
 
-        const { is_restored, size } = await this.client.archive.check_archive_restore_status(
-            { bucket_id: obj.bucket, obj_id: obj._id }, { auth_token });
+        const { is_restored, size } = await rpc_client.archive.check_archive_restore_status(
+            { bucket_id: obj.bucket, obj_id: obj._id });
 
-        if (is_restored) {
-            const log_details = { key: obj.key, obj_id: String(obj._id), bucket: bucket.name.unwrap(), size };
-            if (size > config.RESTORE_WORKER_LARGE_OBJECT_SIZE) {
-                // temporary behavior (logs only) — later: use MPU for large objects.
-                dbg.log0('RestoreWorker: large object restored on deep archive', log_details);
-            } else {
-                // temporary behavior (logs only) — later: GetObject, write STANDARD, update MD expiry.
-                dbg.log0('RestoreWorker: object restored on deep archive', log_details);
-            }
+        if (!is_restored) {
+            dbg.log1('RestoreWorker: restore still ongoing', obj.key, String(obj._id));
             return;
         }
 
-        dbg.log1('RestoreWorker: restore still ongoing', obj.key, String(obj._id));
+        const log_details = { key: obj.key, obj_id: String(obj._id), bucket: bucket.name.unwrap(), size };
+        if (size > config.RESTORE_WORKER_LARGE_OBJECT_SIZE) {
+            dbg.log0('RestoreWorker: large object restored on deep archive, using non-MPU path', log_details);
+            await this._write_standard_restore_copy(obj, bucket, size, rpc_client); // temporary: MPU condition not implemented yet, fallback to the small objects (temporary)
+        } else {
+            dbg.log0('RestoreWorker: object restored on deep archive, writing STANDARD copy', log_details);
+            await this._write_standard_restore_copy(obj, bucket, size, rpc_client);
+        }
+    }
+
+    /**
+     * Writes a temporary STANDARD restore copy from archive when needed, then
+     * sets restore_status to ongoing false with expiry_time
+     * Skips GetObject/rewrite when parts already fully cover the object (retry after MD failure)
+     * @param {nb.ObjectMD} obj
+     * @param {nb.Bucket} bucket
+     * @param {number} size
+     * @param {nb.APIClient} rpc_client
+     */
+    async _write_standard_restore_copy(obj, bucket, size, rpc_client) {
+        dbg.log0('RestoreWorker: starting STANDARD restore copy write',
+            { key: obj.key, obj_id: String(obj._id), bucket: bucket.name.unwrap(), size });
+
+        const params = await this._prepare_restore_copy(obj, bucket, size, rpc_client);
+        const copy_complete = await this._has_complete_restore_copy(obj, params.object_size);
+        dbg.log0('RestoreWorker: restore-copy coverage check', { key: obj.key, obj_id: String(obj._id), copy_complete });
+
+        if (!copy_complete) {
+            await this._clear_previous_restore_copy(obj, params.bucket_name);
+            dbg.log0('RestoreWorker: uploading restore copy from archive',
+                { key: obj.key, obj_id: String(obj._id), bucket: params.bucket_name, size: params.object_size });
+            await this._upload_restore_copy_from_archive(obj, params);
+            dbg.log0('RestoreWorker: restore copy upload finished',
+                { key: obj.key, obj_id: String(obj._id), bucket: params.bucket_name, size: params.object_size });
+        }
+
+        const expires_on = deep_archive_utils.compute_restore_expiry(params.days);
+        dbg.log0('RestoreWorker: updating restore_status',
+            { key: obj.key, obj_id: String(obj._id), bucket: params.bucket_name, expiry_time: expires_on });
+        await this._update_restore_status(rpc_client, { bucket_name: params.bucket_name, key: obj.key, obj_id: obj._id, expires_on });
+        dbg.log0('RestoreWorker: wrote STANDARD restore copy',
+            { key: obj.key, obj_id: String(obj._id), bucket: params.bucket_name, size: params.object_size, expiry_time: expires_on });
+    }
+
+    /**
+     * Validates restore days and size, and returns params for the restore-copy write
+     * @param {nb.ObjectMD} obj
+     * @param {nb.Bucket} bucket
+     * @param {number} size
+     * @param {nb.APIClient} rpc_client
+     * @returns {Promise<{ days: number, bucket_name: string, object_size: number, rpc_client: nb.APIClient }>}
+     */
+    async _prepare_restore_copy(obj, bucket, size, rpc_client) {
+        const days = obj.restore_status?.days;
+        if (!Number.isInteger(days) || days < 1) {
+            throw new Error(`RestoreWorker: missing restore_status.days for object ${obj.key} ${obj._id}`);
+        }
+
+        const object_size = size ?? obj.size;
+        if (!(object_size >= 0)) {
+            throw new Error(`RestoreWorker: invalid object size for ${obj.key} ${obj._id}`);
+        }
+
+        return {
+            days,
+            bucket_name: bucket.name.unwrap(),
+            object_size,
+            rpc_client,
+        };
+    }
+
+    /**
+     * True when committed parts cover [0, object_size) without gaps
+     * For size 0, true when the object has no parts
+     * @param {nb.ObjectMD} obj
+     * @param {number} object_size
+     * @returns {Promise<boolean>}
+     */
+    async _has_complete_restore_copy(obj, object_size) {
+        if (object_size === 0) {
+            return !(await MDStore.instance().has_any_parts_for_object(obj));
+        }
+        const parts = await MDStore.instance().find_parts_sorted_by_start({ obj_id: obj._id });
+        if (!parts.length) return false;
+
+        let covered_until = 0; // the end of the contiguous byte range covered so far
+        for (const part of parts) {
+            if (part.start > covered_until) return false;
+            if (part.end > covered_until) covered_until = part.end;
+            if (covered_until >= object_size) return true;
+        }
+        return covered_until >= object_size;
+    }
+
+    /**
+     * Clears leftover or partial STANDARD restore-copy parts before rewrite
+     * Does not delete multiparts so archive MPU multipart MD is preserved
+     * Without clearing, a second upload_object_range can add another set of parts for the same ranges
+     * @param {nb.ObjectMD} obj
+     * @param {string} bucket_name
+     */
+    async _clear_previous_restore_copy(obj, bucket_name) {
+        const has_parts = await MDStore.instance().has_any_parts_for_object(obj);
+        if (!has_parts) return;
+        dbg.log0('RestoreWorker: clearing previous restore-copy mappings before rewrite',
+            { key: obj.key, obj_id: String(obj._id), bucket: bucket_name });
+        await map_deleter.delete_object_parts(obj);
+    }
+
+    /**
+     * Streams the restored archive object into NB as a STANDARD restore copy via upload_object_range
+     * @param {nb.ObjectMD} obj
+     * @param {{ bucket_name: string, object_size: number, rpc_client: nb.APIClient }} params
+     */
+    async _upload_restore_copy_from_archive(obj, params) {
+        const { bucket_name, object_size, rpc_client } = params;
+        dbg.log0('RestoreWorker: opening archive object stream',
+            { key: obj.key, obj_id: String(obj._id), bucket: bucket_name, size: object_size });
+
+        const source_stream = await archive_server.read_archive_object_stream({
+            bucket_id: obj.bucket,
+            obj_id: obj._id,
+            size: object_size,
+        });
+
+        dbg.log0('RestoreWorker: archive stream opened, starting upload_object_range',
+            { key: obj.key, obj_id: String(obj._id), bucket: bucket_name, start: 0, end: object_size });
+
+        try {
+            await this.object_io.upload_object_range({
+                client: rpc_client,
+                obj_id: obj._id,
+                bucket: bucket_name,
+                key: obj.key,
+                start: 0,
+                end: object_size,
+                size: object_size,
+                source_stream,
+            });
+        } catch (err) {
+            dbg.error('RestoreWorker: failed writing STANDARD restore copy',
+                { key: obj.key, obj_id: String(obj._id), bucket: bucket_name, size: object_size }, err);
+            destroy_source_stream({ source_stream });
+            throw err;
+        }
+    }
+
+    /**
+     * Updates restore_status to ongoing false with expiry_time, with short retries
+     * @param {nb.APIClient} rpc_client
+     * @param {{ bucket_name: string, key: string, obj_id: nb.ID, expires_on: Date }} params
+     */
+    async _update_restore_status(rpc_client, { bucket_name, key, obj_id, expires_on }) {
+        const RESTORE_MD_UPDATE_ATTEMPTS = 3;
+        const RESTORE_MD_UPDATE_DELAY_MS = 500;
+
+        await P.retry({
+            attempts: RESTORE_MD_UPDATE_ATTEMPTS,
+            delay_ms: RESTORE_MD_UPDATE_DELAY_MS,
+            func: () => rpc_client.object.update_object_md({
+                bucket: bucket_name,
+                key,
+                obj_id,
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: expires_on.getTime(),
+                },
+            }),
+            error_logger: err => dbg.warn('RestoreWorker: update_object_md failed, retrying',
+                { key, obj_id: String(obj_id), bucket: bucket_name }, err),
+        });
+        dbg.log0('RestoreWorker: restore_status updated',
+            { key, obj_id: String(obj_id), bucket: bucket_name, expiry_time: expires_on });
     }
 
 }

--- a/src/server/bg_workers.js
+++ b/src/server/bg_workers.js
@@ -232,7 +232,6 @@ function run_master_workers() {
     if (config.RESTORE_WORKER_ENABLED) {
         register_bg_worker(new RestoreWorker({
             name: 'restore_worker',
-            client: server_rpc.client
         }));
     } else {
         dbg.warn('RESTORE_WORKER NOT ENABLED');

--- a/src/server/object_services/map_deleter.js
+++ b/src/server/object_services/map_deleter.js
@@ -30,6 +30,21 @@ async function delete_object_mappings(obj) {
 }
 
 /**
+ * Soft-delete parts and unreferenced chunks only (no multiparts)
+ * Used when clearing a temporary STANDARD restore copy so archive MPU multipart MD is preserved
+ * It is a copy of delete_object_mappings but without deleting multiparts
+ * @param {nb.ObjectMD} obj
+ */
+async function delete_object_parts(obj) {
+    if (!obj || obj.delete_marker) return;
+    const [chunk_ids] = await Promise.all([
+        MDStore.instance().find_parts_chunk_ids(obj),
+        MDStore.instance().delete_parts_of_object(obj),
+    ]);
+    await delete_chunks_if_unreferenced(chunk_ids);
+}
+
+/**
  * Soft-delete multipart MD only (no parts/chunks). Used for remote-archive
  * objects that never had a local restore copy (e.g. aborted archive MPU).
  * @param {nb.ObjectMD} obj
@@ -170,6 +185,7 @@ async function delete_blocks_from_node(blocks) {
 
 // EXPORTS
 exports.delete_object_mappings = delete_object_mappings;
+exports.delete_object_parts = delete_object_parts;
 exports.delete_object_multiparts = delete_object_multiparts;
 exports.delete_object_if_no_parts = delete_object_if_no_parts;
 exports.delete_chunks_if_unreferenced = delete_chunks_if_unreferenced;

--- a/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
@@ -63,9 +63,16 @@ describe('is_restore_active', () => {
 });
 
 describe('compute_restore_expiry', () => {
-    const now = new Date('2026-01-01T00:00:00Z');
+    it('matches AWS 3-day restore example', () => {
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/archived-objects.html
+        // Oct 15 10:30 UTC + 3 days -> Oct 19 00:00 UTC
+        const now = new Date('2012-10-15T10:30:00.000Z');
+        const res = deep_archive_utils.compute_restore_expiry(3, now);
+        expect(res.toISOString()).toBe('2012-10-19T00:00:00.000Z');
+    });
 
-    it('adds days relative to now', () => {
+    it('keeps exact midnight UTC without adding another day', () => {
+        const now = new Date('2026-01-01T00:00:00.000Z');
         const res = deep_archive_utils.compute_restore_expiry(7, now);
         expect(res.toISOString()).toBe('2026-01-08T00:00:00.000Z');
     });

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -4,6 +4,7 @@
 const dbg = require('../util/debug_module')(__filename);
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { GLACIER_STORAGE_CLASSES } = require('../endpoint/s3/s3_utils');
+const { round_up_to_next_time_of_day } = require('../util/time_utils');
 
 const NB_INTERNAL_STORAGE_DIR = 'noobaa_storage/';
 
@@ -66,14 +67,16 @@ function is_restore_active(restore_status, now = new Date()) {
 }
 
 /**
- * Computes restore expiry as now + days.
+ * Computes restore expiry as now + days, rounded up to the next midnight UTC
  * @param {number} days
  * @param {Date} [now]
  * @returns {Date}
  */
 function compute_restore_expiry(days, now = new Date()) {
     const MS_PER_DAY = 24 * 60 * 60 * 1000;
-    return new Date(now.getTime() + days * MS_PER_DAY);
+    const expires_on = new Date(now.getTime() + days * MS_PER_DAY);
+    round_up_to_next_time_of_day(expires_on, 0, 0, 0, 'UTC');
+    return expires_on;
 }
 
 


### PR DESCRIPTION
### Describe the Problem
Implement the BG Worker Restore with `GetObject`- as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)
Note: The BG worker currently does not handle MPU (multipart upload) and falls back to `GetObject`.

### Explain the Changes
1. Add the function `read_archive_object_stream` so we can use `GetObject` in the namespace. Also, added helper function `get_archive_ns_for_bucket`.
2. Add the implementation for small objects (less than 5 GiB): get object -> write the data to `STANDARD` -> update restore status (ongoing to `false`, expiry_time).
3. Edited the `RestoreWorker` so we will have the ability to write the data on `STANDARD` call; hence added the property  `object_io`. Also,  removed unused property `client`.
4. Fixed the function `compute_restore_expiry` so it will always return the midnight hour rounded up (align with AWS [example](https://docs.aws.amazon.com/AmazonS3/latest/userguide/archived-objects.html)).
5. Added the function `delete_object_parts` in `map_deleter` which is a copy of the function `delete_object_mappings` without deleting multiparts.

### Issues:
List of GAPs:
1.  Implementation of BG Worker of `GetObject` from the archive by range for all cases that would also include handling MPU (multipart upload) for object restore (see [comment](https://github.com/noobaa/noobaa-core/pull/9929#discussion_r3756556716)).
2.  Integration tests for the new BG worker (see [comment](https://github.com/noobaa/noobaa-core/pull/9929#discussion_r3749530635)) and slao test for specific scenarios (see [comment](https://github.com/noobaa/noobaa-core/pull/9929#pullrequestreview-4916675641)).
3. Race condition in the copied function in `map_deleter.js` (originally was in the function `delete_object_mappings`), see [comment](https://github.com/noobaa/noobaa-core/pull/9929#discussion_r3757305712), and issue #9939.
4. We might want to pass the RPC client that has admin auth before creating the BG Worker Restore (see [comment](https://github.com/noobaa/noobaa-core/pull/9929#discussion_r3756465429)).
5. The current code is based on the implementation on backingstore - currently we imported `ObjectIO` and we might need to use `object_sdk` so we can use namespacestore as well (generic code).


Planned following PR:
- To read the archive resource by range (GetObject).
- Add cap for failures so we will not getObject and cleanup the parts on consistent failure (for example, using noobaa-core pod with insufficient memory resource).

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js`

#### Manual Tests
The full testing instructions are in the [comment](https://github.com/noobaa/noobaa-core/pull/9929#issuecomment-5270405590) below.
Could not have a full test; added code to have hacks so I can test the code.

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Completed archive restores now create standard storage copies with validated metadata.
- Archived objects are streamed directly into storage during restoration.
- Restore status now includes an expiration date.

## Bug Fixes
- Improved handling of incomplete or existing restore mappings.
- Restore expiration times now round up to midnight UTC.
- Added retry and cleanup handling for restore failures.
- Improved cleanup of object parts while preserving multipart metadata.
- Improved archive object retrieval and restore-status resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->