### PR TITLE
DEEP_ARCHIVE | Fix - `list_objects` To Omit `restore_status` Expiry Invalid or in the Past

### DIFF
--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -88,12 +88,17 @@ class NamespaceMultiStorageClass {
     /**
      * Lists objects from the metadata namespace only.
      * Metadata for all storage classes is stored there.
+     * Omits restore_status on each object when restore is expired or incomplete.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async list_objects(params, object_sdk) {
-        return this._metadata_ns.list_objects(params, object_sdk);
+        const reply = await this._metadata_ns.list_objects(params, object_sdk);
+        return {
+            ...reply,
+            objects: reply.objects.map(obj => this._omit_inactive_restore_status(obj)),
+        };
     }
 
     /**
@@ -131,10 +136,7 @@ class NamespaceMultiStorageClass {
      */
     async read_object_md(params, object_sdk) {
         const object_md = await this._metadata_ns.read_object_md(params, object_sdk);
-        const { restore_status } = object_md;
-
-        return (!restore_status || restore_status.ongoing || is_restore_active(restore_status)) ?
-            object_md : _.omit(object_md, 'restore_status');
+        return this._omit_inactive_restore_status(object_md);
     }
 
     /**
@@ -823,6 +825,18 @@ class NamespaceMultiStorageClass {
      */
     is_standard_storage_class(storage_class) {
         return s3_utils.parse_storage_class(storage_class) === this.default_storage_class;
+    }
+
+    /**
+     * Returns object metadata without restore_status when the restore is expired or incomplete.
+     * Keeps restore_status when restore is ongoing or still active.
+     * @param {nb.ObjectInfo} object_md
+     * @returns {nb.ObjectInfo}
+     */
+    _omit_inactive_restore_status(object_md) {
+        const { restore_status } = object_md;
+        return (!restore_status || restore_status.ongoing || is_restore_active(restore_status)) ?
+            object_md : _.omit(object_md, 'restore_status');
     }
 }
 

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
@@ -76,6 +76,26 @@ function make_read_object_md_msc_fixture(object_md) {
     return { ns_msc, metadata_ns, read_object_md, object_sdk };
 }
 
+function make_list_objects_msc_fixture(objects) {
+    const list_reply = {
+        objects: Array.isArray(objects) ? objects : [objects],
+        common_prefixes: [],
+        is_truncated: false,
+    };
+    const list_objects = jest.fn().mockResolvedValue(list_reply);
+    const metadata_ns = { list_objects };
+    const object_sdk = {};
+
+    const ns_msc = new NamespaceMultiStorageClass({
+        namespace_by_storage_class: {
+            [s3_utils.STORAGE_CLASS_STANDARD]: metadata_ns,
+            [s3_utils.STORAGE_CLASS_DEEP_ARCHIVE]: {},
+        },
+    });
+
+    return { ns_msc, metadata_ns, list_objects, object_sdk, list_reply };
+}
+
 describe('NamespaceMultiStorageClass.restore_object', () => {
     const params = { bucket: BUCKET, key: KEY, days: 7 };
 
@@ -388,5 +408,113 @@ describe('NamespaceMultiStorageClass.read_object_md', () => {
         });
         const object_md = await ns_msc.read_object_md(params, object_sdk);
         expect(object_md.restore_status).toBeUndefined();
+    });
+});
+
+describe('NamespaceMultiStorageClass.list_objects', () => {
+    const params = { bucket: BUCKET, prefix: '', limit: 1000 };
+
+    it('omits restore_status when restore expiry_time is in the past', async () => {
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status: {
+                ongoing: false,
+                expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+            },
+        });
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects[0]).not.toHaveProperty('restore_status');
+        expect(reply.objects[0].storage_class).toBe(s3_utils.STORAGE_CLASS_DEEP_ARCHIVE);
+        expect(reply.is_truncated).toBe(false);
+        expect(reply.common_prefixes).toEqual([]);
+    });
+
+    it('returns restore_status when restore is ongoing', async () => {
+        const restore_status = { ongoing: true, days: 7 };
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects[0].restore_status).toEqual(restore_status);
+    });
+
+    it('returns restore_status when temporary restore is still active', async () => {
+        const restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(),
+        };
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects[0].restore_status).toEqual(restore_status);
+    });
+
+    it('omits restore_status when restore failed without expiry_time', async () => {
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: { ongoing: false },
+        });
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects[0]).not.toHaveProperty('restore_status');
+    });
+
+    it('omits restore_status when restore expiry_time is invalid', async () => {
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: {
+                ongoing: false,
+                expiry_time: 'invalid',
+            },
+        });
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects[0].restore_status).toBeUndefined();
+    });
+
+    it('omits restore_status independently for each object on the same page', async () => {
+        const active_restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(),
+        };
+        const ongoing_restore_status = { ongoing: true, days: 7 };
+        const { ns_msc, object_sdk } = make_list_objects_msc_fixture([
+            {
+                key: 'archived/active',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                restore_status: active_restore_status,
+            },
+            {
+                key: 'archived/expired',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+                },
+            },
+            {
+                key: 'archived/ongoing',
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                restore_status: ongoing_restore_status,
+            },
+        ]);
+        const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects).toHaveLength(3);
+
+        const active_object = reply.objects.find(obj => obj.key === 'archived/active');
+        const expired_object = reply.objects.find(obj => obj.key === 'archived/expired');
+        const ongoing_object = reply.objects.find(obj => obj.key === 'archived/ongoing');
+        expect(active_object).toBeDefined();
+        expect(expired_object).toBeDefined();
+        expect(ongoing_object).toBeDefined();
+        expect(active_object.restore_status).toEqual(active_restore_status);
+        expect(expired_object).not.toHaveProperty('restore_status');
+        expect(ongoing_object.restore_status).toEqual(ongoing_restore_status);
     });
 });


### PR DESCRIPTION
### Describe the Problem
Part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)
In case the object was already restored and its expiry date is in the past, and the BG worker that handles removing the STANDARD copy did not finish removing it, we would like to avoid list objects calls that would include an expiry date in the past (property and header).

Note: This PR handles the GAP that was mentioned in #9945.


### Explain the Changes
1. Edit the function `list_objects` instead of being just a passthrough to the metadata namespace to omit the `restore_status` in case the expiry is invalid or in the past, and adding the helper `_omit_inactive_restore_status` and reuse the code in `read_object_md`.
2. Added AI-generated tests.

### Issues:
List of GAPs:
1. We handled the call for `ListObjects` and `ListObjectsV2`, but when listing objects with versions, for example: `s3 s3api list-object-versions --bucket <bucket name> --optional-object-attributes RestoreStatus`, it is not handled here.

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`

- [ ] Doc added/updated
- [X] Tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Object listings and metadata reads now consistently hide expired or incomplete restore details.
  * Active and ongoing restore statuses remain visible.
  * Restore information is handled independently for each object, including cases with missing or invalid expiry data.

* **Tests**
  * Added coverage for restore-status filtering across multiple object and expiry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->