### PR TITLE
DEEP_ARCHIVE | Add force evict custom header

### DIFF
--- a/config.js
+++ b/config.js
@@ -1110,6 +1110,8 @@ config.NSFS_LIST_IGNORE_ENTRY_ON_EINVAL = true;
 
 config.NSFS_CUSTOM_BUCKET_PATH_HTTP_HEADER = 'x-noobaa-custom-bucket-path';
 config.NSFS_CUSTOM_BUCKET_PATH_ALLOWED_LIST = ''; // colon separated list of paths prefixes
+// Per-request header to force-expire a restored glacier/deep-archive object on GET
+config.NSFS_GLACIER_FORCE_EVICT_HTTP_HEADER = 'x-noobaa-glacier-force-evict';
 
 config.NSFS_SPEEDOMETER_ENABLED = false;
 

--- a/src/endpoint/s3/ops/s3_get_object.js
+++ b/src/endpoint/s3/ops/s3_get_object.js
@@ -7,6 +7,7 @@ const s3_utils = require('../s3_utils');
 const http_utils = require('../../../util/http_utils');
 const rdma_utils = require('../../../util/rdma_utils');
 const { throw_if_restore_incomplete } = require('../../../util/deep_archive_utils');
+const config = require('../../../../config');
 
 /* eslint-disable max-statements */
 
@@ -73,6 +74,9 @@ async function get_object(req, res) {
     }
     if (part_number) {
         params.part_number = part_number;
+    }
+    if (req.headers[config.NSFS_GLACIER_FORCE_EVICT_HTTP_HEADER] === 'true') {
+        params.glacier_force_evict = true;
     }
     try {
         const ranges = http_utils.normalize_http_ranges(

--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1182,9 +1182,9 @@ class NamespaceFS {
             const took_ms = Number(process.hrtime.bigint() - start_time) / 1e6;
             if (nsfs_speedometer) nsfs_speedometer.update(file_reader.num_bytes, took_ms);
 
-            // Force evict only if the entire object is being read as part
-            // of the same request
-            if (start === 0 && end >= stat.size) {
+            // Force-evict on full-object reads, or when the caller requested glacier_force_evict
+            // (e.g. 1-byte restore-worker GET). Platform config is still enforced inside.
+            if (params.glacier_force_evict || (start === 0 && end >= stat.size)) {
                 await this._glacier_force_expire_on_get(fs_context, file_path, file, stat);
             }
 

--- a/src/sdk/namespace_s3.js
+++ b/src/sdk/namespace_s3.js
@@ -261,7 +261,13 @@ class NamespaceS3 {
         this._set_md_conditions(params, request);
         this._assign_encryption_to_request(params, request);
         try {
-            const obj_out = await this.s3.getObject(request);
+            let obj_out;
+            if (params.glacier_force_evict) {
+                const extra_headers = {[config.NSFS_GLACIER_FORCE_EVICT_HTTP_HEADER]: 'true' };
+                obj_out = await noobaa_s3_client.get_object_with_headers(this.s3, request, extra_headers);
+            } else {
+                obj_out = await this.s3.getObject(request);
+            }
             dbg.log0('NamespaceS3.read_object_stream:',
                         this.bucket,
                         inspect(_.omit(params, 'object_md.ns')),

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client.js
@@ -4,6 +4,7 @@
 const _ = require('lodash');
 const http = require('http');
 const https = require('https');
+const { GetObjectCommand } = require('@aws-sdk/client-s3');
 const { S3ClientSDKV2 } = require('./noobaa_s3_client_sdkv2');
 const { S3ClientAutoRegion } = require('./noobaa_s3_client_sdkv3');
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
@@ -149,6 +150,43 @@ function add_response_header_capture(s3) {
 }
 
 /**
+ * Adds custom HTTP headers to an AWS SDK v3 command via build-step middleware.
+ * Use for headers that are not part of the S3 command input shape.
+ * @param {{ middlewareStack: { add: Function } }} cmd
+ * @param {Record<string, string>} [headers]
+ */
+function add_command_headers(cmd, headers) {
+    if (!headers || !Object.keys(headers).length) return;
+    cmd.middlewareStack.add(
+        next => async args => {
+            Object.assign(args.request.headers, headers);
+            return next(args);
+        },
+        { step: 'build', name: 'addCustomHeaders', priority: 'low' }
+    );
+}
+
+/**
+ * getObject that can attach extra HTTP headers on both SDK v2 and v3.
+ * v2: AWS.Request 'build' event. v3: GetObjectCommand middleware + send().
+ * note that getObjectWithHeaders is a function that we created in S3ClientSDKV2 (not derived directly from the SDK.
+ * @param {object} s3 - client returned by get_s3_client_v3_params
+ * @param {object} request - GetObject params
+ * @param {Record<string, string>} [headers]
+ */
+async function get_object_with_headers(s3, request, headers) {
+    if (s3 instanceof S3ClientSDKV2) {
+        return s3.getObjectWithHeaders(request, headers);
+    }
+    if (headers && Object.keys(headers).length) {
+        const cmd = new GetObjectCommand(request);
+        add_command_headers(cmd, headers);
+        return s3.send(cmd);
+    }
+    return s3.getObject(request);
+}
+
+/**
  * Converts AWS SDK getObject Body to a Buffer.
  * SDK v2 returns a Buffer. SDK v3 returns a stream with transformToByteArray.
  * @param {*} body - getObject Body from AWS SDK v2 or v3
@@ -171,4 +209,5 @@ exports.get_sdk_class_str = get_sdk_class_str;
 exports.fix_error_object = fix_error_object;
 exports.get_requestHandler_with_suitable_agent = get_requestHandler_with_suitable_agent;
 exports.add_response_header_capture = add_response_header_capture;
+exports.get_object_with_headers = get_object_with_headers;
 exports.s3_body_to_buffer = s3_body_to_buffer;

--- a/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
+++ b/src/sdk/noobaa_s3_client/noobaa_s3_client_sdkv2.js
@@ -54,6 +54,16 @@ class S3ClientSDKV2 {
         return this.s3.getObject(params).promise();
     }
 
+    getObjectWithHeaders(params, extra_headers) {
+        const req = this.s3.getObject(params);
+        if (extra_headers && Object.keys(extra_headers).length) {
+            req.on('build', () => {
+                Object.assign(req.httpRequest.headers, extra_headers);
+            });
+        }
+        return req.promise();
+    }
+
     getObjectAcl(params) {
         return this.s3.getObjectAcl(params).promise();
     }

--- a/src/server/bg_services/archive_server.js
+++ b/src/server/bg_services/archive_server.js
@@ -398,10 +398,10 @@ async function check_archive_restore_status(req) {
  * Archive RPC replies are JSON only and cannot carry a live Node.js Readable,
  * so the restore worker streams bytes by calling this helper in the same process.
  * Pass start and end for a byte range (omit end for full object).
- * @param {{ bucket_id: string|nb.ID, obj_id: string|nb.ID, start?: number, end?: number }} params
+ * @param {{ bucket_id: string|nb.ID, obj_id: string|nb.ID, start?: number, end?: number, glacier_force_evict?: boolean }} params
  * @returns {Promise<import('stream').Readable>}
  */
-async function read_archive_object_stream({ bucket_id, obj_id, start, end }) {
+async function read_archive_object_stream({ bucket_id, obj_id, start, end, glacier_force_evict }) {
     const archive_key = get_archive_key(bucket_id, obj_id);
     const archive_ns = await get_archive_ns_for_bucket(bucket_id);
     if (!archive_ns) {
@@ -415,6 +415,7 @@ async function read_archive_object_stream({ bucket_id, obj_id, start, end }) {
             key: archive_key,
             start,
             end,
+            glacier_force_evict,
         }, undefined);
     } catch (err) {
         dbg.error('read_archive_object_stream failed', archive_key, err);

--- a/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
+++ b/src/test/unit_tests/nsfs/test_nsfs_glacier_backend.js
@@ -21,6 +21,7 @@ const { Glacier } = require('../../../sdk/glacier');
 const { Semaphore } = require('../../../util/semaphore');
 const nb_native = require('../../../util/nb_native');
 const { handler: s3_get_bucket } = require('../../../endpoint/s3/ops/s3_get_bucket');
+const { handler: s3_get_object } = require('../../../endpoint/s3/ops/s3_get_object');
 const lifecycle_utils = require('../../../util/lifecycle_utils');
 
 const inspect = (x, max_arr = 5) => util.inspect(x, { colors: true, depth: null, maxArrayLength: max_arr });
@@ -630,6 +631,40 @@ mocha.describe('nsfs_glacier', function() {
                     ?.force_expire_on_get === glacier_ns._get_file_path({ key }));
         });
 
+        mocha.it('object should expire on 1-byte read when glacier_force_evict param is set', async function() {
+            const data = crypto.randomBytes(100);
+            const key = `${restore_key}_glacier_force_evict_header`;
+            const params = {
+                bucket: upload_bkt,
+                key,
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                xattr,
+                days: 1,
+                source_stream: buffer_utils.buffer_to_read_stream(data),
+            };
+
+            const upload_res = await glacier_ns.upload_object(params, dummy_object_sdk);
+            console.log('upload_object response', inspect(upload_res));
+
+            const restore_res = await glacier_ns.restore_object(params, dummy_object_sdk);
+            assert(restore_res);
+
+            await backend.perform(glacier_ns.prepare_fs_context(dummy_object_sdk), "RESTORE");
+
+            const eviction_dummy_object_sdk = make_dummy_object_sdk();
+            await glacier_ns.read_object_stream({
+                ...params,
+                start: 0,
+                end: 1,
+                glacier_force_evict: true,
+            }, eviction_dummy_object_sdk, new NoOpWriteStream());
+
+            assert(eviction_dummy_object_sdk
+                    .requesting_account
+                    ?.nsfs_account_config
+                    ?.force_expire_on_get === glacier_ns._get_file_path({ key }));
+        });
+
         mocha.it('object deletion should mark object for tape reclaim', async function() {
             // eslint-disable-next-line no-invalid-this
             this.timeout(5000);
@@ -782,6 +817,16 @@ mocha.describe('nsfs_glacier', function() {
     });
 
     mocha.describe('nsfs_glacier_s3_flow', async function() {
+        mocha.it('GET should set glacier_force_evict when header is true', async function() {
+            const params = await get_object_read_params_for_force_evict_header('true');
+            assert.strictEqual(params.glacier_force_evict, true);
+        });
+
+        mocha.it('GET should not set glacier_force_evict when header is false', async function() {
+            const params = await get_object_read_params_for_force_evict_header('false');
+            assert.strictEqual(params.glacier_force_evict, undefined);
+        });
+
         mocha.it('list_objects should throw error with incorrect optional object attributes', async function() {
             const req = generate_noobaa_req_obj();
             req.params.bucket = src_bkt;
@@ -966,3 +1011,36 @@ EOF`;
         });
     });
 });
+
+/**
+ * Run s3 GET with an optional x-noobaa-glacier-force-evict header and return
+ * the params passed to read_object_stream.
+ * @param {string} [header_value]
+ */
+async function get_object_read_params_for_force_evict_header(header_value) {
+    let captured;
+    const req = generate_noobaa_req_obj();
+    req.params.bucket = 'bucket';
+    req.params.key = 'key';
+    if (header_value !== undefined) {
+        req.headers[config.NSFS_GLACIER_FORCE_EVICT_HTTP_HEADER] = header_value;
+    }
+    req.object_sdk.setup_abort_controller = () => undefined;
+    req.object_sdk.read_object_md = async () => ({
+        obj_id: 'oid',
+        etag: 'etag',
+        create_time: Date.now(),
+        content_type: 'application/octet-stream',
+        size: 100,
+        content_length: 100,
+        xattr: {},
+    });
+    req.object_sdk.read_bucket_sdk_lifecycle_rules = async () => [];
+    req.object_sdk.read_object_stream = async params => {
+        captured = params;
+        return undefined;
+    };
+    const res = { setHeader() { /* noop */ } };
+    await s3_get_object(req, res);
+    return captured;
+}


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. namespace_fs - Added force evict custom header in namespace_fs that will call eviction on DBS3.
2. archive_server - Added force_evict_archive_object() that call getObject of 0 (for empty objects)/1 byte with force evict header so DBs3 will evict.
 

### Issues: Fixed #xxx / Gap #xxx
1. Gap - we should call force_evict_archive_object() on https://github.com/noobaa/noobaa-core/pull/9978 and add tests

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable request header that forces eviction of restored Glacier and deep-archive objects.
  * Force-eviction now works with full and partial object reads, including archive-backed reads.
  * Added support for custom HTTP headers on object read requests.

* **Bug Fixes**
  * Improved expiration handling after Glacier restore reads.
  * Improved error reporting for mismatched upload-part identifiers.

* **Tests**
  * Added coverage for force-eviction during one-byte ranged reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->