### PR TITLE
NC | Fixing account schema to support supplemental_groups

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1640,6 +1640,9 @@ module.exports = {
                     distinguished_name: { wrapper: SensitiveString },
                     new_buckets_path: { type: 'string' },
                     nsfs_only: { type: 'boolean' },
+                    supplemental_groups: {
+                        $ref: '#/definitions/supplemental_groups'
+                    },
                     custom_bucket_path_allowed_list: { type: 'string' },
                 }
             }]

--- a/src/server/system_services/schemas/nsfs_account_schema.js
+++ b/src/server/system_services/schemas/nsfs_account_schema.js
@@ -96,6 +96,9 @@ module.exports = {
                 required: [ 'distinguished_name'],
                 properties: {
                     distinguished_name: { type: 'string' },
+                    supplemental_groups: {
+                        $ref: 'common_api#/definitions/supplemental_groups'
+                    },
                     new_buckets_path: { type: 'string' },
                     fs_backend: {
                         $ref: 'common_api#/definitions/fs_backend'

--- a/src/test/unit_tests/nc/configuration/test_nc_nsfs_account_schema_validation.test.js
+++ b/src/test/unit_tests/nc/configuration/test_nc_nsfs_account_schema_validation.test.js
@@ -31,6 +31,24 @@ describe('schema validation NC NSFS account', () => {
             nsfs_schema_utils.validate_account_schema(account_data);
         });
 
+        it('nsfs_account_config with uid, gid and supplemental_groups', () => {
+            const account_data = get_account_data();
+            // @ts-ignore
+            account_data.nsfs_account_config.supplemental_groups = [7001, 7002];
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
+        it('nsfs_account_config with distinguished_name and supplemental_groups', () => {
+            const account_data = get_account_data();
+            delete account_data.nsfs_account_config;
+            account_data.nsfs_account_config = {
+                // @ts-ignore
+                distinguished_name: distinguished_name,
+                supplemental_groups: [7001],
+            };
+            nsfs_schema_utils.validate_account_schema(account_data);
+        });
+
         it('nsfs_account_config with fs_backend', () => {
             const account_data = get_account_data();
             // @ts-ignore


### PR DESCRIPTION
### Describe the Problem
We were missing support for supplemental_groups + distinguished_name in the schema (we do support it in object.sdk)

### Explain the Changes
1. Fixed the schema for both NC and NSFS
2. Added a test

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-9719

### Testing Instructions:
Add
1. `noobaa-cli account add --name suppuser2 --fs_backend GPFS --user suppuser --new_buckets_path /mnt/gpfs0/suppuser3 --supplemental_groups "7001"` - see you don't get schema errors
or Update:
1. `noobaa-cli account add --name suppuser1 --fs_backend GPFS --user suppuser --new_buckets_path /mnt/gpfs0/suppuser2`
2. `noobaa-cli account update --name suppuser1 --supplemental_groups '7001'` - again no schema


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NSFS account configurations using distinguished names can now include optional supplemental groups.

* **Tests**
  * Added validation coverage for configurations combining supplemental groups with UID/GID and distinguished-name settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->