### PR TITLE
NC RPM | remove node_module dependencies from RPM spec

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -50,7 +50,11 @@ BuildRequires:  cuobjserver
 
 Recommends:     jemalloc
 
-%global __requires_exclude ^/usr/bin/python$
+# Bundled Node and npm prebuilds (gnu/musl, 32/64-bit) must not generate
+# system library Requires. Native NooBaa addons under build/ are still scanned
+# so real deps such as boost remain. Filter leftover libc/libstdc++ names.
+%global __requires_exclude_from ^/usr/local/noobaa-core/(node_modules|node)/.*$
+%global __requires_exclude ^(libc(\\.so|\\.musl)|libm\\.so|libgcc_s\\.so|libstdc\\+\\+\\.so|/usr/bin/python).*$
 
 %description
 NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.


### PR DESCRIPTION
### Describe the Problem
Installing the NC RPM with `rpm -Uvh` fails on RHEL 9 with unsatisfiable automatic Requires such as `libc.musl-x86_64.so.1`, unversioned `libc.so`, and 32-bit `libc.so.6` / `libstdc++.so.6` (no `(64bit)` tag).
rpmbuild’s ELF scanner picks these up from bundled Node and npm prebuilds under `node_modules` (gnu + musl, 32/64-bit). Those libraries are not meant to be system package dependencies; Node is bundled in the RPM and uses the host glibc at runtime. RHEL 9 cannot provide musl or bare `libc.so`.

### Explain the Changes
1. Skip automatic Requires generation for files under `/usr/local/noobaa-core/node_modules` and `/usr/local/noobaa-core/node` (`__requires_exclude_from`)
2. Filter leftover `libc` / `libm` / `libgcc_s` / `libstdc++` / `musl` Requires, while keeping the existing `/usr/bin/python` exclude (`__requires_exclude`)
3. Leave native NooBaa addons under `build/` scanned so real deps such as boost are still recorded

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-10220

### Testing Instructions:
1. Build the RPM: `make rpm`
2. Confirm the bogus Requires are gone: `rpm -qp --requires noobaa.rpm`
   Should not list `libc.musl-*`, bare `libc.so`, or un-tagged 32-bit `libc.so.6`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPM packaging to prevent bundled Node.js/npm components from introducing unnecessary system dependency requirements.
  * Retained dependency detection for native add-ons and required libraries.
  * Removed residual requirements for common runtime libraries and `/usr/bin/python`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->