### PR TITLE
Pass content_type to read_object_mapping

### DIFF
--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -96,14 +96,6 @@ async function archive_object(req) {
             throw new Error('archive_object: object not found ' + obj_id);
         }
 
-        const object_md = {
-            obj_id: obj_md.obj_id,
-            bucket: obj_md.bucket,
-            key: obj_md.key,
-            size: obj_md.size,
-            encryption: obj_md.encryption,
-        };
-
         const { chunks } = await rpc_client.object.read_object_mapping({
             bucket: obj_md.bucket,
             key: obj_md.key,
@@ -145,7 +137,7 @@ async function archive_object(req) {
                     try {
                         const source_stream = object_io.read_object_stream({
                             client: rpc_client,
-                            object_md: object_md,
+                            object_md: obj_md,
                             start: r.start,
                             end: r.end,
                         });


### PR DESCRIPTION
### Describe the Problem
The object's `content_type` was not being passed to `read_object_stream` which was resulting in errors in case of objects larger than 1MB.

### Explain the Changes
1. We already have `read_object_md_by_id` object API which returns object of type `ObjectInfo`. So remove the additional declaration.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archiving now preserves complete source object metadata, improving consistency and retaining file information in archived objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->