### PR TITLE
DEEP_ARCHIVE | Fix - `read_object_md` To Omit `restore_status` Expiry Invalid or in the Past

### DIFF
--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -123,13 +123,18 @@ class NamespaceMultiStorageClass {
     /////////////////
 
     /**
-     * Reads object metadata from the metadata namespace
+     * Reads object metadata from the metadata namespace.
+     * Omits restore_status when restore is expired or incomplete
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<nb.ObjectInfo>}
      */
     async read_object_md(params, object_sdk) {
-        return this._metadata_ns.read_object_md(params, object_sdk);
+        const object_md = await this._metadata_ns.read_object_md(params, object_sdk);
+        const { restore_status } = object_md;
+
+        return (!restore_status || restore_status.ongoing || is_restore_active(restore_status)) ?
+            object_md : _.omit(object_md, 'restore_status');
     }
 
     /**

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
@@ -61,6 +61,21 @@ function make_msc_fixture({ object_restore_info: object_restore_info_override, a
     };
 }
 
+function make_read_object_md_msc_fixture(object_md) {
+    const read_object_md = jest.fn().mockResolvedValue(object_md);
+    const metadata_ns = { read_object_md };
+    const object_sdk = {};
+
+    const ns_msc = new NamespaceMultiStorageClass({
+        namespace_by_storage_class: {
+            [s3_utils.STORAGE_CLASS_STANDARD]: metadata_ns,
+            [s3_utils.STORAGE_CLASS_DEEP_ARCHIVE]: {},
+        },
+    });
+
+    return { ns_msc, metadata_ns, read_object_md, object_sdk };
+}
+
 describe('NamespaceMultiStorageClass.restore_object', () => {
     const params = { bucket: BUCKET, key: KEY, days: 7 };
 
@@ -307,5 +322,71 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(no_such_object_err);
         expect(update_object_md).not.toHaveBeenCalled();
         expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+});
+
+describe('NamespaceMultiStorageClass.read_object_md', () => {
+    const params = { bucket: BUCKET, key: KEY };
+
+    it('omits restore_status when restore expiry_time is in the past', async () => {
+        const { ns_msc, object_sdk } = make_read_object_md_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status: {
+                ongoing: false,
+                expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+            },
+        });
+        const object_md = await ns_msc.read_object_md(params, object_sdk);
+        expect(object_md).not.toHaveProperty('restore_status');
+        expect(object_md.storage_class).toBe(s3_utils.STORAGE_CLASS_DEEP_ARCHIVE);
+    });
+
+    it('returns restore_status when restore is ongoing', async () => {
+        const restore_status = { ongoing: true, days: 7 };
+        const { ns_msc, object_sdk } = make_read_object_md_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const object_md = await ns_msc.read_object_md(params, object_sdk);
+        expect(object_md.restore_status).toEqual(restore_status);
+    });
+
+    it('returns restore_status when temporary restore is still active', async () => {
+        const restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(),
+        };
+        const { ns_msc, object_sdk } = make_read_object_md_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const object_md = await ns_msc.read_object_md(params, object_sdk);
+        expect(object_md.restore_status).toEqual(restore_status);
+    });
+
+    it('omits restore_status when restore failed without expiry_time', async () => {
+        const { ns_msc, object_sdk } = make_read_object_md_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: { ongoing: false },
+        });
+        const object_md = await ns_msc.read_object_md(params, object_sdk);
+        expect(object_md).not.toHaveProperty('restore_status');
+    });
+
+    it('omits restore_status when restore expiry_time is invalid', async () => {
+        const { ns_msc, object_sdk } = make_read_object_md_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: {
+                ongoing: false,
+                expiry_time: 'invalid',
+            },
+        });
+        const object_md = await ns_msc.read_object_md(params, object_sdk);
+        expect(object_md.restore_status).toBeUndefined();
     });
 });


### PR DESCRIPTION
### Describe the Problem
Part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)
In case the object was already restored and its expiry date is in the past, and the BG worker that handles removing the STANDARD copy did not finish removing it, we would like to avoid head-object calls that would include an expiry date in the past (property and header).

### Explain the Changes
1. Edit the function `read_object_md` instead of being just a passthrough to the metadata namespace to omit the `restore_status` in case the expiry is invalid or in the past.
2. Added AI-generated tests.

### Issues: 
List of GAPs:
1. We handled the call for HeadObject, but when listing objects with, for example: `s3 s3api list-objects-v2 --bucket <bucket name> --optional-object-attributes RestoreStatus`, it is not handled here.

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Object metadata now omits restore status when no restore is active or when restore information has expired or is invalid.
  * Restore status remains available for active and ongoing restores.

* **Tests**
  * Added coverage for active, ongoing, expired, missing-expiry, and invalid-expiry restore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->