### PR TITLE
fs worker stats field name rectification

### DIFF
--- a/src/server/analytic_services/prometheus_reporting.js
+++ b/src/server/analytic_services/prometheus_reporting.js
@@ -325,14 +325,14 @@ function set_iam_ops_stats(ops_stats) {
 }
 
 function set_fs_worker_stats(fs_worker_stats) {
-    const op_stats_counters = {};
+    const fs_worker_stats_counters = {};
     // Building the report per op name key and value
-    for (const [op_name, obj] of Object.entries(fs_worker_stats)) {
+    for (const [fs_op_name, obj] of Object.entries(fs_worker_stats)) {
         for (const [key, value] of Object.entries(obj)) {
-            op_stats_counters[`noobaa_nsfs_op_${op_name}_${key}`.toLowerCase()] = value;
+            fs_worker_stats_counters[`noobaa_nsfs_fs_worker_${fs_op_name}_${key}`.toLowerCase()] = value;
         }
     }
-    fs_worker_stats_complete = op_stats_counters;
+    fs_worker_stats_complete = fs_worker_stats_counters;
 }
 
 // -----------------------------------------


### PR DESCRIPTION
### Describe the Problem
FS worker metrics were exposed with the noobaa_nsfs_op_* prefix on the forked endpoint path, even though they belong under fs_worker_stats_counters and should use the noobaa_nsfs_fs_worker_* namespace. This made FS worker metric names inconsistent between code paths and with the intended metrics contract.

### Explain the Changes
1. Updated set_fs_worker_stats() in Prometheus reporting to emit FS worker metrics with the noobaa_nsfs_fs_worker_* prefix instead of the S3 op-style noobaa_nsfs_op_* prefix.
2. Renamed the local accumulator variables in the same function to match the FS worker metric family, keeping the exported payload shape the same while making the implementation consistent and clearer.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Start NSFS without forks, generate a few filesystem-backed operations, and verify /metrics/nsfs_stats returns fs_worker_stats_counters keys prefixed with noobaa_nsfs_fs_worker_.
2. Restart NSFS with --forks 2, generate the same operations, and verify fs_worker_stats_counters still uses the noobaa_nsfs_fs_worker_ prefix instead of noobaa_nsfs_op_.
3. Confirm op_stats_counters continues to expose S3 operation metrics under the noobaa_nsfs_op_* namespace.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected filesystem worker metric naming for more accurate monitoring and reporting.
  * Filesystem worker statistics continue to be included in completed metrics reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->