### PR TITLE
Reduce ERROR log spam for expected NoSuchKey responses

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -552,6 +552,19 @@ function _prepare_error(req, res, err) {
     return s3err;
 }
 
+function _log_s3_request_error(req, err, s3err, reply) {
+    if (s3err.code === 'NoSuchKey' && (req.method === 'GET' || req.method === 'HEAD')) {
+        dbg.log1('S3 NoSuchKey', req.method, req.originalUrl, req.request_id);
+    } else {
+        dbg.error('S3 ERROR', reply,
+            req.method, req.originalUrl,
+            JSON.stringify(req.headers),
+            err.stack || err,
+            err.context ? `- context: ${err.context?.trim()}` : '',
+        );
+    }
+}
+
 function handle_error(req, res, err) {
     const s3err = _prepare_error(req, res, err);
 
@@ -567,12 +580,7 @@ function handle_error(req, res, err) {
             duration_ms: req.start_time ? Date.now() - req.start_time : undefined,
         });
     }
-    dbg.error('S3 ERROR', reply,
-        req.method, req.originalUrl,
-        JSON.stringify(req.headers),
-        err.stack || err,
-        err.context ? `- context: ${err.context?.trim()}` : '',
-    );
+    _log_s3_request_error(req, err, s3err, reply);
     if (res.headersSent) {
         dbg.log0('Sending error xml in body, but too late for headers...');
     } else {
@@ -599,10 +607,7 @@ async function _handle_html_response(req, res, err) {
         </body> \
         </html>`;
     res.statusCode = s3err.http_code;
-    dbg.error('S3 ERROR', reply,
-        req.method, req.originalUrl,
-        JSON.stringify(req.headers),
-        err.stack || err);
+    _log_s3_request_error(req, err, s3err, reply);
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Content-Length', Buffer.byteLength(reply));
     res.end(reply);

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -268,12 +268,17 @@ class RPC extends EventEmitter {
                 this._request_logger('RPC REQUEST CATCH', req.srv, '==>', err);
             }
 
-            dbg.error('RPC._request: response ERROR',
-                req.base_info,
-                'params', util.inspect(params, true, null, true),
-                req.took_info,
-                err.stack || err
-            );
+            // Expected missing-object outcomes (maps to S3 NoSuchKey) — quiet log, no stack/params dump
+            if (err.rpc_code === 'NO_SUCH_OBJECT') {
+                dbg.log1('RPC._request: NO_SUCH_OBJECT', req.base_info, req.took_info);
+            } else {
+                dbg.error('RPC._request: response ERROR',
+                    req.base_info,
+                    'params', util.inspect(params, true, null, true),
+                    req.took_info,
+                    err.stack || err
+                );
+            }
 
             if (this.should_emit_request_errors) {
                 this.emit('request_error', err);
@@ -359,7 +364,12 @@ class RPC extends EventEmitter {
             await this._send_response(conn, req);
 
         } catch (err) {
-            console.error('RPC._on_request: ERROR', req.base_info, err.stack || err);
+            // Expected missing-object outcomes (maps to S3 NoSuchKey) — quiet log, no stack
+            if (err.rpc_code === 'NO_SUCH_OBJECT') {
+                dbg.log1('RPC._on_request: NO_SUCH_OBJECT', req.base_info);
+            } else {
+                console.error('RPC._on_request: ERROR', req.base_info, err.stack || err);
+            }
             // propagate rpc errors from inner rpc client calls (using err.rpc_code)
             // set default internal error if no other error was specified
             if (err instanceof RpcError) {


### PR DESCRIPTION
### Describe the Problem
Expected missing-object lookups (e.g. Thanos marker GETs) were treated like failures. Every NoSuchKey / NO_SUCH_OBJECT was logged at ERROR with a full stack.

### Explain the Changes
1. Demote expected missing-object outcomes to quiet dbg.log1 (no stack): NoSuchKey on GET/HEAD in s3_rest.js, and NO_SUCH_OBJECT in rpc.js (_request and _on_request). S3/RPC responses are unchanged (still 404 NoSuchKey); all other errors (auth, NoSuchBucket, internal failures, etc.) continue to log at ERROR with stack.

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-9093

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary error logging for expected missing-object responses from storage and RPC requests.
  - Missing-object errors are now recorded as informational or debug messages without detailed request data or stack traces.
  - Other errors continue to receive detailed logging for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->