### PR TITLE
fix logs sidecar hang on SIGTERM by adding PID 1 shutdown handler

### DIFF
--- a/src/deploy/NVA_build/logrotate.sh
+++ b/src/deploy/NVA_build/logrotate.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Forward termination to background sleep/segregate loops so parent wait can finish.
+trap 'kill $(jobs -p) 2>/dev/null; wait; exit 0' TERM INT
+
 # Run log segregation every 5 minutes in the background.
 # Using a loop instead of crontab because the container runs as a non-root user
 # with all capabilities dropped, which prevents writing to /var/spool/cron/.

--- a/src/deploy/NVA_build/noobaa_logs.sh
+++ b/src/deploy/NVA_build/noobaa_logs.sh
@@ -20,6 +20,16 @@ chmod 777 /var/log/noobaa_bucket_logs
 mkdir -p /log/noobaa_bucket_logs
 chmod 777 /log/noobaa_bucket_logs
 
+# PID 1 must install a SIGTERM handler; otherwise Linux ignores SIGTERM and the
+# container only dies after kubelet SIGKILL.
+# logrotate.sh runs infinite sleep loops that would otherwise keep `wait` blocked.
+shutdown_handler() {
+    # Signal every other process in this container (sleep loops, rsyslog, logrotate).
+    kill -TERM -1 2>/dev/null || true
+    wait
+    exit 0
+}
+trap shutdown_handler TERM INT
 
 mkdir -p /var/log/rsyslog
 /usr/sbin/rsyslogd -i /var/log/rsyslogd.pid &


### PR DESCRIPTION
### Describe the Problem
The bucket-logs sidecar entrypoint (noobaa_logs.sh) is PID 1. On Linux, PID 1 ignores SIGTERM unless it installs a handler. When Kubernetes stops the pod it sends SIGTERM, waits for the grace period, then force-kills with SIGKILL.

So pod delete looked stuck for the full grace period even though nothing important was still running. A second issue: logrotate.sh keeps infinite sleep loops in the background; without forwarding the signal, those children can keep the parent blocked on wait.

### Explain the Changes
1. Add a SIGTERM/SIGINT handler in noobaa_logs.sh that signals other processes in the container, waits for them to exit, then exits cleanly.
2. Add a matching trap in logrotate.sh so its background segregate/sleep loop is stopped when the parent is terminated.

### Issues: Fixed #xxx / Gap #xxx

### Testing Instructions:
manual tests:
1. Run NooBaa in a Kubernetes environment with the updated image.
2. Delete the core pod (kubectl delete pod noobaa-core-0).
3. Confirm the pod finishes deleting within a few seconds and does not stay in Terminating until the grace period / SIGKILL.  


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for deployment and logging processes.
  * Ensured child and container processes receive termination signals and exit cleanly.
  * Reduced the risk of lingering processes during interrupted or terminated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->