### PR TITLE
Notifications | Lifecycle fails on invalid schema params when NOTIFICATION_LOG_DIR isn't set

### DIFF
--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -11,7 +11,7 @@ const system_store = require('../system_services/system_store').get_instance();
 const auth_server = require('../common_services/auth_server');
 const config = require('../../../config');
 const { get_notification_logger, check_notif_relevant,
-    OP_TO_EVENT, compose_notification_lifecycle } = require('../../util/notifications_util');
+    OP_TO_EVENT, compose_notification_lifecycle, should_notify_on_event } = require('../../util/notifications_util');
 const COMMON_CONSTANTS = require('../../common/constants');
 const { STORAGE_CLASS_STANDARD } = require('../../endpoint/s3/s3_utils');
 
@@ -290,9 +290,7 @@ async function handle_bucket_rule(system, rule, j, bucket) {
     //3.1. notification is without event filtering OR
     //3.2. notification is for LifecycleExpiration event
     //if so, we need the metadata of the deleted objects from the object server
-    const reply_objects = config.NOTIFICATION_LOG_DIR && bucket.notifications &&
-         _.some(bucket.notifications, notif =>
-            (!notif.Events || _.some(notif.Events, event => event.includes(OP_TO_EVENT.lifecycle_delete.name))));
+    const reply_objects = should_notify_on_event(bucket, OP_TO_EVENT.lifecycle_delete.name);
 
     // Check if rule.expiration.days/date is set - if it is, delete expired objects and delete markers
     if (!_.isUndefined(rule.expiration?.days) || !_.isUndefined(rule.expiration?.date)) {

--- a/src/test/integration_tests/api/s3/test_lifecycle.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle.js
@@ -190,6 +190,26 @@ mocha.describe('lifecycle', function() {
             await lifecycle.background_worker();
             await verify_object_deleted(key);
         });
+        mocha.it('test prefix expiration with empty NOTIFICATION_LOG_DIR', async function() {
+            // Containerized core always has NOTIFICATION_LOG_DIR="" unless bucket notifications are enabled.
+            const original_log_dir = config.NOTIFICATION_LOG_DIR;
+            config.NOTIFICATION_LOG_DIR = '';
+            try {
+                const key = crypto.randomUUID();
+                const prefix = key.split('-')[0];
+                const age = 17;
+                const bucket = Bucket;
+
+                await create_mock_object(key, bucket, age);
+
+                const putLifecycleParams = commonTests.date_lifecycle_configuration(bucket, prefix);
+                await s3.putBucketLifecycleConfiguration(putLifecycleParams);
+                await lifecycle.background_worker();
+                await verify_object_deleted(key);
+            } finally {
+                config.NOTIFICATION_LOG_DIR = original_log_dir;
+            }
+        });
         mocha.it('test prefix, absolute date and tags expiration', async function() {
             const key = crypto.randomUUID();
             const prefix = key.split('-')[0];
@@ -419,6 +439,24 @@ mocha.describe('lifecycle', function() {
             await verify_multipart_deleted(obj_id, multi_bucket_key, 0);
         });
 
+        mocha.it('lifecycle - abort incomplete multipart with empty NOTIFICATION_LOG_DIR', async function() {
+            // Containerized core always has NOTIFICATION_LOG_DIR="" unless bucket notifications are enabled.
+            const original_log_dir = config.NOTIFICATION_LOG_DIR;
+            config.NOTIFICATION_LOG_DIR = '';
+            try {
+                const days = 30;
+                const multi_bucket_key = 'test-lifecycle-multipart-empty-notif-dir';
+                const obj_id = await create_mock_multipart_upload(multi_bucket_key, multipart_bucket, days, 45, 7);
+                const putLifecycleParams = commonTests.multipart_lifecycle_configuration(multipart_bucket, multi_bucket_key, days);
+
+                await s3.putBucketLifecycleConfiguration(putLifecycleParams);
+                await lifecycle.background_worker();
+                await verify_multipart_deleted(obj_id, multi_bucket_key, 0);
+            } finally {
+                config.NOTIFICATION_LOG_DIR = original_log_dir;
+            }
+        });
+
         mocha.it('lifecycle - should not delete multipart after 30 days, before expiration', async function() {
             const days = 30;
             const multi_bucket_key = 'test-lifecycle-multipart2';
@@ -448,18 +486,16 @@ mocha.describe('lifecycle', function() {
         });
 
         async function verify_multipart_deleted(obj_id, key, expected_length) {
-            try {
-                const mp_list = await rpc_client.object.list_multiparts({ obj_id, bucket: multipart_bucket, key });
-                console.log('verify_multipart_deleted : multipart upload objects :', mp_list);
-                const actual_length = mp_list.objects.length;
-                console.log('list_objects_admin objects: ', util.inspect(mp_list.objects));
-                assert.strictEqual(actual_length, expected_length, `listObjectResult actual ${actual_length} !== ${expected_length}`);
-            } catch (err) {
-                console.log('verify_multipart_deleted error is :', err);
-                if (err.code === 'NO_SUCH_UPLOAD' && expected_length === 0) {
-                    assert.ok(true);
-                }
+            if (expected_length === 0) {
+                await assert.rejects(
+                    () => rpc_client.object.list_multiparts({ obj_id, bucket: multipart_bucket, key }),
+                    err => err.rpc_code === 'NO_SUCH_UPLOAD'
+                );
+                return;
             }
+            const mp_list = await rpc_client.object.list_multiparts({ obj_id, bucket: multipart_bucket, key });
+            assert.strictEqual(mp_list.multiparts.length, expected_length,
+                `list_multiparts actual ${mp_list.multiparts.length} !== ${expected_length}`);
         }
     });
 

--- a/src/util/notifications_util.js
+++ b/src/util/notifications_util.js
@@ -706,9 +706,9 @@ async function encrypt_connect_file(data) {
  * @returns {Boolean}
  */
 function should_notify_on_event(bucket, event_name) {
-    return config.NOTIFICATION_LOG_DIR && bucket.notifications &&
-    _.some(bucket.notifications, notif =>
-    (!notif.Events || _.some(notif.Events, event => event.includes(event_name))));
+    return Boolean(config.NOTIFICATION_LOG_DIR && bucket.notifications &&
+        _.some(bucket.notifications, notif =>
+            (!notif.Events || _.some(notif.Events, event => event.includes(event_name)))));
 }
 
 exports.Notificator = Notificator;


### PR DESCRIPTION
### Describe the Problem
Lately, a bug fix was merged to noobaa operator - https://github.com/noobaa/noobaa-operator/pull/2077
it sets empty string as the NOTIFICATION_LOG_DIR - when lifecycle BG worker is in use should_notify_on_event() is being called and on object_server it caused the following issue - 
```
 [ERROR] core.rpc.rpc_schema:: INVALID_SCHEMA_PARAMS CLIENT object_api#/methods
/delete_incomplete_multiparts ERRORS: [ { instancePath: '/reply_objects', schemaPath: '#/properties/reply_object
s/type', keyword: 'type', params: { type: 'boolean' }, message: 'must be boolean', schema: 'boolean', parentSche
ma: { type: 'boolean' }, data: '' }, [length]: 1 ] PARAMS: { bucket: SENSITIVE-d767cd6ec3f0ff0d, days_after_init
iation: 1, prefix: '', size_less: undefined, size_greater: undefined, limit: 1000, reply_objects: '' }
Aug-18 9:38:58.310 [BGWorkers/37] [ERROR] core.rpc.rpc:: RPC._request: response ERROR srv object_api.delete_inco
mplete_multiparts reqid <no-reqid-yet> connid <no-connection-yet> params { bucket: SENSITIVE-d767cd6ec3f0ff0d, d
ays_after_initiation: 1, prefix: '', size_less: undefined, size_greater: undefined, limit: 1000, reply_objects:
'' }  Error: INVALID_SCHEMA_PARAMS CLIENT object_api#/methods/delete_incomplete_multiparts
    at method_api.validate_params (/root/node_modules/noobaa-core/src/rpc/rpc_schema.js:118:31)
    at RPC._request (/root/node_modules/noobaa-core/src/rpc/rpc.js:209:32)
    at Object._invoke_api (/root/node_modules/noobaa-core/src/rpc/rpc_schema.js:163:33)
    at api_proto.<computed> [as delete_incomplete_multiparts] (/root/node_modules/noobaa-core/src/rpc/rpc_schema
.js:190:40)
    at delete_incomplete_multipart_uploads (/root/node_modules/noobaa-core/src/server/bg_services/lifecycle.js:2
05:43)
    at handle_bucket_rule (/root/node_modules/noobaa-core/src/server/bg_services/lifecycle.js:347:15)
    at /root/node_modules/noobaa-core/src/server/bg_services/lifecycle.js:409:28
    at arrayMap (/root/node_modules/noobaa-core/node_modules/lodash/lodash.js:654:23)
    at lodash.map (/root/node_modules/noobaa-core/node_modules/lodash/lodash.js:9653:14)
    at Object.background_worker [as run_batch] (/root/node_modules/noobaa-core/src/server/bg_services/lifecycle.
js:406:43)
```
Setting a constant to an empty string && true per node will produce ''  and not false-
```
> node
> const val = '' && true;
undefined
> val
''
``` 
### Explain the Changes
1. Converted the result of should_notify_on_event() to boolean so we will return boolean and not ''.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. `./node_modules/mocha/bin/mocha.js src/test/integration_tests/api/s3/test_lifecycle.js`


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle deletion handling when notification logging is disabled.
  * Ensured object expiration and incomplete multipart-upload cleanup continue to work with an empty notification log configuration.
  * Improved validation of deleted multipart uploads and remaining uploads.

* **Tests**
  * Added integration coverage for expiration and multipart-abort scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->