### PR TITLE
Deep Archive | Support multiple transitions

### DIFF
--- a/docs/design/DeepArchiveAPIsSupport.md
+++ b/docs/design/DeepArchiveAPIsSupport.md
@@ -236,8 +236,8 @@ See [Step 5 — Update archive policy on a bucket](#step-5--update-archive-polic
 |-----------|----------|
 | **PutObject / CompleteMultipartUpload** - (storageClass=DEEP_ARCHIVE)| Create a DB entity for the object metadata and passthrough the data to IBM Deep Archive namespace resource
 | **RestoreObject** | Updates the object's restore_status to be ongoing and will call S3 RestoreObject on the Deep Archive, while the background worker will create the temporary copy of the archived object to standard storage class. If already restored, extend the expiry_time. Allowed for bucket owner/ permissioned accounts - `s3:RestoreObject` permission.|
-| **PutBucketLifecycleConfiguration** | Processes and stores `Transition` / `NonCurrentVersionTransition` lifecycle actions |
-| **GetBucketLifecycleConfiguration** | Return value includes `Transition` / `NonCurrentVersionTransition` elements |
+| **PutBucketLifecycleConfiguration** | Processes and stores `Transitions` / `NoncurrentVersionTransitions` lifecycle actions |
+| **GetBucketLifecycleConfiguration** | Return value includes every `Transition` / `NoncurrentVersionTransition` element |
 
 ---
 
@@ -268,6 +268,8 @@ Users configure them via `PutBucketLifecycleConfiguration`.
 - **StorageClass** - `DEEP_ARCHIVE`
 - **NewerNoncurrentVersions** - how many noncurrent versions will retain in the standard storage class before transitioning object to Deep Archive.
 - **NoncurrentDays** - the number of days an object is noncurrent before transitioning the object to Deep Archive.
+
+A rule may include multiple [Transitions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html) / [NoncurrentVersionTransitions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleRule.html) (arrays of `Transition` / `NoncurrentVersionTransition`). On the S3 REST XML wire these are repeated `<Transition>` / `<NoncurrentVersionTransition>` elements. `GetBucketLifecycleConfiguration` returns all of them. The lifecycle worker applies each entry; only `DEEP_ARCHIVE` and `GLACIER` storage classes are executed.
 
 Note - All other lifecycle rule fields — such as expiration and filter — remain fully supported and work in conjunction with the new transition rules.
 
@@ -1132,14 +1134,14 @@ cat > /tmp/lifecycle.json <<'EOF'
       "ID": "move-to-deep-archive",
       "Status": "Enabled",
       "Filter": { "Prefix": "example-lifecycle-" },
-      "Transition": {
+      "Transitions": [{
         "Days": 90,
         "StorageClass": "DEEP_ARCHIVE"
-      },
-      "NoncurrentVersionTransition": {
+      }],
+      "NoncurrentVersionTransitions": [{
         "NoncurrentDays": 30,
         "StorageClass": "DEEP_ARCHIVE"
-      }
+      }]
     }
   ]
 }
@@ -1167,7 +1169,7 @@ aws s3api get-bucket-lifecycle-configuration \
   --bucket "$BUCKET"
 ```
 
-Response includes the `Transition` and `NoncurrentVersionTransition` elements with `StorageClass: DEEP_ARCHIVE`.
+Response includes the `Transitions` and `NoncurrentVersionTransitions` arrays with `StorageClass: DEEP_ARCHIVE`.
 
 #### Transition flow (overview)
 

--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -174,6 +174,34 @@ module.exports = {
                 }
             }
         },
+        bucket_lifecycle_rule_transition: {
+            type: 'object',
+            properties: {
+                date: {
+                    idate: true
+                },
+                days: {
+                    type: 'integer'
+                },
+                storage_class: {
+                    $ref: '#/definitions/storage_class_enum'
+                }
+            }
+        },
+        bucket_lifecycle_rule_noncurrent_version_transition: {
+            type: 'object',
+            properties: {
+                noncurrent_days: {
+                    type: 'integer'
+                },
+                newer_noncurrent_versions: {
+                    type: 'integer'
+                },
+                storage_class: {
+                    $ref: '#/definitions/storage_class_enum'
+                }
+            }
+        },
         bucket_lifecycle_rule_status: {
             enum: ['Enabled', 'Disabled'],
             type: 'string'
@@ -240,18 +268,10 @@ module.exports = {
                         },
                     }
                 },
-                transition: {
-                    type: 'object',
-                    properties: {
-                        date: {
-                            idate: true
-                        },
-                        days: {
-                            type: 'integer'
-                        },
-                        storage_class: {
-                            $ref: '#/definitions/storage_class_enum'
-                        }
+                transitions: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/bucket_lifecycle_rule_transition'
                     }
                 },
                 noncurrent_version_expiration: {
@@ -265,18 +285,10 @@ module.exports = {
                         }
                     }
                 },
-                noncurrent_version_transition: {
-                    type: 'object',
-                    properties: {
-                        noncurrent_days: {
-                            type: 'integer'
-                        },
-                        newer_noncurrent_versions: {
-                            type: 'integer'
-                        },
-                        storage_class: {
-                            $ref: '#/definitions/storage_class_enum'
-                        }
+                noncurrent_version_transitions: {
+                    type: 'array',
+                    items: {
+                        $ref: '#/definitions/bucket_lifecycle_rule_noncurrent_version_transition'
                     }
                 },
             }

--- a/src/endpoint/s3/ops/s3_get_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_lifecycle.js
@@ -52,24 +52,6 @@ async function get_bucket_lifecycle(req) {
             _.omitBy(current_rule.Expiration, _.isUndefined);
         }
 
-        if (rule.transition) {
-            current_rule.Transition = {
-                Days: rule.transition.days,
-                Date: rule.transition.date ? new Date(rule.transition.date).toISOString() : undefined,
-                StorageClass: rule.transition.storage_class,
-            };
-            _.omitBy(current_rule.Transition, _.isUndefined);
-        }
-
-        if (rule.noncurrent_version_transition) {
-            current_rule.NoncurrentVersionTransition = {
-                NoncurrentDays: rule.noncurrent_version_transition.noncurrent_days,
-                NewerNoncurrentVersions: rule.noncurrent_version_transition.newer_noncurrent_versions,
-                StorageClass: rule.noncurrent_version_transition.storage_class,
-            };
-            _.omitBy(current_rule.NoncurrentVersionTransition, _.isUndefined);
-        }
-
         if (rule.noncurrent_version_expiration) {
             current_rule.NoncurrentVersionExpiration = {
                 NoncurrentDays: rule.noncurrent_version_expiration.noncurrent_days,
@@ -85,10 +67,30 @@ async function get_bucket_lifecycle(req) {
             _.omitBy(current_rule.AbortIncompleteMultipartUpload, _.isUndefined);
         }
 
+        // encode_xml repeats a tag only when sibling objects in an array share that key
+        // (same pattern as multiple <Rule>s). Putting Transition: [t1, t2] on current_rule
+        // would wrap both items in a single <Transition> tag.
+        const rule_parts = [current_rule];
+        for (const t of rule.transitions || []) {
+            rule_parts.push({
+                Transition: _.omitBy({
+                    Days: t.days,
+                    Date: t.date ? new Date(t.date).toISOString() : undefined,
+                    StorageClass: t.storage_class,
+                }, _.isUndefined),
+            });
+        }
+        for (const t of rule.noncurrent_version_transitions || []) {
+            rule_parts.push({
+                NoncurrentVersionTransition: _.omitBy({
+                    NoncurrentDays: t.noncurrent_days,
+                    NewerNoncurrentVersions: t.newer_noncurrent_versions,
+                    StorageClass: t.storage_class,
+                }, _.isUndefined),
+            });
+        }
 
-
-
-        return { Rule: current_rule };
+        return { Rule: rule_parts };
     });
 
     return { LifecycleConfiguration: rules };

--- a/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
+++ b/src/endpoint/s3/ops/s3_put_bucket_lifecycle.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 const s3_const = require('../s3_constants');
+const s3_utils = require('../s3_utils');
 const crypto = require('crypto');
 const dbg = require('../../../util/debug_module')(__filename);
 const S3Error = require('../s3_errors').S3Error;
@@ -10,6 +11,17 @@ const S3Error = require('../s3_errors').S3Error;
 const true_regex = /true/i;
 const MAX_LIFECYCLE_RULES = 1000; // AWS limit
 const MAX_TAGS_IN_AND_FILTER = 10;
+
+/**
+ * Lifecycle Transition / NoncurrentVersionTransition waterfall, earlier (warmer) to later (colder).
+ * A later class must use a strictly greater Days / Date / NoncurrentDays than an earlier class.
+ * Insert new transition targets here; do not special-case class names in the combination validators.
+ * @type {readonly nb.StorageClass[]}
+ */
+const LIFECYCLE_TRANSITION_STORAGE_CLASS_ORDER = Object.freeze([
+    s3_utils.STORAGE_CLASS_GLACIER,
+    s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+]);
 
 /**
  * @param {*} field 
@@ -39,18 +51,10 @@ function validate_lifecycle_expiration_rule(rule, bucket_versioning) {
             throw new S3Error(S3Error.MalformedXML);
         }
         if (expiration_content.Date) {
-            const date = new Date(expiration_content.Date[0]);
-            if (isNaN(date.getTime()) || date.getTime() !== Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())) {
-                dbg.error('Expiration Date value must conform to the ISO 8601 format and be at midnight UTC. Provided:', expiration_content.Date[0]);
-                throw new S3Error({ ...S3Error.InvalidArgument, message: "'Date' must be at midnight GMT" });
-            }
+            reject_if_not_midnight_utc(expiration_content.Date[0], 'Date');
         }
         if (expiration_content.Days) {
-            const days = parseInt(expiration_content.Days[0], 10);
-            if (isNaN(days) || days < 1) {
-                dbg.error('Minimum value for Expiration Days is 1, received:', expiration_content.Days[0]);
-                throw new S3Error({ ...S3Error.InvalidArgument, message: 'Expiration Days must be a positive integer' });
-            }
+            parse_positive_int(expiration_content.Days[0], 'Expiration Days');
         }
         if (expiration_content.ExpiredObjectDeleteMarker) {
             if (expiration_content.ExpiredObjectDeleteMarker[0].toLowerCase() !== 'true') {
@@ -71,18 +75,9 @@ function validate_lifecycle_noncurrentexp_rule(rule, bucket_versioning) {
              dbg.error('NoncurrentVersionExpiration action must specify NoncurrentDays', rule);
              throw new S3Error(S3Error.MalformedXML);
          }
-         const days = parseInt(nve_content.NoncurrentDays[0], 10);
-         if (isNaN(days) || days < 1) {
-             dbg.error('Minimum value for NoncurrentVersionExpiration NoncurrentDays is 1, received:', nve_content.NoncurrentDays[0]);
-             throw new S3Error({ ...S3Error.InvalidArgument, message: 'NoncurrentVersionExpiration NoncurrentDays must be a positive integer' });
-         }
-         // Validate NewerNoncurrentVersions if present
+         parse_positive_int(nve_content.NoncurrentDays[0], 'NoncurrentVersionExpiration NoncurrentDays');
          if (nve_content.NewerNoncurrentVersions) {
-            const newer_versions = parseInt(nve_content.NewerNoncurrentVersions[0], 10);
-            if (isNaN(newer_versions) || newer_versions < 1) {
-                dbg.error('NewerNoncurrentVersions must be a positive integer if specified, received:', nve_content.NewerNoncurrentVersions[0]);
-                throw new S3Error({ ...S3Error.InvalidArgument, message: 'NewerNoncurrentVersions must be a positive integer' });
-            }
+            parse_positive_int(nve_content.NewerNoncurrentVersions[0], 'NewerNoncurrentVersions');
          }
          if (bucket_versioning !== 'ENABLED') {
             dbg.warn('NoncurrentVersionExpiration specified but bucket versioning is not ENABLED.', rule);
@@ -132,13 +127,13 @@ function validate_lifecycle_abortmultipart_rule(rule, has_filter) {
 
 /**
  * validate_lifecycle_rule validates lifecycle rule structure and logical constraints based on AWS S3 rules.
- * Skips validation for Transition and NoncurrentVersionTransition as they are not supported.
  *
  * @param {Object} rule - lifecycle rule to validate
- * @param {string} bucket_versioning - Bucket versioning status ('ENABLED', 'SUSPENDED', or null)
+ * @param {object} bucket_info - bucket from read_bucket (versioning, archive_policy, supported_storage_classes)
  * @throws {S3Error} - on validation failure
  */
-function validate_lifecycle_rule(rule, bucket_versioning) {
+function validate_lifecycle_rule(rule, bucket_info) {
+    const bucket_versioning = bucket_info.versioning;
     if (rule.ID?.length === 1 && rule.ID[0].length > s3_const.MAX_RULE_ID_LENGTH) {
         dbg.error('Rule ID length exceeds maximum limit:', s3_const.MAX_RULE_ID_LENGTH, rule);
         throw new S3Error({ ...S3Error.InvalidArgument, message: `ID length should not exceed allowed limit of ${s3_const.MAX_RULE_ID_LENGTH}` });
@@ -201,12 +196,14 @@ function validate_lifecycle_rule(rule, bucket_versioning) {
     // Expiration Validation
     validate_lifecycle_expiration_rule(rule, bucket_versioning);
 
-    // --- Transition Validation SKIPPED (NooBaa does not support Transition) ---
+    // Transition Validation
+    validate_lifecycle_transition_rule(rule, bucket_info);
 
     // NoncurrentVersionExpiration Validation
     validate_lifecycle_noncurrentexp_rule(rule, bucket_versioning);
 
-    // --- NoncurrentVersionTransition Validation SKIPPED (NooBaa does not support NoncurrentVersionTransition) ---
+    // NoncurrentVersionTransition Validation
+    validate_lifecycle_noncurrent_transition_rule(rule, bucket_info);
 
     // AbortIncompleteMultipartUpload Validation
     validate_lifecycle_abortmultipart_rule(rule, has_filter);
@@ -300,14 +297,7 @@ function parse_filter(filter) {
 // Parses date field, expects ISO 8601 format at midnight UTC. Returns epoch milliseconds.
 function parse_date_field(field_array, field_name) {
      if (field_array?.length === 1) {
-         const date_str = field_array[0];
-         const date = new Date(date_str);
-         // Reuse validation logic from validate_lifecycle_rule for consistency during parsing
-         if (isNaN(date.getTime()) || date.getTime() !== Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())) {
-             dbg.error(`${field_name} must be in ISO 8601 format at midnight UTC. Received:`, date_str);
-             throw new S3Error({ ...S3Error.InvalidArgument, message: `'${field_name}' must be at midnight GMT` });
-         }
-         return date.getTime();
+         return reject_if_not_midnight_utc(field_array[0], field_name).getTime();
      }
      return undefined;
 }
@@ -337,13 +327,12 @@ async function put_bucket_lifecycle(req) {
          throw new S3Error({ ...S3Error.InvalidArgument, message: `The lifecycle configuration cannot have more than ${MAX_LIFECYCLE_RULES} rules.` });
     }
 
-    // Fetch bucket versioning status once for rule validation
+    // Fetch bucket info once for rule validation (versioning, archive policy, supported storage classes)
     const bucket_info = await req.object_sdk.read_bucket({ name: req.params.bucket });
-    const bucket_versioning = bucket_info.versioning; // Should be 'ENABLED', 'SUSPENDED', or null/undefined
 
     const id_set = new Set();
     const lifecycle_rules = _.map(rules_data, rule => {
-        validate_lifecycle_rule(rule, bucket_versioning);
+        validate_lifecycle_rule(rule, bucket_info);
 
         const current_rule = {
             filter: {},
@@ -384,13 +373,7 @@ async function put_bucket_lifecycle(req) {
 
         // Parse Transition
         if (rule.Transition?.length > 0) {
-            const tran = rule.Transition[0];
-            current_rule.transition = _.omitBy({
-                storage_class: parse_lifecycle_field(tran.StorageClass, String),
-                date: parse_lifecycle_field(tran.Date, s => (new Date(s)).getTime()),
-                days: parse_lifecycle_field(tran.Days),
-            }, _.isUndefined);
-            reject_empty_action_field(current_rule.transition, 'Transition');
+            current_rule.transitions = parse_transition_actions(rule.Transition);
         }
 
 
@@ -410,20 +393,9 @@ async function put_bucket_lifecycle(req) {
 
          // Parse NoncurrentVersionTransition
          if (rule.NoncurrentVersionTransition?.length > 0) {
-            const nvt = rule.NoncurrentVersionTransition[0];
-            current_rule.noncurrent_version_transition = _.omitBy({
-                storage_class: parse_lifecycle_field(nvt.StorageClass, String),
-                noncurrent_days: parse_lifecycle_field(nvt.NoncurrentDays),
-                newer_noncurrent_versions: parse_lifecycle_field(nvt.NewerNoncurrentVersions),
-            }, _.isUndefined);
-            reject_empty_action_field(current_rule.noncurrent_version_transition, 'NoncurrentVersionTransition');
-            // Ensure required fields were parsed
-            if (
-                current_rule.noncurrent_version_transition.noncurrent_days === undefined ||
-                current_rule.noncurrent_version_transition.storage_class === undefined
-            ) {
-                throw new S3Error({ ...S3Error.InvalidArgument, message: 'NoncurrentVersionTransition must specify NoncurrentDays and StorageClass.'});
-            }
+            current_rule.noncurrent_version_transitions = parse_noncurrent_version_transition_actions(
+                rule.NoncurrentVersionTransition
+            );
         }
 
         // Parse AbortIncompleteMultipartUpload
@@ -448,6 +420,407 @@ async function put_bucket_lifecycle(req) {
     });
 
     dbg.log0('Successfully set bucket lifecycle configuration for bucket:', req.params.bucket, 'Rules:', lifecycle_rules);
+}
+
+////////////////////////
+// VALIDATION HELPERS //
+////////////////////////
+
+/**
+ * @param {string} raw_value
+ * @param {string} error_message - InvalidArgument message when the value is not an integer >= 0
+ * @returns {number}
+ * @throws {S3Error} InvalidArgument
+ */
+function parse_non_negative_int(raw_value, error_message) {
+    const value = parseInt(raw_value, 10);
+    if (isNaN(value) || value < 0) {
+        dbg.error(error_message, 'received:', raw_value);
+        throw new S3Error({ ...S3Error.InvalidArgument, message: error_message });
+    }
+    return value;
+}
+
+/**
+ * @param {string} raw_value
+ * @param {string} field_name - used in the InvalidArgument message
+ * @returns {number}
+ * @throws {S3Error} InvalidArgument when the value is not an integer >= 1
+ */
+function parse_positive_int(raw_value, field_name) {
+    const value = parseInt(raw_value, 10);
+    if (isNaN(value) || value < 1) {
+        dbg.error(`${field_name} must be a positive integer if specified, received:`, raw_value);
+        throw new S3Error({ ...S3Error.InvalidArgument, message: `${field_name} must be a positive integer` });
+    }
+    return value;
+}
+
+/**
+ * @param {string} date_str - ISO 8601 date string
+ * @param {string} field_name - used in the InvalidArgument message
+ * @returns {Date}
+ * @throws {S3Error} InvalidArgument when the date is invalid or not midnight UTC
+ */
+function reject_if_not_midnight_utc(date_str, field_name) {
+    const date = new Date(date_str);
+    if (isNaN(date.getTime()) || date.getTime() !== Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())) {
+        dbg.error(`${field_name} must be in ISO 8601 format at midnight UTC. Received:`, date_str);
+        throw new S3Error({ ...S3Error.InvalidArgument, message: `'${field_name}' must be at midnight GMT` });
+    }
+    return date;
+}
+
+/**
+ * AWS lifecycle errors include the rule filter, e.g. `(prefix=test/ and objectsizelessthan=120120)`.
+ * @param {object} rule - xml2js lifecycle rule
+ * @returns {string}
+ */
+function format_lifecycle_error_filter(rule) {
+    if (rule.Prefix?.length === 1) {
+        return `(prefix=${rule.Prefix[0]})`;
+    }
+    const filter = rule.Filter?.[0];
+    if (!filter) return '(prefix=)';
+    const node = filter.And?.[0] || filter;
+    const parts = [];
+    if (node.Prefix) {
+        parts.push(`prefix=${node.Prefix[0]}`);
+    }
+    for (const tag of node.Tag || []) {
+        parts.push(`tag={key=${tag.Key?.[0] || ''}, value=${tag.Value?.[0] || ''}}`);
+    }
+    if (node.ObjectSizeGreaterThan) {
+        parts.push(`objectsizegreaterthan=${node.ObjectSizeGreaterThan[0]}`);
+    }
+    if (node.ObjectSizeLessThan) {
+        parts.push(`objectsizelessthan=${node.ObjectSizeLessThan[0]}`);
+    }
+    if (!parts.length) return '(prefix=)';
+    return `(${parts.join(' and ')})`;
+}
+
+////////////////////////
+// TRANSITION HELPERS //
+////////////////////////
+
+/**
+ * Storage classes a bucket may transition into (GLACIER / DEEP_ARCHIVE only, and only
+ * when the bucket actually supports them — archive policy on hosted, NSFS glacier when enabled).
+ * @param {object} bucket_info - bucket from read_bucket
+ * @returns {string[]}
+ */
+function get_allowed_transition_storage_classes(bucket_info) {
+    const glacier_classes = s3_utils.GLACIER_STORAGE_CLASSES;
+    const supported = bucket_info.supported_storage_classes;
+    if (Array.isArray(supported) && supported.length) {
+        return glacier_classes.filter(sc => supported.includes(sc));
+    }
+    if (bucket_info.archive_policy?.deep_archive_resource) {
+        return glacier_classes.slice();
+    }
+    return [];
+}
+
+/**
+ * @param {string} [storage_class]
+ * @param {string} action_name - action name (`Transition` or `NoncurrentVersionTransition`)
+ * @param {string[]} allowed_storage_classes - storage classes this bucket may transition into
+ * @throws {S3Error} MalformedXML when StorageClass is missing or not allowed
+ */
+function reject_invalid_transition_storage_class(storage_class, action_name, allowed_storage_classes) {
+    if (!storage_class || !allowed_storage_classes.includes(storage_class)) {
+        dbg.error(`${action_name} StorageClass is missing or not allowed. Received:`, storage_class, 'allowed:', allowed_storage_classes);
+        throw new S3Error(S3Error.MalformedXML);
+    }
+}
+
+/**
+ * Transition and NoncurrentVersionTransition require archive support (hosted archive policy,
+ * or NSFS glacier). Callers already know a Transition or NoncurrentVersionTransition is present.
+ * @param {object} rule - lifecycle rule
+ * @param {object} bucket_info - bucket from read_bucket
+ * @throws {S3Error} InvalidRequest when the bucket has no archive/glacier support
+ */
+function reject_transitions_without_archive_policy(rule, bucket_info) {
+    if (get_allowed_transition_storage_classes(bucket_info).length > 0) return;
+    dbg.error('Transition actions require the bucket to have an archive policy attached', rule);
+    throw new S3Error({
+        ...S3Error.InvalidRequest,
+        message: "'Transition' and 'NoncurrentVersionTransition' actions require the bucket to have an archive policy attached.",
+    });
+}
+
+/**
+ * Validates Transition actions: StorageClass (GLACIER / DEEP_ARCHIVE), Days xor Date,
+ * and midnight UTC dates. Combination with Expiration is checked separately.
+ * @param {object} rule - lifecycle rule
+ * @param {object} bucket_info - bucket from read_bucket
+ * @throws {S3Error} on invalid Transition configuration
+ */
+function validate_lifecycle_transition_rule(rule, bucket_info) {
+    if (!rule.Transition?.length) return;
+    reject_transitions_without_archive_policy(rule, bucket_info);
+
+    const allowed_storage_classes = get_allowed_transition_storage_classes(bucket_info);
+
+    for (const transition of rule.Transition) {
+        const has_date = Boolean(transition.Date?.[0]);
+        // Days=0 is valid for Transition (unlike Expiration, which requires >= 1)
+        const has_days_field = Boolean(transition.Days);
+        reject_invalid_transition_storage_class(transition.StorageClass?.[0], 'Transition', allowed_storage_classes);
+
+        if (has_days_field && has_date) {
+            // AWS XSD is a choice of Date vs Days; both on one Transition is MalformedXML.
+            dbg.error('Transition must specify only one of Days or Date', rule);
+            throw new S3Error(S3Error.MalformedXML);
+        }
+        if (!has_days_field && !has_date) {
+            dbg.error('Transition must specify either Days or Date', rule);
+            throw new S3Error({ ...S3Error.InvalidArgument, message: "'Transition' action must specify either 'Days' or 'Date'" });
+        }
+        if (has_days_field) {
+            parse_non_negative_int(transition.Days[0], "'Days' in Transition action must be nonnegative");
+        } else {
+            reject_if_not_midnight_utc(transition.Date[0], 'Date');
+        }
+    }
+
+    const has_transition_days = rule.Transition.some(t => t.Days);
+    const has_transition_date = rule.Transition.some(t => t.Date?.[0]);
+    validate_lifecycle_transitions_combination(rule, has_transition_days, has_transition_date);
+    validate_lifecycle_expiration_transition_combination(rule, has_transition_days, has_transition_date);
+}
+
+/**
+ * When a rule has more than one Transition, they must all use Days or all use Date, StorageClass
+ * must be unique, and a later StorageClass (colder in `LIFECYCLE_TRANSITION_STORAGE_CLASS_ORDER`)
+ * must have a strictly greater Days or Date than an earlier class.
+ * @param {object} rule - lifecycle rule
+ * @param {boolean} has_transition_days - true if any Transition uses Days
+ * @param {boolean} has_transition_date - true if any Transition uses Date
+ * @throws {S3Error} InvalidRequest when Days and Date are mixed or StorageClass is repeated;
+ *     InvalidArgument when a later StorageClass is not strictly after an earlier one
+ */
+function validate_lifecycle_transitions_combination(rule, has_transition_days, has_transition_date) {
+    if (has_transition_days && has_transition_date) {
+        dbg.error('Days and Date cannot be mixed across Transition actions in the same rule', rule);
+        throw new S3Error({
+            ...S3Error.InvalidRequest,
+            message: `Found mixed 'Date' and 'Days' based Transition actions in lifecycle rule for filter '${format_lifecycle_error_filter(rule)}'`,
+        });
+    }
+    reject_duplicate_storage_classes(
+        rule.Transition.map(t => ({ storage_class: t.StorageClass?.[0] })),
+        'Transition',
+        rule
+    );
+    if (has_transition_date) {
+        reject_later_storage_class_timing_not_greater(
+            rule.Transition, rule, 'Transition', 'Date', 'Date', raw => new Date(raw).getTime());
+    } else {
+        reject_later_storage_class_timing_not_greater(
+            rule.Transition, rule, 'Transition', 'Days', 'Days', raw => parseInt(raw, 10));
+    }
+}
+
+/**
+ * When a rule has more than one NoncurrentVersionTransition, StorageClass must be unique and a
+ * later StorageClass must have a strictly greater NoncurrentDays than an earlier class.
+ * @param {object} rule - lifecycle rule
+ * @throws {S3Error} InvalidRequest when StorageClass is repeated; InvalidArgument when a later
+ *     StorageClass is not strictly after an earlier one
+ */
+function validate_lifecycle_noncurrent_transitions_combination(rule) {
+    reject_duplicate_storage_classes(
+        rule.NoncurrentVersionTransition.map(nvt => ({ storage_class: nvt.StorageClass?.[0] })),
+        'NoncurrentVersionTransition',
+        rule
+    );
+    reject_later_storage_class_timing_not_greater(
+        rule.NoncurrentVersionTransition, rule, 'NoncurrentVersionTransition',
+        'NoncurrentDays', 'NoncurrentDays', raw => parseInt(raw, 10));
+}
+
+/**
+ * @param {object[]} [items] - xml2js Transition or NoncurrentVersionTransition elements
+ * @param {object} rule - xml2js lifecycle rule
+ * @param {string} action_name - `Transition` or `NoncurrentVersionTransition`
+ * @param {string} xml_field - `Days`, `Date`, or `NoncurrentDays`
+ * @param {string} field_label - name used in the error message
+ * @param {(raw: string) => number} to_number
+ * @throws {S3Error} MalformedXML when StorageClass or timing cannot be ranked;
+ *     InvalidArgument when a later StorageClass is not strictly after an earlier one
+ */
+function reject_later_storage_class_timing_not_greater(items, rule, action_name, xml_field, field_label, to_number) {
+    if (!items || items.length < 2) return;
+    const ranked = [];
+    for (const item of items) {
+        const storage_class = item.StorageClass?.[0];
+        const rank = LIFECYCLE_TRANSITION_STORAGE_CLASS_ORDER.indexOf(storage_class);
+        const value = to_number(item[xml_field]?.[0]);
+        if (rank < 0 || Number.isNaN(value)) {
+            dbg.error('Cannot rank lifecycle transition for StorageClass ordering', {
+                action_name, xml_field, storage_class, rank, value,
+            });
+            throw new S3Error(S3Error.MalformedXML);
+        }
+        ranked.push({ storage_class, value, rank });
+    }
+    ranked.sort((a, b) => a.rank - b.rank);
+    for (let i = 1; i < ranked.length; i++) {
+        const prev = ranked[i - 1];
+        const curr = ranked[i];
+        if (curr.value > prev.value) continue;
+        const filter = format_lifecycle_error_filter(rule);
+        throw new S3Error({
+            ...S3Error.InvalidArgument,
+            message: `'${field_label}' in the ${action_name} action for StorageClass '${curr.storage_class}' for filter '${filter}' must be greater than '${field_label}' in the ${action_name} action for StorageClass '${prev.storage_class}' for filter '${filter}'`,
+        });
+    }
+}
+
+/**
+ * When a rule has both Expiration and Transition, they must use the same timing
+ * (Days vs Date), and Expiration Days/Date must be greater than Transition Days/Date.
+ * @param {object} rule - lifecycle rule
+ * @param {boolean} has_transition_days - true if any Transition uses Days
+ * @param {boolean} has_transition_date - true if any Transition uses Date
+ * @throws {S3Error} InvalidRequest when Days and Date are mixed; InvalidArgument when
+ *     Expiration is not strictly after Transition
+ */
+function validate_lifecycle_expiration_transition_combination(rule, has_transition_days, has_transition_date) {
+    if (!rule.Expiration?.length) return;
+    const expiration_content = rule.Expiration[0];
+    if ((expiration_content.Days && has_transition_date) ||
+        (expiration_content.Date && has_transition_days)) {
+        throw new S3Error({
+            ...S3Error.InvalidRequest,
+            message: `Found mixed 'Date' and 'Days' based Expiration and Transition actions in lifecycle rule for filter '${format_lifecycle_error_filter(rule)}'`,
+        });
+    }
+    if (expiration_content.Days) {
+        const exp_days = parseInt(expiration_content.Days[0], 10);
+        if (!isNaN(exp_days) && rule.Transition.some(t => t.Days && exp_days <= parseInt(t.Days[0], 10))) {
+            throw new S3Error({
+                ...S3Error.InvalidArgument,
+                message: `'Days' in the Expiration action for filter '${format_lifecycle_error_filter(rule)}' must be greater than 'Days' in the Transition action`,
+            });
+        }
+    }
+    if (expiration_content.Date) {
+        const exp_date = new Date(expiration_content.Date[0]);
+        if (!isNaN(exp_date.getTime()) &&
+            rule.Transition.some(t => t.Date?.[0] && exp_date.getTime() <= new Date(t.Date[0]).getTime())) {
+            throw new S3Error({
+                ...S3Error.InvalidArgument,
+                message: `'Date' in the Expiration action for filter '${format_lifecycle_error_filter(rule)}' must be greater than 'Date' in the Transition action`,
+            });
+        }
+    }
+}
+
+/**
+ * Validates NoncurrentVersionTransition actions: StorageClass, NoncurrentDays,
+ * and NewerNoncurrentVersions. Combination with NoncurrentVersionExpiration is checked separately.
+ * @param {object} rule - lifecycle rule
+ * @param {object} bucket_info - bucket from read_bucket
+ * @throws {S3Error} on invalid NoncurrentVersionTransition configuration
+ */
+function validate_lifecycle_noncurrent_transition_rule(rule, bucket_info) {
+    if (!rule.NoncurrentVersionTransition?.length) return;
+    reject_transitions_without_archive_policy(rule, bucket_info);
+
+    const allowed_storage_classes = get_allowed_transition_storage_classes(bucket_info);
+
+    for (const nvt of rule.NoncurrentVersionTransition) {
+        reject_invalid_transition_storage_class(nvt.StorageClass?.[0], 'NoncurrentVersionTransition', allowed_storage_classes);
+        if (!nvt.NoncurrentDays || nvt.NoncurrentDays.length !== 1) {
+            dbg.error('NoncurrentVersionTransition action must specify NoncurrentDays', rule);
+            throw new S3Error(S3Error.MalformedXML);
+        }
+        parse_non_negative_int(nvt.NoncurrentDays[0],
+            "'NoncurrentDays' in NoncurrentVersionTransition action must be nonnegative");
+        if (nvt.NewerNoncurrentVersions) {
+            parse_positive_int(nvt.NewerNoncurrentVersions[0], 'NewerNoncurrentVersions');
+        }
+    }
+
+    validate_lifecycle_noncurrent_transitions_combination(rule);
+    validate_lifecycle_noncurrent_expiration_transition_combination(rule);
+}
+
+/**
+ * When a rule has both NoncurrentVersionExpiration and NoncurrentVersionTransition,
+ * NVE NoncurrentDays must be greater than NVT NoncurrentDays.
+ * @param {object} rule - lifecycle rule
+ * @throws {S3Error} InvalidArgument when NVE NoncurrentDays is not greater than NVT
+ */
+function validate_lifecycle_noncurrent_expiration_transition_combination(rule) {
+    if (!rule.NoncurrentVersionExpiration?.length) return;
+    const nve_content = rule.NoncurrentVersionExpiration[0];
+    if (nve_content.NoncurrentDays) {
+        const nve_days = parseInt(nve_content.NoncurrentDays[0], 10);
+        if (!isNaN(nve_days) &&
+            rule.NoncurrentVersionTransition.some(nvt => nve_days <= parseInt(nvt.NoncurrentDays[0], 10))) {
+            throw new S3Error({
+                ...S3Error.InvalidArgument,
+                message: `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '${format_lifecycle_error_filter(rule)}' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`,
+            });
+        }
+    }
+}
+
+/**
+ * AWS rejects two Transition actions (or two NoncurrentVersionTransition actions) in the same
+ * rule that target the same StorageClass (InvalidRequest). Transition and NoncurrentVersionTransition
+ * may share a StorageClass — they apply to current vs noncurrent versions.
+ *
+ * @param {Array<{storage_class?: string}>} items - parsed transition actions
+ * @param {string} action_name - XML action name used in the error message
+ * @param {object} rule - xml2js lifecycle rule, formatted into the AWS error text on throw
+ * @throws {S3Error} InvalidRequest when a StorageClass is repeated
+ */
+function reject_duplicate_storage_classes(items, action_name, rule) {
+    const seen = new Set();
+    for (const item of items) {
+        if (item.storage_class === undefined) continue;
+        if (seen.has(item.storage_class)) {
+            throw new S3Error({
+                ...S3Error.InvalidRequest,
+                message: `'StorageClass' must be different for '${action_name}' actions in same 'Rule' with filter '${format_lifecycle_error_filter(rule)}'`,
+            });
+        }
+        seen.add(item.storage_class);
+    }
+}
+
+/**
+ * Parses every `<Transition>` element on a lifecycle rule into the stored array shape.
+ * Required fields and emptiness are already checked by validate_lifecycle_transition_rule.
+ * @param {object[]} transitions - array of Transition elements
+ * @returns {Array<{storage_class?: string, date?: number, days?: number}>}
+ */
+function parse_transition_actions(transitions) {
+    return transitions.map(tran => _.omitBy({
+        storage_class: parse_lifecycle_field(tran.StorageClass, String),
+        date: parse_date_field(tran.Date, 'Date'),
+        days: parse_lifecycle_field(tran.Days),
+    }, _.isUndefined));
+}
+
+/**
+ * Parses every `<NoncurrentVersionTransition>` element on a lifecycle rule into the stored array shape.
+ * Required fields and emptiness are already checked by validate_lifecycle_noncurrent_transition_rule.
+ * @param {object[]} noncurrent_version_transitions - array of NoncurrentVersionTransition elements
+ * @returns {Array<{storage_class: string, noncurrent_days: number, newer_noncurrent_versions?: number}>}
+ */
+function parse_noncurrent_version_transition_actions(noncurrent_version_transitions) {
+    return noncurrent_version_transitions.map(nvt => _.omitBy({
+        storage_class: parse_lifecycle_field(nvt.StorageClass, String),
+        noncurrent_days: parse_lifecycle_field(nvt.NoncurrentDays),
+        newer_noncurrent_versions: parse_lifecycle_field(nvt.NewerNoncurrentVersions),
+    }, _.isUndefined));
 }
 
 module.exports = {

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -69,7 +69,7 @@ function get_transition_timestamp(transition) {
  *
  * @param {Object} system - the NooBaa system object from system_store
  * @param {nb.Bucket} bucket_info - the bucket object
- * @param {Object} rule - the transition or noncurrent_version_transition sub-rule
+ * @param {Object} rule - the transition or noncurrent_version_transition item
  * @param {Object} [lifecycle_filter] - the lifecycle rule filter (prefix, tags, object_size_*)
  */
 async function process_transition(system, bucket_info, rule, lifecycle_filter) {
@@ -135,7 +135,8 @@ async function process_transition(system, bucket_info, rule, lifecycle_filter) {
                 1. Transition - All the latest versions of the objects
                 2. NoncurrentVersionTransition - AND operation between NoncurrentDays and NewerNoncurrentVersions
             */
-            const is_latest = !(rule.noncurrent_days || rule.newer_noncurrent_versions);
+            // NoncurrentDays=0 is valid; do not treat 0 as falsy (that would run the latest-version finder).
+            const is_latest = rule.noncurrent_days === undefined && rule.newer_noncurrent_versions === undefined;
             result = await object_server.find_versioned_objects_to_transition({
                 bucket: bucket_info.name,
                 batch_size,
@@ -269,6 +270,8 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'schedule min', config.LIFECYCLE_SCHEDULE_MIN);
         return;
     }
+    const transitions = rule.transitions || [];
+    const noncurrent_transitions = rule.noncurrent_version_transitions || [];
     // When creating rules via the AWS web console, they always contain an Expiration key
     // However, rules applied via the CLI don't have to contain Expiration, and can instead contain
     // NoncurrentVersionExpiration or AbortIncompleteMultipartUpload
@@ -276,7 +279,7 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         rule.expiration === undefined &&
         rule.abort_incomplete_multipart_upload === undefined &&
         rule.noncurrent_version_expiration === undefined &&
-        !rule.transition && !rule.noncurrent_version_transition
+        !transitions.length && !noncurrent_transitions.length
     ) {
         dbg.log0('LIFECYCLE SKIP bucket:', bucket.name, '(bucket id:', bucket._id, ') rule', util.inspect(rule), 'now', now, 'last_sync', rule.last_sync, 'rule contains no expiration parameters');
         return;
@@ -364,18 +367,22 @@ async function handle_bucket_rule(system, rule, j, bucket) {
         );
     }
 
-    if (rule.transition || rule.noncurrent_version_transition) {
+    if (transitions.length || noncurrent_transitions.length) {
+        for (const t of transitions) {
+            const transition_has_more = await process_transition(system, bucket, t, rule.filter);
+            if (transition_has_more) should_rerun = true;
+        }
         // NoncurrentVersionTransition has no effect on versioning disabled buckets
-        if (rule.noncurrent_version_transition &&
+        if (noncurrent_transitions.length &&
             bucket.versioning === COMMON_CONSTANTS.S3.VERSIONING.DISABLED) {
             dbg.log1("skipping noncurrent_version_transition rule as bucket versioning is disabled", bucket.name);
         } else {
-            const transition_has_more = await process_transition(system, bucket, rule.transition, rule.filter);
-            const noncurrent_has_more = await process_transition(system, bucket, rule.noncurrent_version_transition, rule.filter);
-            if (transition_has_more || noncurrent_has_more) should_rerun = true;
-
-            dbg.log1("bucket", bucket.name, "transition batch completed");
+            for (const t of noncurrent_transitions) {
+                const noncurrent_has_more = await process_transition(system, bucket, t, rule.filter);
+                if (noncurrent_has_more) should_rerun = true;
+            }
         }
+        dbg.log1("bucket", bucket.name, "transition batch completed");
     }
 
     if (num_objects_deleted >= config.LIFECYCLE_BATCH_SIZE) should_rerun = true;

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -2600,6 +2600,9 @@ class MDStore {
         }
         const values = [bucket_id];
 
+        // TODO: skipping every object with transition_info is enough for a single archive class.
+        // When more Transition targets are available this will not fit — select by current class
+        // and promote already-transitioned objects (e.g. GLACIER → DEEP_ARCHIVE) instead.
         let query = `
         SELECT *
         FROM ${this._objects.name}
@@ -2726,7 +2729,8 @@ class MDStore {
                     + interval '${noncurrent_days} days'
                 ) AT TIME ZONE 'UTC'
             )`,
-            // Not already transitioned or in progress
+            // TODO: skipping all transition_info will not fit when more Transition targets exist;
+            // promote already-transitioned noncurrent versions (e.g. GLACIER → DEEP_ARCHIVE) then.
             `(transition_info IS NULL OR transition_info = 'null'::jsonb)`,
         ];
 

--- a/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
@@ -25,8 +25,21 @@ const system_store = require('../../../../server/system_services/system_store').
 
 const ARCHIVE = COMMON_CONSTANTS.ARCHIVE;
 const { rpc_client, EMAIL } = coretest;
+const test_utils = require('../../../system_tests/test_utils');
 const TRANSITION_BUCKET = 'test-lifecycle-transition-bucket';
 const TARGET_STORAGE_CLASS = 'DEEP_ARCHIVE';
+const ARCHIVE_CONNECTION = 'lifecycle-transition-archive-connection';
+const ARCHIVE_NSR = 'lifecycle-transition-archive-nsr';
+const ARCHIVE_TARGET = 'lifecycle-transition-archive-target';
+
+async function create_archive_bucket(name) {
+    await rpc_client.bucket.create_bucket({
+        name,
+        archive_policy: {
+            deep_archive_resource: { resource: ARCHIVE_NSR },
+        },
+    });
+}
 
 function get_bucket_from_store(bucket_name) {
     const system = system_store.data.systems[0];
@@ -104,6 +117,34 @@ mocha.describe('lifecycle-transitions', function() {
                 httpAgent: http_utils.get_unsecured_agent(coretest.get_http_address()),
             }),
         });
+
+        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        await s3.createBucket({ Bucket: ARCHIVE_TARGET });
+        await rpc_client.account.add_external_connection({
+            name: ARCHIVE_CONNECTION,
+            endpoint: coretest.get_http_address(),
+            endpoint_type: 'S3_COMPATIBLE',
+            auth_method: 'AWS_V4',
+            identity: account_info.access_keys[0].access_key.unwrap(),
+            secret: account_info.access_keys[0].secret_key.unwrap(),
+        });
+        await rpc_client.pool.create_namespace_resource({
+            name: ARCHIVE_NSR,
+            connection: ARCHIVE_CONNECTION,
+            target_bucket: ARCHIVE_TARGET,
+            archive: true,
+        });
+    });
+
+    mocha.after(async function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        try {
+            await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+            await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+            await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET]);
+        } finally {
+            config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+        }
     });
 
     // ──────────────────────────────────────────────────────────────────────
@@ -116,7 +157,7 @@ mocha.describe('lifecycle-transitions', function() {
         const RULE_DAYS = 1;
 
         mocha.before(async function() {
-            await rpc_client.bucket.create_bucket({ name: bucket });
+            await create_archive_bucket(bucket);
         });
 
         mocha.after(async function() {
@@ -577,6 +618,478 @@ mocha.describe('lifecycle-transitions', function() {
             const matching = results.filter(o => o.key === key);
             assert(matching.length >= 1,
                 'Noncurrent version from 2 days ago should be eligible with NoncurrentDays=0');
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Multiple Transitions in one rule
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Multiple Transitions', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-multi';
+
+        mocha.before(async function() {
+            await create_archive_bucket(bucket);
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should store and return every Transition in the rule', async function() {
+            await s3.putBucketLifecycleConfiguration({
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [{
+                        ID: 'multi-transition',
+                        Status: 'Enabled',
+                        Filter: { Prefix: '' },
+                        Transitions: [
+                            { Days: 30, StorageClass: 'GLACIER' },
+                            { Days: 90, StorageClass: TARGET_STORAGE_CLASS },
+                        ],
+                    }],
+                },
+            });
+
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: bucket });
+            assert.strictEqual(res.Rules[0].Transitions.length, 2);
+            assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'GLACIER');
+            assert.strictEqual(res.Rules[0].Transitions[1].StorageClass, TARGET_STORAGE_CLASS);
+
+            const stored = get_bucket_from_store(bucket).lifecycle_configuration_rules[0].transitions;
+            assert(Array.isArray(stored), 'stored transition should be an array');
+            assert.strictEqual(stored.length, 2);
+            assert.strictEqual(stored[0].storage_class, 'GLACIER');
+            assert.strictEqual(stored[1].storage_class, TARGET_STORAGE_CLASS);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // PUT lifecycle Transition validation
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('PUT lifecycle Transition validation', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const archive_bucket = TRANSITION_BUCKET + '-put-archive';
+        const no_archive_bucket = TRANSITION_BUCKET + '-put-no-archive';
+
+        mocha.before(async function() {
+            await create_archive_bucket(archive_bucket);
+            await rpc_client.bucket.create_bucket({ name: no_archive_bucket });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, archive_bucket);
+            await delete_lifecycle(s3, no_archive_bucket);
+            await rpc_client.bucket.delete_bucket({ name: archive_bucket });
+            await rpc_client.bucket.delete_bucket({ name: no_archive_bucket });
+        });
+
+        async function put_rule(bucket, extra_rule_fields) {
+            return s3.putBucketLifecycleConfiguration({
+                Bucket: bucket,
+                LifecycleConfiguration: {
+                    Rules: [{
+                        ID: 'validate-transition',
+                        Status: 'Enabled',
+                        Filter: { Prefix: 'test/' },
+                        ...extra_rule_fields,
+                    }],
+                },
+            });
+        }
+
+        async function assert_rejected(bucket, extra_rule_fields, code, message) {
+            try {
+                await put_rule(bucket, extra_rule_fields);
+                assert.fail(`expected putBucketLifecycleConfiguration to fail with ${code}`);
+            } catch (err) {
+                assert.strictEqual(err.Code, code, err.message);
+                if (message) assert.strictEqual(err.message, message);
+            }
+        }
+
+        mocha.it('should reject Transition when the bucket has no archive policy', async function() {
+            await assert_rejected(no_archive_bucket, {
+                Transitions: [{ Days: 1, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidRequest',
+                "'Transition' and 'NoncurrentVersionTransition' actions require the bucket to have an archive policy attached.");
+        });
+
+        mocha.it('should reject NoncurrentVersionTransition when the bucket has no archive policy', async function() {
+            await assert_rejected(no_archive_bucket, {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'GLACIER' }],
+            }, 'InvalidRequest',
+                "'Transition' and 'NoncurrentVersionTransition' actions require the bucket to have an archive policy attached.");
+        });
+
+        mocha.it('should reject StorageClass that is not GLACIER or DEEP_ARCHIVE', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{ Days: 1, StorageClass: 'STANDARD_IA' }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject Transition that specifies both Days and Date', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{
+                    Days: 1,
+                    Date: new Date('2026-01-01T00:00:00.000Z'),
+                    StorageClass: 'DEEP_ARCHIVE',
+                }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject Transition that specifies neither Days nor Date', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{ StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidArgument',
+                "'Transition' action must specify either 'Days' or 'Date'");
+        });
+
+        mocha.it('should reject Transition that omits StorageClass', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{ Days: 1 }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject empty Transition action', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{}],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject Transition Date that is not midnight UTC', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{
+                    Date: new Date('2026-01-01T15:00:00.000Z'),
+                    StorageClass: 'DEEP_ARCHIVE',
+                }],
+            }, 'InvalidArgument',
+                "'Date' must be at midnight GMT");
+        });
+
+        mocha.it('should reject negative Transition Days', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [{ Days: -1, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidArgument',
+                "'Days' in Transition action must be nonnegative");
+        });
+
+        mocha.it('should reject mixed Days and Date Transitions in the same rule', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [
+                    { Days: 30, StorageClass: 'GLACIER' },
+                    { Date: new Date('2026-01-01T00:00:00.000Z'), StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            }, 'InvalidRequest',
+                "Found mixed 'Date' and 'Days' based Transition actions in lifecycle rule for filter '(prefix=test/)'");
+        });
+
+        mocha.it('should reject mixed Expiration Date and Transition Days in the same rule', async function() {
+            await assert_rejected(archive_bucket, {
+                Expiration: { Date: new Date('2027-01-03T00:00:00.000Z') },
+                Transitions: [{ Days: 12, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidRequest',
+                "Found mixed 'Date' and 'Days' based Expiration and Transition actions in lifecycle rule for filter '(prefix=test/)'");
+        });
+
+        mocha.it('should reject mixed Expiration Days and Transition Date in the same rule', async function() {
+            await assert_rejected(archive_bucket, {
+                Expiration: { Days: 180 },
+                Transitions: [{ Date: new Date('2027-01-01T00:00:00.000Z'), StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidRequest',
+                "Found mixed 'Date' and 'Days' based Expiration and Transition actions in lifecycle rule for filter '(prefix=test/)'");
+        });
+
+        mocha.it('should reject duplicate StorageClass in Transitions', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [
+                    { Days: 90, StorageClass: 'DEEP_ARCHIVE' },
+                    { Days: 180, StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            }, 'InvalidRequest',
+                `'StorageClass' must be different for 'Transition' actions in same 'Rule' with filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should reject duplicate StorageClass before Days ordering', async function() {
+            await assert_rejected(archive_bucket, {
+                Transitions: [
+                    { Days: 90, StorageClass: 'GLACIER' },
+                    { Days: 30, StorageClass: 'GLACIER' },
+                ],
+            }, 'InvalidRequest',
+                `'StorageClass' must be different for 'Transition' actions in same 'Rule' with filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should reject Expiration Days that are not greater than Transition Days', async function() {
+            try {
+                await put_rule(archive_bucket, {
+                    Expiration: { Days: 180 },
+                    Transitions: [{ Days: 180, StorageClass: 'DEEP_ARCHIVE' }],
+                });
+                assert.fail('expected putBucketLifecycleConfiguration to fail with InvalidArgument');
+            } catch (err) {
+                assert.strictEqual(err.Code, 'InvalidArgument');
+                assert.strictEqual(err.message,
+                    `'Days' in the Expiration action for filter '(prefix=test/)' must be greater than 'Days' in the Transition action`);
+            }
+        });
+
+        mocha.it('should reject Expiration Date that is not greater than Transition Date', async function() {
+            const same_midnight = new Date('2027-01-01T00:00:00.000Z');
+            try {
+                await put_rule(archive_bucket, {
+                    Expiration: { Date: same_midnight },
+                    Transitions: [{ Date: same_midnight, StorageClass: 'DEEP_ARCHIVE' }],
+                });
+                assert.fail('expected putBucketLifecycleConfiguration to fail with InvalidArgument');
+            } catch (err) {
+                assert.strictEqual(err.Code, 'InvalidArgument');
+                assert.strictEqual(err.message,
+                    `'Date' in the Expiration action for filter '(prefix=test/)' must be greater than 'Date' in the Transition action`);
+            }
+        });
+
+        mocha.it('should reject NoncurrentVersionExpiration NoncurrentDays that are not greater than NoncurrentVersionTransition', async function() {
+            try {
+                await put_rule(archive_bucket, {
+                    NoncurrentVersionExpiration: { NoncurrentDays: 180 },
+                    NoncurrentVersionTransitions: [{ NoncurrentDays: 180, StorageClass: 'DEEP_ARCHIVE' }],
+                });
+                assert.fail('expected putBucketLifecycleConfiguration to fail with InvalidArgument');
+            } catch (err) {
+                assert.strictEqual(err.Code, 'InvalidArgument');
+                assert.strictEqual(err.message,
+                    `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '(prefix=test/)' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`);
+            }
+        });
+
+        mocha.it('should include And filter fields in the NoncurrentDays ordering error', async function() {
+            try {
+                await s3.putBucketLifecycleConfiguration({
+                    Bucket: archive_bucket,
+                    LifecycleConfiguration: {
+                        Rules: [{
+                            ID: 'validate-transition',
+                            Status: 'Enabled',
+                            Filter: {
+                                And: {
+                                    Prefix: 'test/',
+                                    ObjectSizeLessThan: 120120,
+                                },
+                            },
+                            NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                            NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' }],
+                        }],
+                    },
+                });
+                assert.fail('expected putBucketLifecycleConfiguration to fail with InvalidArgument');
+            } catch (err) {
+                assert.strictEqual(err.Code, 'InvalidArgument');
+                assert.strictEqual(err.message,
+                    `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '(prefix=test/ and objectsizelessthan=120120)' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`);
+            }
+        });
+
+        mocha.it('should include ObjectSizeGreaterThan in the filter error text', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: { ObjectSizeGreaterThan: 1048576 },
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidArgument',
+                `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '(objectsizegreaterthan=1048576)' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`);
+        });
+
+        mocha.it('should include Tag in the filter error text', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: { Tag: { Key: 'archive', Value: 'true' } },
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidArgument',
+                `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '(tag={key=archive, value=true})' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`);
+        });
+
+        mocha.it('should include Prefix, Tag, and ObjectSize in And filter error text', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: {
+                    And: {
+                        Prefix: 'test/',
+                        Tags: [{ Key: 'archive', Value: 'true' }],
+                        ObjectSizeGreaterThan: 500,
+                        ObjectSizeLessThan: 120120,
+                    },
+                },
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' }],
+            }, 'InvalidArgument',
+                `'NoncurrentDays' in the NoncurrentVersionExpiration action for filter '(prefix=test/ and tag={key=archive, value=true} and objectsizegreaterthan=500 and objectsizelessthan=120120)' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action`);
+        });
+
+        mocha.it('should reject Prefix combined with ObjectSize at Filter top level without And', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: { Prefix: 'test/', ObjectSizeLessThan: 120120 },
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject negative NoncurrentDays', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: -1, StorageClass: 'GLACIER' }],
+            }, 'InvalidArgument',
+                "'NoncurrentDays' in NoncurrentVersionTransition action must be nonnegative");
+        });
+
+        mocha.it('should reject NewerNoncurrentVersions that is not a positive integer', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{
+                    NoncurrentDays: 1,
+                    NewerNoncurrentVersions: 0,
+                    StorageClass: 'DEEP_ARCHIVE',
+                }],
+            }, 'InvalidArgument',
+                'NewerNoncurrentVersions must be a positive integer');
+        });
+
+        mocha.it('should accept Transition Days=0 with StorageClass=DEEP_ARCHIVE', async function() {
+            await put_rule(archive_bucket, {
+                Transitions: [{ Days: 0, StorageClass: 'DEEP_ARCHIVE' }],
+            });
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
+            assert.strictEqual(res.Rules[0].Transitions[0].Days, 0);
+            assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'DEEP_ARCHIVE');
+        });
+
+        mocha.it('should accept ExpiredObjectDeleteMarker together with Transition', async function() {
+            await put_rule(archive_bucket, {
+                Expiration: { ExpiredObjectDeleteMarker: true },
+                Transitions: [{ Days: 12, StorageClass: 'DEEP_ARCHIVE' }],
+            });
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
+            assert.strictEqual(res.Rules[0].Expiration.ExpiredObjectDeleteMarker, true);
+            assert.strictEqual(res.Rules[0].Transitions[0].Days, 12);
+        });
+
+        mocha.it('should reject NoncurrentVersionTransition that omits StorageClass', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1 }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject NoncurrentVersionTransition that omits NoncurrentDays', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{ StorageClass: 'GLACIER' }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject empty NoncurrentVersionTransition action', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{}],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject StorageClass that is not GLACIER or DEEP_ARCHIVE on NoncurrentVersionTransition', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'STANDARD_IA' }],
+            }, 'MalformedXML');
+        });
+
+        mocha.it('should reject duplicate StorageClass in NoncurrentVersionTransitions', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [
+                    { NoncurrentDays: 30, StorageClass: 'DEEP_ARCHIVE' },
+                    { NoncurrentDays: 90, StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            }, 'InvalidRequest',
+                `'StorageClass' must be different for 'NoncurrentVersionTransition' actions in same 'Rule' with filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should reject duplicate StorageClass before NoncurrentDays ordering', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [
+                    { NoncurrentDays: 90, StorageClass: 'GLACIER' },
+                    { NoncurrentDays: 30, StorageClass: 'GLACIER' },
+                ],
+            }, 'InvalidRequest',
+                `'StorageClass' must be different for 'NoncurrentVersionTransition' actions in same 'Rule' with filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should include Tag in duplicate StorageClass error text', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: { Tag: { Key: 'archive', Value: 'true' } },
+                Transitions: [
+                    { Days: 30, StorageClass: 'GLACIER' },
+                    { Days: 90, StorageClass: 'GLACIER' },
+                ],
+            }, 'InvalidRequest',
+                `'StorageClass' must be different for 'Transition' actions in same 'Rule' with filter '(tag={key=archive, value=true})'`);
+        });
+
+        mocha.it('should reject DEEP_ARCHIVE Days that are not greater than GLACIER Days', async function() {
+            await assert_rejected(archive_bucket, {
+                Filter: {
+                    And: { Prefix: 'test/', ObjectSizeLessThan: 120120 },
+                },
+                Transitions: [
+                    { Days: 1, StorageClass: 'DEEP_ARCHIVE' },
+                    { Days: 1, StorageClass: 'GLACIER' },
+                ],
+            }, 'InvalidArgument',
+                `'Days' in the Transition action for StorageClass 'DEEP_ARCHIVE' for filter '(prefix=test/ and objectsizelessthan=120120)' must be greater than 'Days' in the Transition action for StorageClass 'GLACIER' for filter '(prefix=test/ and objectsizelessthan=120120)'`);
+        });
+
+        mocha.it('should reject DEEP_ARCHIVE Date that is not greater than GLACIER Date', async function() {
+            const midnight = new Date('2027-01-01T00:00:00.000Z');
+            await assert_rejected(archive_bucket, {
+                Transitions: [
+                    { Date: midnight, StorageClass: 'GLACIER' },
+                    { Date: midnight, StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            }, 'InvalidArgument',
+                `'Date' in the Transition action for StorageClass 'DEEP_ARCHIVE' for filter '(prefix=test/)' must be greater than 'Date' in the Transition action for StorageClass 'GLACIER' for filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should reject DEEP_ARCHIVE NoncurrentDays that are not greater than GLACIER NoncurrentDays', async function() {
+            await assert_rejected(archive_bucket, {
+                NoncurrentVersionTransitions: [
+                    { NoncurrentDays: 1, StorageClass: 'GLACIER' },
+                    { NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            }, 'InvalidArgument',
+                `'NoncurrentDays' in the NoncurrentVersionTransition action for StorageClass 'DEEP_ARCHIVE' for filter '(prefix=test/)' must be greater than 'NoncurrentDays' in the NoncurrentVersionTransition action for StorageClass 'GLACIER' for filter '(prefix=test/)'`);
+        });
+
+        mocha.it('should accept GLACIER then later DEEP_ARCHIVE Transitions in the same rule', async function() {
+            await put_rule(archive_bucket, {
+                Transitions: [
+                    { Days: 30, StorageClass: 'GLACIER' },
+                    { Days: 90, StorageClass: 'DEEP_ARCHIVE' },
+                ],
+            });
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
+            assert.strictEqual(res.Rules[0].Transitions.length, 2);
+            assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'GLACIER');
+            assert.strictEqual(res.Rules[0].Transitions[1].StorageClass, 'DEEP_ARCHIVE');
+        });
+
+        mocha.it('should accept the same StorageClass on Transition and NoncurrentVersionTransition', async function() {
+            await put_rule(archive_bucket, {
+                Transitions: [{ Days: 1, StorageClass: 'DEEP_ARCHIVE' }],
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'DEEP_ARCHIVE' }],
+            });
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
+            assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'DEEP_ARCHIVE');
+            assert.strictEqual(res.Rules[0].NoncurrentVersionTransitions[0].StorageClass, 'DEEP_ARCHIVE');
+        });
+
+        mocha.it('should accept Date-based Transition at midnight UTC', async function() {
+            const midnight = new Date('2026-01-01T00:00:00.000Z');
+            await put_rule(archive_bucket, {
+                Transitions: [{ Date: midnight, StorageClass: 'GLACIER' }],
+            });
+            const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
+            assert.strictEqual(new Date(res.Rules[0].Transitions[0].Date).getTime(), midnight.getTime());
+            assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'GLACIER');
         });
     });
 });

--- a/src/test/integration_tests/api/s3/test_s3_ops.js
+++ b/src/test/integration_tests/api/s3/test_s3_ops.js
@@ -290,8 +290,7 @@ mocha.describe('s3_ops', function() {
                 assert.strictEqual(res.Rules[0].Expiration.Days, 1);
             });
 
-            mocha.it('should put and get bucket lifecycle with Transitions', async function() {
-                // put bucket lifecycle
+            mocha.it('should reject Transitions when the bucket has no archive policy', async function() {
                 const params = {
                     Bucket: "lifecycle-bucket",
                     LifecycleConfiguration: {
@@ -301,25 +300,22 @@ mocha.describe('s3_ops', function() {
                             Prefix: 'prefix1-transition',
                             Transitions: [{
                                 Days: 1,
-                                StorageClass: 'STANDARD_IA'
+                                StorageClass: 'DEEP_ARCHIVE'
                             }]
                         }]
                     }
                 };
-                await s3.putBucketLifecycleConfiguration(params);
-
-                // get bucket lifecycle
-                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
-                assert.strictEqual(res.Rules.length, 1);
-                assert.strictEqual(res.Rules[0].ID, 'rule1');
-                assert.strictEqual(res.Rules[0].Status, 'Enabled');
-                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-transition');
-                assert.strictEqual(res.Rules[0].Transitions[0].Days, 1);
-                assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'STANDARD_IA');
+                try {
+                    await s3.putBucketLifecycleConfiguration(params);
+                    assert.fail('expected Transition without archive policy to fail');
+                } catch (err) {
+                    assert.strictEqual(err.Code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                        "'Transition' and 'NoncurrentVersionTransition' actions require the bucket to have an archive policy attached.");
+                }
             });
 
-            mocha.it('should put and get bucket lifecycle with NoncurrentVersionTransition', async function() {
-                // put bucket lifecycle
+            mocha.it('should reject NoncurrentVersionTransition when the bucket has no archive policy', async function() {
                 const params = {
                     Bucket: "lifecycle-bucket",
                     LifecycleConfiguration: {
@@ -329,21 +325,19 @@ mocha.describe('s3_ops', function() {
                             Prefix: 'prefix1-noncurrent-version-transition',
                             NoncurrentVersionTransitions: [{
                                 NoncurrentDays: 1,
-                                StorageClass: 'STANDARD_IA'
+                                StorageClass: 'DEEP_ARCHIVE'
                             }]
                         }]
                     }
                 };
-                await s3.putBucketLifecycleConfiguration(params);
-
-                // get bucket lifecycle
-                const res = await s3.getBucketLifecycleConfiguration({ Bucket: "lifecycle-bucket" });
-                assert.strictEqual(res.Rules.length, 1);
-                assert.strictEqual(res.Rules[0].ID, 'rule1');
-                assert.strictEqual(res.Rules[0].Status, 'Enabled');
-                assert.strictEqual(res.Rules[0].Prefix, 'prefix1-noncurrent-version-transition');
-                assert.strictEqual(res.Rules[0].NoncurrentVersionTransitions[0].NoncurrentDays, 1);
-                assert.strictEqual(res.Rules[0].NoncurrentVersionTransitions[0].StorageClass, 'STANDARD_IA');
+                try {
+                    await s3.putBucketLifecycleConfiguration(params);
+                    assert.fail('expected NoncurrentVersionTransition without archive policy to fail');
+                } catch (err) {
+                    assert.strictEqual(err.Code, 'InvalidRequest');
+                    assert.strictEqual(err.message,
+                        "'Transition' and 'NoncurrentVersionTransition' actions require the bucket to have an archive policy attached.");
+                }
             });
 
             mocha.it('should put and get bucket lifecycle with AbortIncompleteMultipartUpload', async function() {


### PR DESCRIPTION
### Describe the Problem
AWS S3 deprecates singular Transition / NoncurrentVersionTransition actions per lifecycle rule and now allows Plural  Transitions / NoncurrentVersionTransitions actions per rule.
NooBaa missing validation for transition/NoncurrentVersionTransition actions - for example - archive policy missing on the bucket, storage class, Days vs Date, ordering vs expiration, duplicates, or related fields the way AWS does.

### Explain the Changes
1. common_api.js — store transitions and noncurrent_version_transitions as arrays (no migration; not used in production).
2. s3_put_bucket_lifecycle.js — parse every <Transition> / <NoncurrentVersionTransition> element and validate them against AWS (archive policy required, GLACIER/DEEP_ARCHIVE storage_class only, Days xor Date, mixed Days/Date, Expiration/NoncurrentVersionExpiration ordering, duplicate StorageClass, midnight UTC Date, non-negative Days, filter text in errors).
3. s3_get_bucket_lifecycle.js — return all stored transitions as repeated XML elements.
4. lifecycle.js — apply each transition / NoncurrentVersionTransition entry on the rule (still only DEEP_ARCHIVE and GLACIER).
5. Tests and design doc — multi-transition PUT/GET round-trip, PUT validation coverage, archive-policy rejects in test_s3_ops.js, and a note that a rule may include multiple Transitions/NoncurrentVersionTransitions.
6. 2 bug fixes -  
a. lifecycle didn't run when both transition and noncurrentversionTransition actions were set if the bucket's versioning state was disabled, the fix was to run only transition action.
b. transition date parsing called parse_lifecycle_field() instead of date: parse_date_field(tran.Date, 'Date').


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
auto -

npm run mocha -- --grep 'lifecycle-transitions'
npm run mocha -- --grep 'bucket-lifecycle'



- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple current-version and noncurrent-version lifecycle transitions.
  - Lifecycle configurations now preserve and return all transition actions.
  - Lifecycle processing executes each configured transition independently.

- **Bug Fixes**
  - Improved validation for storage classes, dates, ordering, duplicates, filters, and archive-policy requirements.
  - Correctly supports valid zero-day transitions and rejects unsupported configurations with clear errors.

- **Documentation**
  - Updated lifecycle API documentation, CLI examples, and verification output for multiple transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->