### PR TITLE
DEEP_ARCHIVE | Fix - `list_objects_versions` To Omit `restore_status` Expiry Invalid or in the Past

### DIFF
--- a/src/endpoint/s3/ops/s3_get_bucket.js
+++ b/src/endpoint/s3/ops/s3_get_bucket.js
@@ -27,15 +27,7 @@ async function get_bucket(req) {
     const cont_tok = req.query['continuation-token'];
     const start_after = req.query['start-after'];
 
-    const optional_object_attributes = req.headers['x-amz-optional-object-attributes'];
-    const restore_status_requested = optional_object_attributes === 'RestoreStatus';
-
-    // Only RestoreStatus is a valid attribute for now
-    if (optional_object_attributes && !restore_status_requested) {
-        // S3 API fails with `InvalidArgument` and this message
-        throw new S3Error({ ...S3Error.InvalidArgument, message: 'Invalid attribute name specified' });
-    }
-
+    const restore_status_requested = s3_utils.parse_optional_object_attributes_header(req.headers);
 
     const params = {
         bucket: req.params.bucket,
@@ -84,7 +76,7 @@ async function get_bucket(req) {
                 Size: obj.size,
                 Owner: (!list_type || req.query['fetch-owner']) && (s3_utils.get_object_owner(obj) || default_object_owner),
                 StorageClass: s3_utils.parse_storage_class(obj.storage_class),
-                RestoreStatus: get_object_restore_status(obj, restore_status_requested)
+                RestoreStatus: s3_utils.get_object_restore_status(obj, restore_status_requested)
             }
         })),
         _.map(reply.common_prefixes, prefix => ({
@@ -94,21 +86,6 @@ async function get_bucket(req) {
         }))
         ]
     };
-}
-
-function get_object_restore_status(obj, restore_status_requested) {
-    if (!restore_status_requested || !obj.restore_status) {
-        return;
-    }
-
-    const restore_status = {
-        IsRestoreInProgress: obj.restore_status.ongoing,
-    };
-    if (!obj.restore_status.ongoing && obj.restore_status.expiry_time) {
-        restore_status.RestoreExpiryDate = new Date(obj.restore_status.expiry_time).toUTCString();
-    }
-
-    return restore_status;
 }
 
 module.exports = {

--- a/src/endpoint/s3/ops/s3_get_bucket_versions.js
+++ b/src/endpoint/s3/ops/s3_get_bucket_versions.js
@@ -21,6 +21,9 @@ async function get_bucket_versions(req) {
         dbg.warn('A version-id marker cannot be specified without a key marker');
         throw new S3Error(S3Error.InvalidArgument);
     }
+
+    const restore_status_requested = s3_utils.parse_optional_object_attributes_header(req.headers);
+
     const version_id_marker = s3_utils.parse_version_id(req.query['version-id-marker'], S3Error.InvalidArgumentEmptyVersionIdMarker);
     const reply = await req.object_sdk.list_object_versions({
         bucket: req.params.bucket,
@@ -65,6 +68,7 @@ async function get_bucket_versions(req) {
                 Size: obj.size,
                 Owner: s3_utils.get_object_owner(obj) || default_object_owner,
                 StorageClass: s3_utils.parse_storage_class(obj.storage_class),
+                RestoreStatus: s3_utils.get_object_restore_status(obj, restore_status_requested),
             }
         }))),
         _.map(reply.common_prefixes, prefix => ({

--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -884,6 +884,46 @@ function parse_s3_restore_field(restore_field) {
 }
 
 
+/**
+ * Parses x-amz-optional-object-attributes and returns whether RestoreStatus was requested
+ * @param {import('http').IncomingHttpHeaders} headers
+ * @returns {boolean}
+ */
+function parse_optional_object_attributes_header(headers) {
+    const optional_object_attributes_header = headers['x-amz-optional-object-attributes'];
+    const optional_object_attributes = Array.isArray(optional_object_attributes_header) ?
+        optional_object_attributes_header[0] : optional_object_attributes_header;
+    const restore_status_requested = optional_object_attributes === 'RestoreStatus';
+
+    // Only RestoreStatus is a valid attribute for now
+    if (optional_object_attributes && !restore_status_requested) {
+        throw new S3Error({ ...S3Error.InvalidArgument, message: 'Invalid attribute name specified' });
+    }
+    return restore_status_requested;
+}
+
+/**
+ * Returns RestoreStatus XML fields when requested and object has restore_status
+ * @param {nb.ObjectInfo} obj
+ * @param {boolean} restore_status_requested
+ * @returns {{ IsRestoreInProgress: boolean | undefined, RestoreExpiryDate?: string } | undefined}
+ */
+function get_object_restore_status(obj, restore_status_requested) {
+    if (!restore_status_requested || !obj.restore_status) {
+        return;
+    }
+
+    /** @type {{ IsRestoreInProgress: boolean | undefined, RestoreExpiryDate?: string }} */
+    const restore_status = {
+        IsRestoreInProgress: obj.restore_status.ongoing,
+    };
+    if (!obj.restore_status.ongoing && obj.restore_status.expiry_time) {
+        restore_status.RestoreExpiryDate = new Date(obj.restore_status.expiry_time).toUTCString();
+    }
+
+    return restore_status;
+}
+
 exports.STORAGE_CLASS_STANDARD = STORAGE_CLASS_STANDARD;
 exports.STORAGE_CLASS_GLACIER = STORAGE_CLASS_GLACIER;
 exports.STORAGE_CLASS_GLACIER_IR = STORAGE_CLASS_GLACIER_IR;
@@ -931,6 +971,8 @@ exports.parse_sse_c = parse_sse_c;
 exports.verify_string_byte_length = verify_string_byte_length;
 exports.parse_body_public_access_block = parse_body_public_access_block;
 exports.parse_s3_restore_field = parse_s3_restore_field;
+exports.parse_optional_object_attributes_header = parse_optional_object_attributes_header;
+exports.get_object_restore_status = get_object_restore_status;
 exports.OBJECT_ATTRIBUTES = OBJECT_ATTRIBUTES;
 exports.OBJECT_ATTRIBUTES_UNSUPPORTED = OBJECT_ATTRIBUTES_UNSUPPORTED;
 exports.GLACIER_STORAGE_CLASSES = GLACIER_STORAGE_CLASSES;

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -115,12 +115,17 @@ class NamespaceMultiStorageClass {
 
     /**
      * Lists object versions from the metadata namespace only.
+     * Omits restore_status on each object when restore is expired or incomplete.
      * @param {object} params
      * @param {nb.ObjectSDK} object_sdk
      * @returns {Promise<object>}
      */
     async list_object_versions(params, object_sdk) {
-        return this._metadata_ns.list_object_versions(params, object_sdk);
+        const reply = await this._metadata_ns.list_object_versions(params, object_sdk);
+        return {
+            ...reply,
+            objects: reply.objects.map(obj => this._omit_inactive_restore_status(obj)),
+        };
     }
 
     /////////////////

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
@@ -96,6 +96,26 @@ function make_list_objects_msc_fixture(objects) {
     return { ns_msc, metadata_ns, list_objects, object_sdk, list_reply };
 }
 
+function make_list_object_versions_msc_fixture(objects) {
+    const list_reply = {
+        objects: Array.isArray(objects) ? objects : [objects],
+        common_prefixes: [],
+        is_truncated: false,
+    };
+    const list_object_versions = jest.fn().mockResolvedValue(list_reply);
+    const metadata_ns = { list_object_versions };
+    const object_sdk = {};
+
+    const ns_msc = new NamespaceMultiStorageClass({
+        namespace_by_storage_class: {
+            [s3_utils.STORAGE_CLASS_STANDARD]: metadata_ns,
+            [s3_utils.STORAGE_CLASS_DEEP_ARCHIVE]: {},
+        },
+    });
+
+    return { ns_msc, metadata_ns, list_object_versions, object_sdk, list_reply };
+}
+
 describe('NamespaceMultiStorageClass.restore_object', () => {
     const params = { bucket: BUCKET, key: KEY, days: 7 };
 
@@ -505,6 +525,114 @@ describe('NamespaceMultiStorageClass.list_objects', () => {
             },
         ]);
         const reply = await ns_msc.list_objects(params, object_sdk);
+        expect(reply.objects).toHaveLength(3);
+
+        const active_object = reply.objects.find(obj => obj.key === 'archived/active');
+        const expired_object = reply.objects.find(obj => obj.key === 'archived/expired');
+        const ongoing_object = reply.objects.find(obj => obj.key === 'archived/ongoing');
+        expect(active_object).toBeDefined();
+        expect(expired_object).toBeDefined();
+        expect(ongoing_object).toBeDefined();
+        expect(active_object.restore_status).toEqual(active_restore_status);
+        expect(expired_object).not.toHaveProperty('restore_status');
+        expect(ongoing_object.restore_status).toEqual(ongoing_restore_status);
+    });
+});
+
+describe('NamespaceMultiStorageClass.list_object_versions', () => {
+    const params = { bucket: BUCKET, prefix: '', limit: 1000 };
+
+    it('omits restore_status when restore expiry_time is in the past', async () => {
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status: {
+                ongoing: false,
+                expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+            },
+        });
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
+        expect(reply.objects[0]).not.toHaveProperty('restore_status');
+        expect(reply.objects[0].storage_class).toBe(s3_utils.STORAGE_CLASS_DEEP_ARCHIVE);
+        expect(reply.is_truncated).toBe(false);
+        expect(reply.common_prefixes).toEqual([]);
+    });
+
+    it('returns restore_status when restore is ongoing', async () => {
+        const restore_status = { ongoing: true, days: 7 };
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
+        expect(reply.objects[0].restore_status).toEqual(restore_status);
+    });
+
+    it('returns restore_status when temporary restore is still active', async () => {
+        const restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(),
+        };
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            restore_status,
+        });
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
+        expect(reply.objects[0].restore_status).toEqual(restore_status);
+    });
+
+    it('omits restore_status when restore failed without expiry_time', async () => {
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: { ongoing: false },
+        });
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
+        expect(reply.objects[0]).not.toHaveProperty('restore_status');
+    });
+
+    it('omits restore_status when restore expiry_time is invalid', async () => {
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture({
+            key: KEY,
+            storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+            restore_status: {
+                ongoing: false,
+                expiry_time: 'invalid',
+            },
+        });
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
+        expect(reply.objects[0].restore_status).toBeUndefined();
+    });
+
+    it('omits restore_status independently for each object on the same page', async () => {
+        const active_restore_status = {
+            ongoing: false,
+            expiry_time: new Date('2099-01-01T00:00:00Z').getTime(),
+        };
+        const ongoing_restore_status = { ongoing: true, days: 7 };
+        const { ns_msc, object_sdk } = make_list_object_versions_msc_fixture([
+            {
+                key: 'archived/active',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                restore_status: active_restore_status,
+            },
+            {
+                key: 'archived/expired',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: new Date('2000-01-01T00:00:00Z').getTime(),
+                },
+            },
+            {
+                key: 'archived/ongoing',
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                restore_status: ongoing_restore_status,
+            },
+        ]);
+        const reply = await ns_msc.list_object_versions(params, object_sdk);
         expect(reply.objects).toHaveLength(3);
 
         const active_object = reply.objects.find(obj => obj.key === 'archived/active');

--- a/src/test/unit_tests/util_functions_tests/test_s3_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_s3_utils.test.js
@@ -281,4 +281,55 @@ describe('s3_utils', () => {
             expect(result.expiry_time).toBeUndefined();
         });
     });
+
+    describe('parse_optional_object_attributes_header', () => {
+        it('returns false when header is absent', () => {
+            expect(s3_utils.parse_optional_object_attributes_header({})).toBe(false);
+        });
+
+        it('returns true when RestoreStatus is requested', () => {
+            expect(s3_utils.parse_optional_object_attributes_header({
+                'x-amz-optional-object-attributes': 'RestoreStatus',
+            })).toBe(true);
+        });
+
+        it('throws InvalidArgument for unknown attribute names', () => {
+            expect(() => s3_utils.parse_optional_object_attributes_header({
+                'x-amz-optional-object-attributes': 'restorestatus',
+            })).toThrow(S3Error);
+        });
+    });
+
+    describe('get_object_restore_status', () => {
+        it('returns undefined when RestoreStatus was not requested', () => {
+            const object_md = {
+                restore_status: { ongoing: true, days: 7 },
+            };
+            expect(s3_utils.get_object_restore_status(object_md, false)).toBeUndefined();
+        });
+
+        it('returns undefined when object has no restore_status', () => {
+            expect(s3_utils.get_object_restore_status({}, true)).toBeUndefined();
+        });
+
+        it('returns ongoing restore status without expiry', () => {
+            const object_md = {
+                restore_status: { ongoing: true, days: 7 },
+            };
+            expect(s3_utils.get_object_restore_status(object_md, true)).toEqual({
+                IsRestoreInProgress: true,
+            });
+        });
+
+        it('returns completed restore status with expiry', () => {
+            const expiry_time = new Date('2099-01-01T00:00:00Z').getTime();
+            const object_md = {
+                restore_status: { ongoing: false, expiry_time },
+            };
+            expect(s3_utils.get_object_restore_status(object_md, true)).toEqual({
+                IsRestoreInProgress: false,
+                RestoreExpiryDate: new Date(expiry_time).toUTCString(),
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Describe the Problem
Part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)
In case the object was already restored and its expiry date is in the past, and the BG worker that handles removing the STANDARD copy did not finish removing it, we would like to avoid list object versions calls that would include an expiry date in the past (property and header).

Note: This PR handles the GAP that was mentioned in #9962.

### Explain the Changes
1. Edit the function `list_object_versions ` instead of being just a passthrough to the metadata namespace to omit the `restore_status` in case the expiry is invalid or in the past, and use the helper `_omit_inactive_restore_status`.
2. Move the functions for parsing the header and adding the restore status from list objects to `s3_utils` and use them in list object versions op.
3. Added AI-generated tests.

### Issues:
List of GAPs:
1. We might want to move the decision to omit restore_status expiry from MSC to the op itself - it is mutual to head object, list object, and list object versions (see [comment](https://github.com/noobaa/noobaa-core/pull/9983#discussion_r3869830646)).

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`
2. `npx jest src/test/unit_tests/util_functions_tests/test_s3_utils.test.js`

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting object restore status when listing bucket versions.
  * Version responses now include restore status details, including completion state and optional expiration dates.
* **Bug Fixes**
  * Expired or incomplete restore information is no longer shown in object-version listings.
  * Invalid optional object-attribute requests are rejected with appropriate validation.
* **Tests**
  * Added coverage for restore-status parsing, response generation, and filtering across multiple restore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->