### PR TITLE
Resolve cached archive namespace resource

### DIFF
--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -89,11 +89,6 @@ async function archive_object(req) {
             object_io,
         });
 
-        const bucket = system_store.data.get_by_id(bucket_id);
-        if (!bucket) {
-            throw new Error('archive_object: bucket not found ' + bucket_id);
-        }
-
         const obj_md = await rpc_client.object.read_object_md_by_id({
             obj_id,
         });
@@ -122,8 +117,11 @@ async function archive_object(req) {
             throw new Error('archive_object: unable to fetch chunks for ' + obj_id);
         }
 
-        const dest_ns = get_archive_ns_info_for_bucket(bucket_id);
-        if (dest_ns.is_readonly_namespace()) {
+        const dest_ns = await get_archive_ns_for_bucket(bucket_id);
+        if (!dest_ns) {
+            dbg.error(`archive_object: bucket ${bucket_id} has no archive namespace`);
+            throw new Error(`archive_object: bucket ${bucket_id} has no archive namespace`);
+        } else if (dest_ns.is_readonly_namespace()) {
             throw new RpcError('UNAUTHORIZED', 'archive object requires a writable archive namespace');
         }
 


### PR DESCRIPTION
### Describe the Problem
Update the code to align with new changes while resolving namespace resource for bucket.

### Explain the Changes
1. Call `get_with_cache` to obtain the cached resource.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive operations by resolving the appropriate archive destination before reading object metadata.
  * Added clearer error handling when no archive destination is available for a bucket.
  * Archive operations now support read-only archive destinations without unnecessary rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->