### PR TITLE
RPC: pass optional default_handler to register_http_transport

### DIFF
--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -3,6 +3,10 @@
 
 /** @typedef {import('./rpc_base_conn')} RpcBaseConnection */
 /** @typedef {import('./rpc_schema')} RpcSchema */
+/** @typedef {import('http').Server} HttpServer */
+/** @typedef {import('http').IncomingMessage} HttpIncomingMessage */
+/** @typedef {import('http').ServerResponse} HttpServerResponse */
+/** @typedef {(req: HttpIncomingMessage, res: HttpServerResponse) => void} HttpDefaultHandler */
 
 const _ = require('lodash');
 const util = require('util');
@@ -848,12 +852,14 @@ class RPC extends EventEmitter {
 
     /**
      * register_http_transport
+     * @param {HttpServer} server
+     * @param {HttpDefaultHandler} [default_handler]
      */
-    register_http_transport(server) {
+    register_http_transport(server, default_handler) {
         dbg.log0('RPC register_http_transport');
         const http_server = new RpcHttpServer();
         http_server.on('connection', conn => this._accept_new_connection(conn));
-        http_server.install_on_server(server);
+        http_server.install_on_server(server, default_handler);
         return http_server;
     }
 


### PR DESCRIPTION
### Describe the Problem
The RPC is the gateway for HTTP traffic. When calling a non-RPC call (have no `/rpc/`), use the default `web_handler`
Currently, Express is handling the default web server.
If we remove Express, it will lead to 404 as Express handles the default `web_handler`.

We might want to consider reversing this and letting HTTP not be gated in the RPC, but for know we will keep the RPC as a gateway, and only add a `default_handler` as an option, so it will be able to pass it on to the `install_on_server` and not get 404

### Explain the Changes
Expose RpcHttpServer.install_on_server default_handler through
register_http_transport so callers can serve non-/rpc/ HTTP routes on
the same server without Express.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP transport registration now supports an optional default handler for requests without a dedicated route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->