### PR TITLE
[Backport into 5.18] NC RPM | remove node_module dependencies from RPM spec

### DIFF
--- a/src/deploy/RPM_build/noobaa.spec
+++ b/src/deploy/RPM_build/noobaa.spec
@@ -37,7 +37,11 @@ BuildRequires:  gcc-toolset-11
 
 Recommends:     jemalloc
 
-%global __requires_exclude ^/usr/bin/python$
+# Bundled Node and npm prebuilds (gnu/musl, 32/64-bit) must not generate
+# system library Requires. Native NooBaa addons under build/ are still scanned
+# so real deps such as boost remain. Filter leftover libc/libstdc++ names.
+%global __requires_exclude_from ^/usr/local/noobaa-core/(node_modules|node)/.*$
+%global __requires_exclude ^(libc(\\.so|\\.musl)|libm\\.so|libgcc_s\\.so|libstdc\\+\\+\\.so|/usr/bin/python).*$
 
 %description
 NooBaa is a data service for cloud environments, providing S3 object-store interface with flexible tiering, mirroring, and spread placement policies, over any storage resource that allows GET/PUT including S3, GCS, Azure Blob, Filesystems, etc.


### PR DESCRIPTION
### Explain the Changes
1. [Backport into 5.18] NC RPM | remove node_module dependencies from RPM spec

(cherry picked from commit f57523d24a345499a2c45046666d6fb26ab2f614)
