### PR TITLE
Namespacestore in Connecting state with "message: Cannot read properties of undefined"

### DIFF
--- a/src/server/system_services/pool_server.js
+++ b/src/server/system_services/pool_server.js
@@ -1109,6 +1109,9 @@ function get_pool_info(pool, nodes_aggregate_pool, hosts_aggregate_pool) {
 }
 
 function get_namespace_resource_info(namespace_resource) {
+    if (!namespace_resource || !namespace_resource._id) {
+        return {};
+    }
     const connection_info = namespace_resource.connection && {
         endpoint_type: namespace_resource.connection.endpoint_type,
         endpoint: namespace_resource.connection.endpoint,
@@ -1134,6 +1137,9 @@ function get_namespace_resource_info(namespace_resource) {
 }
 
 function calc_namespace_resource_mode(namespace_resource) {
+    if (!namespace_resource || !namespace_resource._id) {
+        return 'STORAGE_NOT_EXIST';
+    }
     const map_err_to_type_count = {
         ContainerNotFound: 'storage_not_exist',
         NoSuchBucket: 'storage_not_exist',


### PR DESCRIPTION
### Describe the Problem

Namespacestore in Connecting state with "message: Cannot read properties of undefined (reading 'toString')" errors


### Explain the Changes
1. check for namespace_resource undefined before `get_namespace_resource_info() `and `calc_namespace_resource_mode() `methods

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9096

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or invalid namespace resources.
  * Prevented errors when resource details or identifiers are unavailable.
  * Correctly reports unavailable storage for missing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->