### PR TITLE
Replace openssl with base64 in nobaa_init.sh

### DIFF
--- a/src/deploy/NVA_build/noobaa_init.sh
+++ b/src/deploy/NVA_build/noobaa_init.sh
@@ -93,10 +93,18 @@ run_internal_process() {
   done
 }
 
+is_valid_json_file() {
+  [ -s "$1" ] && node -e "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))" "$1" >/dev/null 2>&1
+}
+
 prepare_agent_conf() {
   AGENT_CONF_FILE="/noobaa_storage/agent_conf.json"
 
-  [ -f "$AGENT_CONF_FILE" ] && return 0
+  # A previous run may have left behind an empty/corrupt file.
+  # Only trust an existing file if it is actually valid JSON, otherwise regenerate it.
+  if is_valid_json_file "$AGENT_CONF_FILE"; then
+    return 0
+  fi
 
   # get AGENT_CONFIG from env var or file
   AGENT_CONFIG_PATH=${AGENT_CONFIG_PATH:-"/etc/agent-config/agent_config"}
@@ -107,13 +115,33 @@ prepare_agent_conf() {
     exit 1
   fi
 
-  # write agent config - decode base64 if not a valid JSON format
-  if ! echo "${AGENT_CONFIG}" | jq . >"$AGENT_CONF_FILE" 2>/dev/null; then
-    openssl enc -base64 -d -A <<<"${AGENT_CONFIG}" >"$AGENT_CONF_FILE" || {
-      echo "AGENT_CONFIG format is invalid. AGENT_CONFIG must be valid JSON or base64 encoded JSON. Exit"
-      exit 1
-    }
+  # write to a temp file so a failed/partial decode never clobbers a
+  # previously-good agent_conf.json, and validate the result before using it.
+  local tmp_file="${AGENT_CONF_FILE}.tmp"
+
+  # AGENT_CONFIG may already be plain JSON (e.g. supplied via a mounted
+  # file/secret) - write it out first and check with node.
+  echo "${AGENT_CONFIG}" >"${tmp_file}"
+  if ! is_valid_json_file "${tmp_file}"; then
+    # Not valid plain JSON - treat it as base64 encoded JSON.
+    # NOTE: Prefer GNU `base64 -d`, which fails loudly (non-zero exit).
+    #  Fall back to openssl only if `base64` isn't available.
+    if command -v base64 >/dev/null 2>&1; then
+      base64 -d <<<"${AGENT_CONFIG}" >"${tmp_file}" 2>/dev/null
+    else
+      openssl enc -base64 -d -A <<<"${AGENT_CONFIG}" >"${tmp_file}" 2>/dev/null
+    fi
   fi
+
+  # validate actual content, not just the decoder's exit code.
+  if ! is_valid_json_file "${tmp_file}"; then
+    rm -f "${tmp_file}"
+    echo "AGENT_CONFIG format is invalid. AGENT_CONFIG must be valid JSON or base64 encoded JSON. Exit"
+    exit 1
+  fi
+
+  mv "${tmp_file}" "${AGENT_CONF_FILE}"
+  echo "AGENT_CONFIG successfully moved to ${AGENT_CONF_FILE}"
 }
 
 prepare_mongo_pv() {


### PR DESCRIPTION
### Describe the Problem

`openssl enc -base64 -d -A` failed to decode the base64-encoded `agent_conf` and exited without throwing an error.
This issue likely stems from the unreliable behavior of OpenSSL's `-A` flag, as documented in the [Base64 Encoding Strings](https://wiki.openssl.org/index.php/Command_Line_Utilities) section of the OpenSSL man page.

### Explain the Changes
1. prefer `base64` over `openssl` for encoding the `AGENT_CONFIG` in `nobaa_init.sh`
2. Remove `jq`

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9553

### Testing Instructions:
1. create backingstore and check for message 
`AGENT_CONFIG successfully moved to /noobaa_storage/agent_conf.json`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved configuration handling by validating existing and newly supplied configuration files.
* Added support for plain JSON and base64-encoded configuration input.
* Invalid, empty, or malformed configuration data is now rejected with an error.
* Configuration updates are applied safely to help prevent incomplete or corrupted files.
* Improved compatibility when decoding base64-encoded configuration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->