### PR TITLE
NAMESPACE_MONITOR - Do not skip AccessDenied when probing namespacestore health

### DIFF
--- a/src/server/bg_services/namespace_monitor.js
+++ b/src/server/bg_services/namespace_monitor.js
@@ -73,7 +73,7 @@ class NamespaceMonitor {
                 this.update_last_monitoring(nsr._id, nsr.name, endpoint_type);
             } catch (err) {
                 this.run_update_issues_report(err, nsr);
-                dbg.log1(`test_namespace_resource_validity: namespace resource ${nsr.name} has an unexpected error`);
+                dbg.log1(`test_namespace_resource_validity: namespace resource ${nsr.name} has an unexpected error`, err);
             }
         });
         dbg.log1(`test_namespace_resource_validity finished successfully..`);
@@ -140,7 +140,7 @@ class NamespaceMonitor {
             });
         } catch (err) {
             noobaa_s3_client.fix_error_object(err);
-            if (err.code === 'AccessDenied' && nsr.is_readonly_namespace()) {
+            if (err.code === 'AccessDenied' && this._is_readonly_namespace(nsr)) {
                 return;
             }
             dbg.log1(`test_s3_resource: on bucket ${target_bucket} got error:`, err);
@@ -174,7 +174,7 @@ class NamespaceMonitor {
             const container_client = conn.getContainerClient(target_bucket);
             await container_client.deleteBlob(block_key);
         } catch (err) {
-            if (err.code === 'InsufficientAccountPermissions' && nsr.is_readonly_namespace()) {
+            if (err.code === 'InsufficientAccountPermissions' && this._is_readonly_namespace(nsr)) {
                 return;
             }
             dbg.log1(`test_blob_resource: on bucket ${target_bucket} got error:`, err);
@@ -209,7 +209,7 @@ class NamespaceMonitor {
             if (err.code === S3Error.NoSuchBucket.code) {
                 throw err;
             }
-            if (reason === 'UserProjectAccessDenied' && nsr.is_readonly_namespace()) {
+            if (reason === 'UserProjectAccessDenied' && this._is_readonly_namespace(nsr)) {
                 return;
             }
             // https://cloud.google.com/storage/docs/json_api/v1/status-codes
@@ -252,6 +252,10 @@ class NamespaceMonitor {
             }
             throw err;
         }
+    }
+
+    _is_readonly_namespace(nsr) {
+        return nsr.access_mode === 'READ_ONLY';
     }
 }
 


### PR DESCRIPTION

### Describe the Problem
After AWS returns AccessDenied, a namespacestore stayed Ready while S3 I/O already failed.

The health probe called is_readonly_namespace() on a namespace resources from the system store that does not have that method. The resulting TypeError has no err.code, so the auth failure was dropped and the status never changed.


### Explain the Changes
1. Use access_mode === 'READ_ONLY' instead of is_readonly_namespace().
2. Include err on the existing probe-failure log.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-8507

### Testing Instructions:
1. Create an AWS namespacestore (read-write) on a real S3 bucket. Confirm Ready / OPTIMAL.
2. Confirm Get/Put through a namespace bucket on that store works.
3. On the target bucket, add a policy that Denies the namespacestore IAM user (s3:* or at least s3:DeleteObjectTagging + s3:ListBucket).
4. Confirm AWS itself returns AccessDenied (e.g. aws s3api delete-object-tagging with those creds on a fake key).
5. Wait up to 3 minutes (monitor cycle),
6. Expected: namespacestore Rejected / AUTH_FAILED. Data path still AccessDenied.





- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of read-only access for S3, Azure Blob, and GCS resources, providing more consistent monitoring behavior across supported storage services.
* Enhanced diagnostic information for unexpected namespace validation errors, making issues easier to investigate and resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->