### PR TITLE
AgentBlocksReclaimer should handle invalid blocks

### DIFF
--- a/src/server/bg_services/agent_blocks_reclaimer.js
+++ b/src/server/bg_services/agent_blocks_reclaimer.js
@@ -113,7 +113,8 @@ class AgentBlocksReclaimer {
      * @override in unit tests for decoupling dependencies
      */
     populate_nodes_for_blocks(blocks) {
-        return map_server.prepare_blocks_from_db(blocks);
+        return map_server.prepare_blocks_from_db(blocks,
+            /*include_empty_blocks=*/true);
     }
 
 }

--- a/src/server/bg_services/agent_blocks_verifier.js
+++ b/src/server/bg_services/agent_blocks_verifier.js
@@ -81,7 +81,7 @@ class AgentBlocksVerifier {
         if (!populated_blocks || !populated_blocks.length) return;
         const blocks_with_alive_nodes = populated_blocks.filter(block =>
             block.node && block.node.rpc_address && block.node.online);
-        if (!blocks_with_alive_nodes || !blocks_with_alive_nodes.length) return;
+        if (!blocks_with_alive_nodes.length) return;
         return populated_blocks.map(block => block.to_block_md());
     }
 

--- a/src/server/object_services/map_db_types.js
+++ b/src/server/object_services/map_db_types.js
@@ -318,8 +318,8 @@ class BlockDB {
             pool: optional_id_str(this.block_db.pool),
             address: this.node && this.node.rpc_address,
             size: this.block_db.size,
-            digest_type: this.digest_type || this.chunk.chunk_coder_config.frag_digest_type,
-            digest_b64: this.frag.digest_b64,
+            digest_type: this.digest_type || this.chunk?.chunk_coder_config?.frag_digest_type,
+            digest_b64: this.frag?.digest_b64,
             node_type: this.node && this.node.node_type,
             is_preallocated: this.is_preallocated,
         };

--- a/src/server/object_services/map_server.js
+++ b/src/server/object_services/map_server.js
@@ -629,19 +629,34 @@ async function prepare_blocks(blocks) {
 /**
  *
  * @param {nb.BlockSchemaDB[]} blocks
+ * @param {boolean} include_empty_blocks - include blocks with no valid chunks in return
  * @return {Promise<nb.Block[]>}
  */
-async function prepare_blocks_from_db(blocks) {
-    const chunk_ids = blocks.map(block => block.chunk);
+async function prepare_blocks_from_db(blocks, include_empty_blocks) {
+    const chunk_ids = blocks.map(block => block.chunk).filter(Boolean);
     const chunks = await MDStore.instance().find_chunks_by_ids(chunk_ids);
     const chunks_by_id = _.keyBy(chunks, '_id');
-    const db_blocks = blocks.map(block => {
-        const chunk_db = new ChunkDB(chunks_by_id[block.chunk.toHexString()]);
-        const frag_db = _.find(chunk_db.frags, frag =>
-            frag._id.toHexString() === block.frag.toHexString());
+    const db_blocks = _.compact(blocks.map(block => {
+        let valid_block = true;
+        if (!block.chunk || !chunks_by_id[block.chunk.toHexString()]) {
+            valid_block = false;
+        }
+
+        if (!include_empty_blocks && !valid_block) {
+            dbg.error('skipping invalid block with no matching chunk', block);
+            return null;
+        }
+
+        let chunk_db;
+        let frag_db;
+        if (valid_block) {
+            chunk_db = new ChunkDB(chunks_by_id[block.chunk.toHexString()]);
+            frag_db = _.find(chunk_db.frags, frag =>
+                frag._id.toHexString() === block.frag.toHexString());
+        }
         const block_db = new BlockDB(block, frag_db, chunk_db);
         return block_db;
-    });
+    }));
     await prepare_blocks(db_blocks);
     return db_blocks;
 }

--- a/src/test/integration_tests/internal/test_agent_blocks_reclaimer.js
+++ b/src/test/integration_tests/internal/test_agent_blocks_reclaimer.js
@@ -19,6 +19,7 @@ const MDStore = require('../../../server/object_services/md_store').MDStore;
 const ObjectIO = require('../../../sdk/object_io');
 const SliceReader = require('../../../util/slice_reader');
 const AgentBlocksReclaimer = require('../../../server/bg_services/agent_blocks_reclaimer').AgentBlocksReclaimer;
+const map_server = require('../../../server/object_services/map_server');
 
 class ReclaimerMock extends AgentBlocksReclaimer {
 
@@ -175,6 +176,76 @@ mocha.describe('not mocked agent_blocks_reclaimer', function() {
             console.error(err, err.stack);
             throw err;
         }
+    });
+
+    mocha.it('should reclaim deleted blocks when chunks are missing', async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(40000);
+        const obj_key = 'sloth_obj_missing_chunk';
+        const agent_blocks_reclaimer = new AgentBlocksReclaimer(self.test.title);
+
+        const obj_id = await upload_object(obj_key, obj_data, obj_size);
+        const chunk_ids = await MDStore.instance().find_parts_chunk_ids({
+            _id: db_client.instance().parse_object_id(obj_id)
+        });
+        const blocks_uploaded = await MDStore.instance().find_blocks_of_chunks(chunk_ids);
+        await MDStore.instance()._blocks.updateMany({
+            _id: { $in: blocks_uploaded.map(block => block._id) }
+        }, {
+            $set: { deleted: new Date() }
+        });
+        await MDStore.instance()._chunks.deleteMany({
+            _id: { $in: chunk_ids }
+        });
+
+        await agent_blocks_reclaimer.run_batch();
+        while (agent_blocks_reclaimer.marker) {
+            await agent_blocks_reclaimer.run_batch();
+        }
+
+        const blocks = await MDStore.instance()._blocks.find({
+            _id: { $in: blocks_uploaded.map(block => block._id) }
+        });
+        assert(blocks.length > 0, 'expected uploaded blocks to still exist');
+        assert(_.every(blocks, block => block.reclaimed), 'NOT ALL BLOCKS WERE RECLAIMED');
+    });
+
+    mocha.it('should handle missing chunks in prepare_blocks_from_db', async function() {
+        const self = this; // eslint-disable-line no-invalid-this
+        self.timeout(40000);
+        const obj_key = 'sloth_obj_prepare_missing_chunk';
+
+        const obj_id = await upload_object(obj_key, obj_data, obj_size);
+        const chunk_ids = await MDStore.instance().find_parts_chunk_ids({
+            _id: db_client.instance().parse_object_id(obj_id)
+        });
+        const real_blocks = await MDStore.instance().find_blocks_of_chunks(chunk_ids);
+        assert(real_blocks.length > 0, 'expected uploaded object to have blocks');
+
+        const missing_chunk_block = {
+            ...real_blocks[0],
+            _id: new mongodb.ObjectId(),
+            chunk: new mongodb.ObjectId(),
+        };
+        const no_chunk_block = {
+            ...real_blocks[0],
+            _id: new mongodb.ObjectId(),
+            chunk: undefined,
+        };
+
+        const included = await map_server.prepare_blocks_from_db(
+            [missing_chunk_block, no_chunk_block], true);
+        assert.strictEqual(included.length, 2);
+        assert.ok(included.every(Boolean), 'include path must not have undefined elements');
+        assert.strictEqual(included[0].chunk, undefined);
+        assert.strictEqual(included[1].chunk, undefined);
+        assert.doesNotThrow(() => included[0].to_block_md());
+
+        const skipped = await map_server.prepare_blocks_from_db(
+            [missing_chunk_block, no_chunk_block, real_blocks[0]], false);
+        assert.strictEqual(skipped.length, 1);
+        assert.ok(skipped.every(Boolean), 'skip path must not have undefined elements');
+        assert.strictEqual(String(skipped[0]._id), String(real_blocks[0]._id));
     });
 
     async function upload_object(key, data, size) {

--- a/src/test/unit_tests/internal/test_map_server.js
+++ b/src/test/unit_tests/internal/test_map_server.js
@@ -1,0 +1,181 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+/** @typedef {typeof import('../../../sdk/nb')} nb */
+
+const coretest = require('../../utils/coretest/coretest');
+coretest.no_setup();
+
+const mocha = require('mocha');
+const assert = require('assert');
+const sinon = require('sinon');
+const mongodb = require('mongodb');
+
+const MDStore = require('../../../server/object_services/md_store').MDStore;
+const nodes_client = require('../../../server/node_services/nodes_client');
+const system_store = require('../../../server/system_services/system_store').get_instance();
+const map_server = require('../../../server/object_services/map_server');
+const { BlockDB } = require('../../../server/object_services/map_db_types');
+
+mocha.describe('test map_server', function() {
+    mocha.describe('prepare_blocks_from_db missing chunks', function() {
+        const pool_id = new mongodb.ObjectId();
+        const node_id = new mongodb.ObjectId();
+        const system = { _id: new mongodb.ObjectId() };
+        const pool = { _id: pool_id, name: 'pool1', system };
+        const node = {
+            _id: node_id,
+            pool: 'pool1',
+            rpc_address: 'n2n://test',
+            node_type: 'BLOCK_STORE_FS',
+        };
+
+        let sandbox;
+        let find_chunks_by_ids;
+        let list_nodes_by_identity;
+        let orig_data;
+
+        mocha.beforeEach(function() {
+            sandbox = sinon.createSandbox();
+            find_chunks_by_ids = sandbox.stub();
+            list_nodes_by_identity = sandbox.stub().resolves({ nodes: [node] });
+            sandbox.stub(MDStore, 'instance').returns({ find_chunks_by_ids });
+            sandbox.stub(nodes_client, 'instance').returns({ list_nodes_by_identity });
+            orig_data = system_store.data;
+            system_store.data = {
+                get_by_id(id) {
+                    return String(id) === String(pool_id) ? pool : null;
+                },
+                systems: [{ pools_by_name: { pool1: pool } }],
+            };
+        });
+
+        mocha.afterEach(function() {
+            system_store.data = orig_data;
+            sandbox.restore();
+        });
+
+        mocha.it('includes blocks with no matching chunk when include_empty_blocks is true', async function() {
+            find_chunks_by_ids.resolves([]);
+            const block = make_block({ chunk: new mongodb.ObjectId() });
+
+            const db_blocks = await map_server.prepare_blocks_from_db([block], true);
+
+            assert.strictEqual(db_blocks.length, 1);
+            assert.ok(db_blocks[0] instanceof BlockDB);
+            assert.strictEqual(db_blocks[0].chunk, undefined);
+            assert.strictEqual(db_blocks[0].frag, undefined);
+            const block_md = db_blocks[0].to_block_md();
+            assert.strictEqual(block_md.id, String(block._id));
+            assert.strictEqual(block_md.digest_type, undefined);
+            assert.strictEqual(block_md.digest_b64, undefined);
+        });
+
+        mocha.it('does not throw when block.chunk is missing', async function() {
+            find_chunks_by_ids.resolves([]);
+            const block = make_block({ chunk: undefined });
+
+            const included = await map_server.prepare_blocks_from_db([block], true);
+            assert.strictEqual(included.length, 1);
+            assert.strictEqual(included[0].chunk, undefined);
+
+            const skipped = await map_server.prepare_blocks_from_db([block], false);
+            assert.strictEqual(skipped.length, 0);
+            assert.strictEqual(list_nodes_by_identity.callCount, 1, 'skip path should not populate nodes for empty results');
+        });
+
+        mocha.it('skips missing-chunk blocks when include_empty_blocks is false', async function() {
+            const frag = make_frag();
+            const chunk = make_chunk(frag);
+            const valid_block = make_block({ chunk: chunk._id, frag: frag._id });
+            const missing_block = make_block({ chunk: new mongodb.ObjectId(), frag: frag._id });
+            find_chunks_by_ids.resolves([chunk]);
+
+            const db_blocks = await map_server.prepare_blocks_from_db([missing_block, valid_block], false);
+
+            assert.strictEqual(db_blocks.length, 1);
+            assert.ok(db_blocks.every(Boolean), 'result must not contain undefined elements');
+            assert.strictEqual(String(db_blocks[0]._id), String(valid_block._id));
+            assert.ok(db_blocks[0].chunk);
+        });
+
+        mocha.it('keeps both valid and missing-chunk blocks when include_empty_blocks is true', async function() {
+            const frag = make_frag();
+            const chunk = make_chunk(frag);
+            const valid_block = make_block({ chunk: chunk._id, frag: frag._id });
+            const missing_block = make_block({ chunk: new mongodb.ObjectId(), frag: frag._id });
+            find_chunks_by_ids.resolves([chunk]);
+
+            const db_blocks = await map_server.prepare_blocks_from_db([missing_block, valid_block], true);
+
+            assert.strictEqual(db_blocks.length, 2);
+            assert.ok(db_blocks.every(Boolean), 'result must not contain undefined elements');
+            assert.strictEqual(db_blocks[0].chunk, undefined);
+            assert.ok(db_blocks[1].chunk);
+            assert.doesNotThrow(() => db_blocks[0].to_block_md());
+        });
+
+        /**
+         * @param {{ chunk?: nb.ID, frag?: nb.ID }} params
+         * @returns {nb.BlockSchemaDB}
+         */
+        function make_block({ chunk, frag } = {}) {
+            return {
+                _id: new mongodb.ObjectId(),
+                node: node_id,
+                frag: frag || new mongodb.ObjectId(),
+                chunk,
+                system: system._id,
+                bucket: new mongodb.ObjectId(),
+                pool: pool_id,
+                size: 20,
+            };
+        }
+
+        /**
+         * @returns {nb.FragSchemaDB}
+         */
+        function make_frag() {
+            return {
+                _id: new mongodb.ObjectId(),
+                digest: Buffer.from('digest'),
+            };
+        }
+
+        /**
+         * @param {nb.FragSchemaDB} frag
+         * @returns {nb.ChunkSchemaDB}
+         */
+        function make_chunk(frag) {
+            return {
+                _id: new mongodb.ObjectId(),
+                system: system._id,
+                bucket: new mongodb.ObjectId(),
+                tier: new mongodb.ObjectId(),
+                tier_lru: new Date(),
+                chunk_config: new mongodb.ObjectId(),
+                size: 10,
+                compress_size: 10,
+                frag_size: 10,
+                frags: [frag],
+            };
+        }
+    });
+
+    mocha.describe('BlockDB.to_block_md missing chunk', function() {
+
+        mocha.it('does not throw when chunk and frag are undefined', function() {
+            const block = new BlockDB({
+                _id: new mongodb.ObjectId(),
+                node: new mongodb.ObjectId(),
+                pool: new mongodb.ObjectId(),
+                size: 10,
+            }, undefined, undefined);
+            const md = block.to_block_md();
+            assert.strictEqual(md.id, String(block._id));
+            assert.strictEqual(md.digest_type, undefined);
+            assert.strictEqual(md.digest_b64, undefined);
+        });
+
+    });
+});

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -55,6 +55,7 @@ require('../../integration_tests/internal/test_map_deleter');
 require('../../unit_tests/internal/test_chunk_coder');
 require('../../unit_tests/internal/test_chunk_splitter');
 require('../../unit_tests/internal/test_chunk_config_utils');
+require('../../unit_tests/internal/test_map_server');
 require('../../unit_tests/internal/test_core_init');
 //require('./test_md_aggregator_unit');
 require('../../integration_tests/internal/test_agent_blocks_verifier');


### PR DESCRIPTION
### Describe the Problem
In an earlier issue with db_cleaner we had scenario where chunks which were referenced by valid blocks were removed. This scenario causes a crash of AgentBlocksReclaimer when it tries to load the frags for the chunk.

### Explain the Changes
1. For reclaimer, we don't need the chunks and frags to be present. So conditionally include blocks which dont have these but prevent the chunks and frags from being initialized for these blocks.
2. For AgentBlocksVerifier, log an error for this scenario and skip those blocks since we dont want further processing for these blocks.


Note: Fixed an unrelated issue in agent_blocks_verifier that was causing DCO check to fail: `check condition '!blocks_with_alive_nodes' is always false. The value of variable 'blocks_with_alive_nodes' is originated from the return value of 'Array.prototype.filter()'`

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocks whose associated chunk or fragment data is unavailable.
  * Prevented errors when processing blocks with missing chunk references.
  * Empty blocks can now be retained when explicitly requested; otherwise, unmatched blocks continue to be skipped.

* **Tests**
  * Added unit and integration coverage for missing chunks, deleted chunks, and empty-block handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->