### PR TITLE
Deep Archive | Buckets Reclaimer shouldn't hard delete bucket with archive policy

### DIFF
--- a/src/server/bg_services/buckets_reclaimer.js
+++ b/src/server/bg_services/buckets_reclaimer.js
@@ -8,6 +8,9 @@ const system_utils = require('../utils/system_utils');
 const P = require('../../util/promise');
 const auth_server = require('../common_services/auth_server');
 const tier_server = require('../system_services/tier_server');
+const { MDStore } = require('../object_services/md_store');
+const COMMON_CONSTANTS = require('../../common/constants');
+const ARCHIVE_STORAGE_CLASSES = Object.values(COMMON_CONSTANTS.ARCHIVE.STORAGE_CLASS);
 
 class BucketsReclaimer {
 
@@ -43,6 +46,10 @@ class BucketsReclaimer {
                     })
                 });
                 if (is_empty) {
+                    if (await this._should_wait_for_archive_reclaim(bucket)) {
+                        dbg.log0(`bucket ${bucket.name} has unreclaimed archive objects; waiting for ObjectsReclaimer`);
+                        return;
+                    }
                     dbg.log0(`bucket ${bucket.name} is empty. calling delete_bucket`);
                     this._add_bucket_to_delete_lists(bucket);
                 } else {
@@ -96,6 +103,18 @@ class BucketsReclaimer {
     _get_deleting_buckets() {
         // return buckets that has the deleting flag set
         return system_store.data.buckets.filter(bucket => Boolean(bucket.deleting));
+    }
+
+    /**
+     * Keep archive buckets until ObjectsReclaimer finishes remote deletes for
+     * unreclaimed GLACIER/DEEP_ARCHIVE objects. Removing the bucket earlier
+     * drops archive_policy and orphans archive keys.
+     * @param {nb.Bucket} bucket
+     * @returns {Promise<boolean>}
+     */
+    async _should_wait_for_archive_reclaim(bucket) {
+        if (!bucket.archive_policy?.deep_archive_resource) return false;
+        return MDStore.instance().has_any_unreclaimed_objects_in_bucket_with_storage_class(bucket._id, ARCHIVE_STORAGE_CLASSES);
     }
 
     _add_bucket_to_delete_lists(bucket) {

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -956,6 +956,26 @@ class MDStore {
     }
 
     /**
+     * True when the bucket still has soft-deleted objects with one of the given
+     * storage classes that ObjectsReclaimer has not marked reclaimed yet
+     * (e.g. remote archive keys still pending delete).
+     * @param {nb.ID} bucket_id
+     * @param {string[]} storage_classes - storage classes to match (e.g. ['DEEP_ARCHIVE', 'GLACIER'])
+     * @returns {Promise<boolean>}
+     */
+    async has_any_unreclaimed_objects_in_bucket_with_storage_class(bucket_id, storage_classes) {
+        const obj = await this._objects.findOne({
+            bucket: bucket_id,
+            deleted: { $exists: true },
+            reclaimed: null,
+            storage_class: { $in: storage_classes },
+        }, {
+            preferred_pool: 'read_only',
+        });
+        return Boolean(obj);
+    }
+
+    /**
      * Live objects whose temporary restore has expired (STANDARD restore copy).
      * @param {number} limit
      * @param {Date} [now]

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -173,19 +173,33 @@ async function assert_archived_via_s3({ key, buf, storage_class, bucket = BUCKET
 }
 
 /**
- * Puts a DEEP_ARCHIVE object via S3 and returns its md.
- * @param {{ bucket?: string, key: string, buf: Buffer }} args
+ * Puts an archive storage-class object via S3 and returns its md.
+ * @param {{ bucket?: string, key: string, buf: Buffer, storage_class: string }} args
  * @returns {Promise<object>}
  */
-async function put_deep_archive({ bucket = BUCKET, key, buf }) {
+async function put_archive({ bucket = BUCKET, key, buf, storage_class }) {
     await s3.putObject({
         Bucket: bucket,
         Key: key,
         Body: buf,
         ContentType: 'application/octet-stream',
-        StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        StorageClass: storage_class,
     });
     return rpc_client.object.read_object_md({ bucket, key });
+}
+
+/**
+ * Puts a DEEP_ARCHIVE object via S3 and returns its md.
+ * @param {{ bucket?: string, key: string, buf: Buffer }} args
+ * @returns {Promise<object>}
+ */
+async function put_deep_archive({ bucket = BUCKET, key, buf }) {
+    return put_archive({
+        bucket,
+        key,
+        buf,
+        storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+    });
 }
 
 /**
@@ -246,41 +260,44 @@ async function create_archive_bucket(name) {
 }
 
 /**
- * Soft-deletes all objects on a deleting bucket, runs ObjectsReclaimer while
- * archive_policy is still available, then finishes BucketsReclaimer.
+ * Drive BucketsReclaimer + ObjectsReclaimer like production bg workers until the
+ * deleting bucket is removed and the given objects are marked reclaimed.
+ * BucketsReclaimer soft-deletes objects and keeps archive buckets until
+ * ObjectsReclaimer finishes remote archive deletes.
  * @param {string} bid
  * @param {...string} obj_ids
  * @returns {Promise<void>}
  */
 async function reclaim_deleting_bucket(bid, ...obj_ids) {
-    const deleting_bucket = system_store.data.buckets.find(
-        b => Boolean(b.deleting) && String(b._id) === String(bid)
-    );
-    assert.ok(deleting_bucket, 'expected bucket to be marked deleting');
-    const deleting_name = deleting_bucket.name.unwrap ?
-        deleting_bucket.name.unwrap() :
-        String(deleting_bucket.name);
-
-    // Soft-delete MD without removing the bucket yet (archive_policy still needed).
-    let is_empty = false;
-    while (!is_empty) {
-        const reply = await rpc_client.object.delete_multiple_objects_unordered({
-            bucket: deleting_name,
-            limit: config.BUCKET_RECLAIMER_BATCH_SIZE,
-        });
-        is_empty = reply.is_empty;
-    }
-
-    await run_objects_reclaimer(...obj_ids);
-
+    assert.ok(obj_ids.length, 'reclaim_deleting_bucket requires at least one obj_id');
+    const ids = obj_ids.map(parse_obj_id);
+    const objects_reclaimer = new ObjectsReclaimer({
+        name: 'test_object_reclaimer',
+        client: rpc_client,
+    });
     const buckets_reclaimer = new BucketsReclaimer({
         name: 'test_bucket_reclaimer',
         client: rpc_client,
     });
-    await buckets_reclaimer.run_batch();
 
-    const bucket_still_present = system_store.data.buckets.some(b => String(b._id) === String(bid));
-    assert.ok(!bucket_still_present, 'expected bucket to be removed from system_store');
+    for (let i = 0; i < 1000; i++) {
+        await buckets_reclaimer.run_batch();
+        await objects_reclaimer.run_batch();
+
+        const bucket_gone = !system_store.data.buckets.some(b => String(b._id) === String(bid));
+        const objs = await MDStore.instance().find_objects_by_id(ids);
+        if (bucket_gone && objs.length === ids.length && objs.every(o => o.reclaimed)) {
+            return;
+        }
+    }
+
+    const bucket_gone = !system_store.data.buckets.some(b => String(b._id) === String(bid));
+    const objs = await MDStore.instance().find_objects_by_id(ids);
+    assert.ok(bucket_gone, 'expected bucket to be removed from system_store');
+    assert.ok(
+        objs.length === ids.length && objs.every(o => o.reclaimed),
+        `objects not reclaimed: ${obj_ids.join(', ')}`
+    );
 }
 
 /**
@@ -698,6 +715,100 @@ mocha.describe('deep_archive_via_s3', function() {
             assert.ok(!std_has_parts);
             await assert_object_reclaimed(std_md.obj_id);
             await assert_object_reclaimed(arch_md.obj_id);
+        });
+
+        mocha.it('keeps archive bucket until unreclaimed objects are cleared', async function() {
+            for (const storage_class of s3_utils.GLACIER_STORAGE_CLASSES) {
+                const name = `test-s3-bucket-reclaim-wait-${storage_class.toLowerCase().replaceAll('_', '-')}-${Date.now()}`;
+                const bid = await create_archive_bucket(name);
+                const arch_key = `breclaim/wait-${storage_class}`;
+                const arch_buf = Buffer.from(`bucket-reclaim-wait-${storage_class}`);
+
+                const arch_md = await put_archive({
+                    bucket: name,
+                    key: arch_key,
+                    buf: arch_buf,
+                    storage_class,
+                });
+                await assert_archived_via_s3({
+                    bucket: name,
+                    key: arch_key,
+                    buf: arch_buf,
+                    storage_class,
+                });
+
+                await rpc_client.bucket.delete_bucket_and_objects({ name });
+
+                const buckets_reclaimer = new BucketsReclaimer({
+                    name: 'test_bucket_reclaimer',
+                    client: rpc_client,
+                });
+
+                // Soft-delete live objects only — do not run ObjectsReclaimer yet.
+                for (let i = 0; i < 1000; i++) {
+                    await buckets_reclaimer.run_batch();
+                    const has_live = await MDStore.instance().has_any_objects_for_bucket(parse_obj_id(bid));
+                    if (!has_live) break;
+                }
+                const has_live = await MDStore.instance().has_any_objects_for_bucket(parse_obj_id(bid));
+                assert.ok(!has_live, `expected BucketsReclaimer to soft-delete all live objects (${storage_class})`);
+                await assert_object_unreclaimed(arch_md.obj_id);
+                await assert_archive_present(bid, arch_md.obj_id, arch_buf.length);
+
+                assert.ok(
+                    system_store.data.buckets.some(b => String(b._id) === String(bid)),
+                    `archive bucket must remain while unreclaimed ${storage_class} objects exist`
+                );
+                // Extra BucketsReclaimer passes must still wait on ObjectsReclaimer.
+                await buckets_reclaimer.run_batch();
+                assert.ok(
+                    system_store.data.buckets.some(b => String(b._id) === String(bid)),
+                    `BucketsReclaimer must not remove archive bucket with unreclaimed ${storage_class} objects`
+                );
+
+                await run_objects_reclaimer(arch_md.obj_id);
+                await assert_object_reclaimed(arch_md.obj_id);
+                await assert_archive_absent(bid, arch_md.obj_id);
+
+                let bucket_gone = false;
+                for (let i = 0; i < 100; i++) {
+                    await buckets_reclaimer.run_batch();
+                    if (!system_store.data.buckets.some(b => String(b._id) === String(bid))) {
+                        bucket_gone = true;
+                        break;
+                    }
+                }
+                assert.ok(
+                    bucket_gone,
+                    `expected bucket removed after unreclaimed ${storage_class} objects were cleared`
+                );
+            }
+        });
+
+        mocha.it('does not wait on unreclaimed STANDARD objects before removing archive bucket', async function() {
+            const name = `test-s3-bucket-reclaim-std-only-${Date.now()}`;
+            const bid = await create_archive_bucket(name);
+            const std_key = 'breclaim/standard-only';
+            const std_buf = Buffer.from('bucket-reclaim-standard-only');
+
+            const std_md = await put_standard({ bucket: name, key: std_key, buf: std_buf });
+
+            await rpc_client.bucket.delete_bucket_and_objects({ name });
+
+            const buckets_reclaimer = new BucketsReclaimer({
+                name: 'test_bucket_reclaimer',
+                client: rpc_client,
+            });
+
+            // Soft-delete only — leave STANDARD unreclaimed. Archive wait must not apply.
+            for (let i = 0; i < 1000; i++) {
+                await buckets_reclaimer.run_batch();
+                if (!system_store.data.buckets.some(b => String(b._id) === String(bid))) {
+                    await assert_object_unreclaimed(std_md.obj_id);
+                    return;
+                }
+            }
+            assert.fail('expected archive bucket removed despite unreclaimed STANDARD object');
         });
     });
 


### PR DESCRIPTION
### Describe the Problem
When deleting a bucket with archive_policy, BucketsReclaimer soft-deletes live objects and then removes the bucket from system_store as soon as it is empty. That drops archive_policy before ObjectsReclaimer can delete remote GLACIER/DEEP_ARCHIVE keys, so archive objects can be marked reclaimed without removing the remote data (orphaned archive keys).

### Explain the Changes
1. BucketsReclaimer waits to hard-delete archive-policy buckets until there are no unreclaimed soft-deleted GLACIER/DEEP_ARCHIVE objects (_should_wait_for_archive_reclaim).
2. Added MDStore.has_any_unreclaimed_objects_in_bucket_with_storage_class() for that existence check (scoped by storage class so STANDARD unreclaimed objects do not block bucket removal).
3. Updated deep-archive S3 tests: interleave both reclaimers in reclaim_deleting_bucket, assert the wait invariant for GLACIER/DEEP_ARCHIVE, and assert STANDARD unreclaimed does not block removal.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-9709

### Testing Instructions:
1. `./node_modules/mocha/bin/mocha.js src/test/integration_tests/api/s3/test_deep_archive_via_s3.js --grep 'Bucket reclaim'`

Manual - see in the Jira ticket
Manually: create an archive-policy bucket, put DEEP_ARCHIVE objects, delete the bucket, confirm the bucket stays deleting until ObjectsReclaimer finishes, archive keys are removed, then the bucket is removed.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep-archive buckets are now protected from deletion while archived objects are still awaiting reclamation.
  * Bucket removal proceeds automatically after all applicable archived objects have been reclaimed.
  * Unreclaimed STANDARD-storage objects no longer unnecessarily delay bucket deletion.
* **Tests**
  * Added coverage for bucket lifecycle behavior across archive and STANDARD storage classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->