### PR TITLE
s3 block store - adapt buffer to sdk V3

### DIFF
--- a/src/agent/block_store_services/block_store_s3.js
+++ b/src/agent/block_store_services/block_store_s3.js
@@ -87,8 +87,9 @@ class BlockStoreS3 extends BlockStoreBase {
                 Key: this.usage_path,
             });
 
+            const body = await noobaa_s3_client.s3_body_to_buffer(res.Body);
             const usage_data = this.disable_metadata ?
-                res.Body.toString() :
+                body.toString() :
                 res.Metadata[this.usage_md_key];
             if (usage_data && usage_data.length) {
                 this._usage = this._decode_block_md(usage_data);
@@ -174,7 +175,7 @@ class BlockStoreS3 extends BlockStoreBase {
                 Key: this._block_key(block_md.id),
             });
             return {
-                data: res.Body,
+                data: await noobaa_s3_client.s3_body_to_buffer(res.Body),
                 block_md: this._get_store_block_md(block_md, res),
             };
         } catch (err) {

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -148,6 +148,22 @@ function add_response_header_capture(s3) {
     return () => response_headers;
 }
 
+/**
+ * Converts AWS SDK getObject Body to a Buffer.
+ * SDK v2 returns a Buffer. SDK v3 returns a stream with transformToByteArray.
+ * @param {*} body - getObject Body from AWS SDK v2 or v3
+ * @returns {Promise<Buffer>}
+ */
+async function s3_body_to_buffer(body) {
+    // SDK v2 returns a Buffer
+    if (Buffer.isBuffer(body)) return body;
+    // SDK v3 returns a stream with transformToByteArray
+    if (body && typeof body.transformToByteArray === 'function') {
+        return Buffer.from(await body.transformToByteArray());
+    }
+    throw new Error(`Unexpected Body type: ${body && body.constructor && body.constructor.name}`);
+}
+
 // EXPORTS
 exports.get_s3_client_v3_params = get_s3_client_v3_params;
 exports.change_s3_client_params_to_v2_structure = change_s3_client_params_to_v2_structure;
@@ -155,3 +171,4 @@ exports.get_sdk_class_str = get_sdk_class_str;
 exports.fix_error_object = fix_error_object;
 exports.get_requestHandler_with_suitable_agent = get_requestHandler_with_suitable_agent;
 exports.add_response_header_capture = add_response_header_capture;
+exports.s3_body_to_buffer = s3_body_to_buffer;

--- a/src/test/unit_tests/internal/test_noobaa_s3_client.test.js
+++ b/src/test/unit_tests/internal/test_noobaa_s3_client.test.js
@@ -109,3 +109,30 @@ describe('noobaa_s3_client change_s3_client_params_to_v2_structure', () => {
     });
 
 });
+
+describe('noobaa_s3_client s3_body_to_buffer', () => {
+
+    const data = Buffer.from('s3-body-payload');
+
+    it('returns a Buffer Body unchanged (SDK v2 shape)', async () => {
+        const buf = await noobaa_s3_client.s3_body_to_buffer(data);
+        expect(Buffer.isBuffer(buf)).toBe(true);
+        expect(buf.equals(data)).toBe(true);
+    });
+
+    it('converts an SDK v3 stream Body to a Buffer', async () => {
+        const body = {
+            transformToByteArray: async () => new Uint8Array(data),
+        };
+        const buf = await noobaa_s3_client.s3_body_to_buffer(body);
+        expect(Buffer.isBuffer(buf)).toBe(true);
+        expect(buf.equals(data)).toBe(true);
+    });
+
+    it('rejects an unsupported Body type', async () => {
+        await expect(noobaa_s3_client.s3_body_to_buffer({})).rejects.toThrow(
+            /Unexpected Body type: Object/
+        );
+    });
+
+});


### PR DESCRIPTION
### Describe the Problem
AWS SDK v3 getObject returns a stream, not a Buffer (see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrate-s3.html#amazon-s3-stream-vs-buffer). The block store still expected a Buffer, so reads and mirror copies failed with `Block data must be a buffer`.

### Explain the Changes
1.  s3_body_to_buffer: if Body is already a Buffer (SDK v2), return it; if v3, call transformToByteArray() and wrap in a Buffer.
2. Use it on block read and usage-file read.
3. Add unit tests

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9429

### Testing Instructions:
1. `node ./node_modules/.bin/_mocha src/test/unit_tests/internal/test_block_store_s3.js`



- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of S3 object data across supported AWS SDK versions.
  * Block initialization and reads now consistently process response bodies and report unsupported formats clearly.
  * Improved reliability when retrieving data returned as either buffers or streams.

* **Tests**
  * Added coverage for buffer responses, stream-based responses, and unsupported body types.
  * Verified consistent conversion and error handling across supported response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->