### PR TITLE
Deep Archive | Use parameterized query for noncurrent transition

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2900]*/
+/*eslint max-lines: ["error", 3000]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -2701,9 +2701,11 @@ class MDStore {
 
         if (noncurrent_days === undefined) throw new Error('noncurrent_days is required');
 
+        const values = [String(bucket_id)];
+
         // --- CTE base filters (applied before window functions) ---
         const base_conditions = [
-            `data->>'bucket' = '${String(bucket_id)}'`,
+            `data->>'bucket' = $${values.length}`,
             `(data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)`,
             `(data->'upload_started' IS NULL OR data->'upload_started' = 'null'::jsonb)`,
             `(data->'reclaimed' IS NULL OR data->'reclaimed' = 'null'::jsonb)`,
@@ -2713,11 +2715,14 @@ class MDStore {
         // Prefix filter goes in base_conditions — all versions of a key share the
         // same key, so filtering early is efficient.
         if (prefix) {
-            const escaped = prefix.replace(/'/g, "''").replace(/%/g, '\\%').replace(/_/g, '\\_');
-            base_conditions.push(`data->>'key' LIKE '${escaped}%'`);
+            const escaped = prefix.replace(/%/g, '\\%').replace(/_/g, '\\_');
+            values.push(escaped + '%');
+            base_conditions.push(`data->>'key' LIKE $${values.length}`);
         }
 
         // --- Ranked result filters (applied after window functions) ---
+        values.push(noncurrent_days);
+        const noncurrent_days_idx = values.length;
         const ranked_conditions = [
             // A noncurrent version becomes eligible after the configured number
             // of UTC calendar days from the day it became noncurrent.
@@ -2726,7 +2731,7 @@ class MDStore {
                 AND CURRENT_TIMESTAMP >= (
                     date_trunc('day', successor_time AT TIME ZONE 'UTC')
                     + interval '1 day'
-                    + interval '${noncurrent_days} days'
+                    + interval '1 day' * $${noncurrent_days_idx}
                 ) AT TIME ZONE 'UTC'
             )`,
             // TODO: skipping all transition_info will not fit when more Transition targets exist;
@@ -2738,33 +2743,42 @@ class MDStore {
         // same key can have different sizes/tags. Filtering in base_conditions would
         // corrupt ROW_NUMBER() and LEAD() calculations.
         if (size_greater !== undefined && size_greater !== null) {
-            ranked_conditions.push(`size > ${Number(size_greater)}`);
+            values.push(Number(size_greater));
+            ranked_conditions.push(`size > $${values.length}`);
         }
         if (size_less !== undefined && size_less !== null) {
-            ranked_conditions.push(`size < ${Number(size_less)}`);
+            values.push(Number(size_less));
+            ranked_conditions.push(`size < $${values.length}`);
         }
         if (tags && tags.length) {
-            const tags_json = JSON.stringify(tags);
-            ranked_conditions.push(`tags @> '${tags_json.replace(/'/g, "''")}'::jsonb`);
+            values.push(JSON.stringify(tags));
+            ranked_conditions.push(`tags @> $${values.length}::jsonb`);
         }
 
         // NewerNoncurrentVersions: rn=1 is the newest noncurrent version, rn=2 is next, etc.
         // Only transition versions ranked beyond the retention count.
         if (newer_noncurrent_versions) {
-            ranked_conditions.push(`(rn > ${newer_noncurrent_versions} + 1)`);
+            values.push(newer_noncurrent_versions + 1);
+            ranked_conditions.push(`(rn > $${values.length})`);
         }
 
         // Composite keyset pagination on (key, version_seq).
         // Results are ordered by key ASC, version_seq DESC, so for the same key
         // we resume from versions with a lower version_seq than the marker.
         if (key_marker && version_seq_marker) {
+            values.push(key_marker);
+            const key_idx = values.length;
+            values.push(version_seq_marker);
+            const seq_idx = values.length;
             ranked_conditions.push(
-                `((key = '${key_marker}' AND version_seq < ${version_seq_marker}) OR key > '${key_marker}')`
+                `((key = $${key_idx} AND version_seq < $${seq_idx}) OR key > $${key_idx})`
             );
         } else if (key_marker) {
-            ranked_conditions.push(`key > '${key_marker}'`);
+            values.push(key_marker);
+            ranked_conditions.push(`key > $${values.length}`);
         }
 
+        values.push(query_limit);
         const query = `
             WITH ranked AS (
                 SELECT
@@ -2792,10 +2806,10 @@ class MDStore {
             WHERE
                 ${sql_and_conditions(...ranked_conditions)}
             ORDER BY ranked.key ASC, ranked.version_seq DESC
-            LIMIT ${query_limit};`;
+            LIMIT $${values.length};`;
 
-        dbg.log1('[find_versioned_objects_to_transition] generated query:', query);
-        const result = await db_client.instance().executeSQL(query, [], {
+        dbg.log1('[find_versioned_objects_to_transition] generated query:', query, 'values:', values);
+        const result = await db_client.instance().executeSQL(query, values, {
             preferred_pool: 'read_only',
         });
         return result.rows.map(row => decode_json(this._objects.schema, row.data));

--- a/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
@@ -206,6 +206,267 @@ mocha.describe('lifecycle-transitions', function() {
     });
 
     // ──────────────────────────────────────────────────────────────────────
+    // Transition filters (prefix, size, tags)
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Transition filters', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-l';
+        const AGE_DAYS = 5;
+        const RULE_DAYS = 1;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await rpc_client.object.list_objects_admin({ bucket });
+            for (const obj of list.objects) {
+                await rpc_client.object.delete_object({ bucket, key: obj.key });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should filter by prefix', async function() {
+            const ts = Date.now();
+            const key_logs_a = `logs/tfilt-a-${ts}`;
+            const key_logs_b = `logs/tfilt-b-${ts}`;
+            const key_data_c = `data/tfilt-c-${ts}`;
+
+            for (const key of [key_logs_a, key_logs_b, key_data_c]) {
+                await create_aged_object(key, bucket, AGE_DAYS);
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const transition_ts = Math.floor(Date.now() / 1000) - (RULE_DAYS * 24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts,
+                prefix: 'logs/',
+            });
+
+            const matching_logs = results.filter(o => o.key.startsWith('logs/tfilt-'));
+            const matching_data = results.filter(o => o.key.startsWith('data/tfilt-'));
+            assert(matching_logs.length === 2,
+                `Expected 2 logs/* objects, got ${matching_logs.length}`);
+            assert.strictEqual(matching_data.length, 0,
+                'data/* objects should be excluded by prefix filter');
+        });
+
+        mocha.it('should filter by size_greater', async function() {
+            const ts = Date.now();
+            const key_small = `szgt-small-${ts}`;
+            const key_large = `szgt-large-${ts}`;
+
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const transition_ts = Math.floor(Date.now() / 1000) - (RULE_DAYS * 24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts,
+                size_greater: 500,
+            });
+
+            const found_small = results.find(o => o.key === key_small);
+            const found_large = results.find(o => o.key === key_large);
+            assert(!found_small, 'Small object should be excluded by size_greater filter');
+            assert(found_large, 'Large object should be included');
+        });
+
+        mocha.it('should filter by size_less', async function() {
+            const ts = Date.now();
+            const key_small = `szlt-small-${ts}`;
+            const key_large = `szlt-large-${ts}`;
+
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const transition_ts = Math.floor(Date.now() / 1000) - (RULE_DAYS * 24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts,
+                size_less: 500,
+            });
+
+            const found_small = results.find(o => o.key === key_small);
+            const found_large = results.find(o => o.key === key_large);
+            assert(found_small, 'Small object should be included');
+            assert(!found_large, 'Large object should be excluded by size_less filter');
+        });
+
+        mocha.it('should filter by tags', async function() {
+            const ts = Date.now();
+            const key_tagged = `tag-yes-${ts}`;
+            const key_untagged = `tag-no-${ts}`;
+
+            const tagged_id = await create_aged_object(key_tagged, bucket, AGE_DAYS);
+            await create_aged_object(key_untagged, bucket, AGE_DAYS);
+
+            // Tag the object via MDStore
+            const id = new mongodb.ObjectId(tagged_id);
+            await MDStore.instance().update_object_by_id(id, {
+                tagging: [{ key: 'env', value: 'prod' }],
+            });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const transition_ts = Math.floor(Date.now() / 1000) - (RULE_DAYS * 24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts,
+                tags: [{ key: 'env', value: 'prod' }],
+            });
+
+            const found_tagged = results.find(o => o.key === key_tagged);
+            const found_untagged = results.find(o => o.key === key_untagged);
+            assert(found_tagged, 'Tagged object should be in results');
+            assert(!found_untagged, 'Untagged object should be excluded by tag filter');
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Transition multi-key ordering
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Transition multi-key ordering', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-m';
+        const AGE_DAYS = 5;
+        const RULE_DAYS = 1;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await rpc_client.object.list_objects_admin({ bucket });
+            for (const obj of list.objects) {
+                await rpc_client.object.delete_object({ bucket, key: obj.key });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should return results sorted by key ASC', async function() {
+            const ts = Date.now();
+            // Create in reverse order to ensure sort is DB-driven, not insertion-order
+            const keys = [`zzz-order-${ts}`, `mmm-order-${ts}`, `aaa-order-${ts}`];
+            for (const key of keys) {
+                await create_aged_object(key, bucket, AGE_DAYS);
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const transition_ts = Math.floor(Date.now() / 1000) - (RULE_DAYS * 24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts,
+            });
+
+            const matching = results.filter(o => keys.includes(o.key));
+            assert.strictEqual(matching.length, 3,
+                `Expected 3 objects, got ${matching.length}`);
+
+            for (let i = 1; i < matching.length; i++) {
+                assert(matching[i].key > matching[i - 1].key,
+                    `Results should be sorted by key ASC: ` +
+                    `${matching[i - 1].key} should come before ${matching[i].key}`);
+            }
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Date-based Transition (is_date flag)
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Date-based Transition', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-n';
+        const AGE_DAYS = 5;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await rpc_client.object.list_objects_admin({ bucket });
+            for (const obj of list.objects) {
+                await rpc_client.object.delete_object({ bucket, key: obj.key });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should return empty when is_date=true and transition date is in the future', async function() {
+            const key = 'date-future-' + Date.now();
+            await create_aged_object(key, bucket, AGE_DAYS);
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            // Set transition_ts to tomorrow (future)
+            const future_ts = Math.floor(Date.now() / 1000) + (24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts: future_ts,
+                is_date: true,
+            });
+
+            assert.strictEqual(results.length, 0,
+                'Should return empty array when is_date=true and date is in the future');
+        });
+
+        mocha.it('should return eligible objects when is_date=true and transition date is in the past', async function() {
+            const key = 'date-past-' + Date.now();
+            await create_aged_object(key, bucket, AGE_DAYS);
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            // Set transition_ts to yesterday (past)
+            const past_ts = Math.floor(Date.now() / 1000) - (24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts: past_ts,
+                is_date: true,
+            });
+
+            const found = results.find(o => o.key === key);
+            assert(found,
+                'Object should be eligible when is_date=true and date is in the past');
+        });
+
+        mocha.it('is_date=true should skip the create_time midnight rounding filter', async function() {
+            // With is_date, objects of any age should be returned (no days-based filter)
+            const key = 'date-young-' + Date.now();
+            await create_aged_object(key, bucket, 0); // created just now
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const past_ts = Math.floor(Date.now() / 1000) - (24 * 60 * 60);
+
+            const results = await MDStore.instance().find_objects_to_transition({
+                bucket: bucket_obj,
+                batch_size: 100,
+                transition_ts: past_ts,
+                is_date: true,
+            });
+
+            const found = results.find(o => o.key === key);
+            assert(found,
+                'Young object should be eligible with is_date=true (no create_time filter applied)');
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
     // Transition on versioned bucket (latest versions only)
     // ──────────────────────────────────────────────────────────────────────
     mocha.describe('Versioned Transition (latest only)', function() {
@@ -1090,6 +1351,530 @@ mocha.describe('lifecycle-transitions', function() {
             const res = await s3.getBucketLifecycleConfiguration({ Bucket: archive_bucket });
             assert.strictEqual(new Date(res.Rules[0].Transitions[0].Date).getTime(), midnight.getTime());
             assert.strictEqual(res.Rules[0].Transitions[0].StorageClass, 'GLACIER');
+        });
+    });
+
+
+    // ──────────────────────────────────────────────────────────────────────
+    // NoncurrentVersionTransition filters (prefix, size, tags)
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('NoncurrentVersionTransition filters', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-f';
+        const AGE_DAYS = 10;
+        const NONCURRENT_DAYS = 1;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+            await s3.putBucketVersioning({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await s3.listObjectVersions({ Bucket: bucket });
+            const to_delete = [
+                ...(list.Versions || []).map(v => ({ Key: v.Key, VersionId: v.VersionId })),
+                ...(list.DeleteMarkers || []).map(d => ({ Key: d.Key, VersionId: d.VersionId })),
+            ];
+            if (to_delete.length) {
+                await s3.deleteObjects({ Bucket: bucket, Delete: { Objects: to_delete } });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should filter by prefix', async function() {
+            const ts = Date.now();
+            const key_logs_a = `logs/a-${ts}`;
+            const key_logs_b = `logs/b-${ts}`;
+            const key_data_c = `data/c-${ts}`;
+
+            for (const key of [key_logs_a, key_logs_b, key_data_c]) {
+                await create_aged_object(key, bucket, AGE_DAYS);
+                await P.delay(50);
+                await create_aged_object(key, bucket, AGE_DAYS);
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+                prefix: 'logs/',
+            });
+
+            const matching_logs = results.filter(o => o.key.startsWith('logs/'));
+            const matching_data = results.filter(o => o.key.startsWith('data/'));
+            assert(matching_logs.length > 0, 'Expected noncurrent logs/* versions in results');
+            assert.strictEqual(matching_data.length, 0,
+                'data/* versions should be excluded by prefix filter');
+        });
+
+        mocha.it('should filter by size_greater', async function() {
+            const ts = Date.now();
+            const key_small = `size-small-${ts}`;
+            const key_large = `size-large-${ts}`;
+
+            // 2 versions each; noncurrent versions get size filters applied
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+            await P.delay(50);
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+            await P.delay(50);
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+                size_greater: 500,
+            });
+
+            const matching = results.filter(o =>
+                o.key === key_small || o.key === key_large);
+            for (const obj of matching) {
+                assert(obj.size > 500,
+                    `Expected size > 500, got ${obj.size} for key ${obj.key}`);
+            }
+            const small_found = matching.find(o => o.key === key_small);
+            assert(!small_found, 'Small object should be excluded by size_greater filter');
+        });
+
+        mocha.it('should filter by size_less', async function() {
+            const ts = Date.now();
+            const key_small = `sizelt-small-${ts}`;
+            const key_large = `sizelt-large-${ts}`;
+
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+            await P.delay(50);
+            await create_aged_object(key_small, bucket, AGE_DAYS, { size: 100 });
+
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+            await P.delay(50);
+            await create_aged_object(key_large, bucket, AGE_DAYS, { size: 1000 });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+                size_less: 500,
+            });
+
+            const matching = results.filter(o =>
+                o.key === key_small || o.key === key_large);
+            for (const obj of matching) {
+                assert(obj.size < 500,
+                    `Expected size < 500, got ${obj.size} for key ${obj.key}`);
+            }
+            const large_found = matching.find(o => o.key === key_large);
+            assert(!large_found, 'Large object should be excluded by size_less filter');
+        });
+
+        mocha.it('should filter by tags', async function() {
+            const ts = Date.now();
+            const key_tagged = `tagged-${ts}`;
+            const key_untagged = `untagged-${ts}`;
+
+            // 2 versions each
+            await create_aged_object(key_tagged, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key_tagged, bucket, AGE_DAYS);
+
+            await create_aged_object(key_untagged, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key_untagged, bucket, AGE_DAYS);
+
+            // Tag all versions of key_tagged via MDStore (tag the noncurrent one)
+            const bucket_obj = get_bucket_from_store(bucket);
+            const all_results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+            });
+            const noncurrent_tagged = all_results.filter(o => o.key === key_tagged);
+            for (const obj of noncurrent_tagged) {
+                await MDStore.instance().update_object_by_id(obj._id, {
+                    tagging: [{ key: 'env', value: 'prod' }],
+                });
+            }
+
+            const filtered = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+                tags: [{ key: 'env', value: 'prod' }],
+            });
+
+            const matching_tagged = filtered.filter(o => o.key === key_tagged);
+            const matching_untagged = filtered.filter(o => o.key === key_untagged);
+            assert(matching_tagged.length > 0, 'Tagged noncurrent versions should be in results');
+            assert.strictEqual(matching_untagged.length, 0,
+                'Untagged versions should be excluded by tag filter');
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Versioned Pagination (composite keyset)
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Versioned Pagination', function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-h';
+        const AGE_DAYS = 10;
+        const NONCURRENT_DAYS = 1;
+        const NUM_KEYS = 3;
+        const VERSIONS_PER_KEY = 4; // 3 noncurrent each = 9 eligible total
+        const SMALL_BATCH = 3;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+            await s3.putBucketVersioning({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await s3.listObjectVersions({ Bucket: bucket });
+            const to_delete = [
+                ...(list.Versions || []).map(v => ({ Key: v.Key, VersionId: v.VersionId })),
+                ...(list.DeleteMarkers || []).map(d => ({ Key: d.Key, VersionId: d.VersionId })),
+            ];
+            if (to_delete.length) {
+                await s3.deleteObjects({ Bucket: bucket, Delete: { Objects: to_delete } });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should paginate through all eligible noncurrent versions', async function() {
+            const ts = Date.now();
+            const keys = Array.from({ length: NUM_KEYS }, (_, i) =>
+                `page-${String(i).padStart(3, '0')}-${ts}`);
+
+            for (const key of keys) {
+                for (let v = 0; v < VERSIONS_PER_KEY; v++) {
+                    await create_aged_object(key, bucket, AGE_DAYS);
+                    await P.delay(50);
+                }
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const expected_total = NUM_KEYS * (VERSIONS_PER_KEY - 1); // 9
+
+            let all_results = [];
+            let key_marker;
+            let version_seq_marker;
+            let is_truncated = true;
+
+            while (is_truncated) {
+                const batch = await MDStore.instance().find_versioned_objects_to_transition({
+                    bucket_id: bucket_obj._id,
+                    batch_size: SMALL_BATCH,
+                    noncurrent_days: NONCURRENT_DAYS,
+                    key_marker,
+                    version_seq_marker,
+                });
+
+                const matching = batch.filter(o =>
+                    keys.some(k => o.key === k));
+                all_results = all_results.concat(matching);
+
+                is_truncated = batch.length >= SMALL_BATCH;
+                if (batch.length) {
+                    const last = batch[batch.length - 1];
+                    key_marker = last.key;
+                    version_seq_marker = last.version_seq;
+                }
+            }
+
+            assert.strictEqual(all_results.length, expected_total,
+                `Expected ${expected_total} noncurrent versions across pages, got ${all_results.length}`);
+
+            // Verify sort order: key ASC, then version_seq DESC within same key
+            for (let i = 1; i < all_results.length; i++) {
+                const prev = all_results[i - 1];
+                const curr = all_results[i];
+                if (prev.key === curr.key) {
+                    assert(curr.version_seq < prev.version_seq,
+                        `Within key ${prev.key}: version_seq should be DESC, ` +
+                        `got ${prev.version_seq} then ${curr.version_seq}`);
+                } else {
+                    assert(curr.key > prev.key,
+                        `Keys should be ASC: ${prev.key} should be before ${curr.key}`);
+                }
+            }
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Versioned Concurrency guards
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Versioned Concurrency guards', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-i';
+        const AGE_DAYS = 10;
+        const NONCURRENT_DAYS = 1;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+            await s3.putBucketVersioning({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await s3.listObjectVersions({ Bucket: bucket });
+            const to_delete = [
+                ...(list.Versions || []).map(v => ({ Key: v.Key, VersionId: v.VersionId })),
+                ...(list.DeleteMarkers || []).map(d => ({ Key: d.Key, VersionId: d.VersionId })),
+            ];
+            if (to_delete.length) {
+                await s3.deleteObjects({ Bucket: bucket, Delete: { Objects: to_delete } });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should skip noncurrent versions with transition_info=IN_PROGRESS', async function() {
+            const key = 'guard-v-inprog-' + Date.now();
+
+            // 3 versions: 1 current + 2 noncurrent
+            const v1_id = await create_aged_object(key, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key, bucket, AGE_DAYS);
+
+            // Mark oldest noncurrent (v1) as IN_PROGRESS
+            const id = new mongodb.ObjectId(v1_id);
+            await MDStore.instance().update_object_by_id(id, {
+                transition_info: { status: ARCHIVE.TRANSITION_STATUS.IN_PROGRESS },
+            });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+            });
+
+            const matching = results.filter(o => o.key === key);
+            const found_v1 = matching.find(o => o._id.toHexString() === v1_id);
+            assert(!found_v1,
+                'Noncurrent version with transition_info=IN_PROGRESS should be excluded');
+            // The other noncurrent version (v2) should still be found
+            assert(matching.length >= 1,
+                'Other noncurrent versions should still be eligible');
+        });
+
+        mocha.it('should skip noncurrent versions with transition_info=DONE', async function() {
+            const key = 'guard-v-done-' + Date.now();
+
+            const v1_id = await create_aged_object(key, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key, bucket, AGE_DAYS);
+
+            const id = new mongodb.ObjectId(v1_id);
+            await MDStore.instance().update_object_by_id(id, {
+                transition_info: {
+                    status: ARCHIVE.TRANSITION_STATUS.DONE,
+                    source_info: {
+                        storage_class: 'STANDARD',
+                        transition_timestamp: new Date(),
+                    },
+                },
+                storage_class: TARGET_STORAGE_CLASS,
+            });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+            });
+
+            const found_v1 = results.find(o => o._id.toHexString() === v1_id);
+            assert(!found_v1,
+                'Noncurrent version with transition_info=DONE should be excluded');
+        });
+
+        mocha.it('should skip deleted noncurrent versions', async function() {
+            const key = 'guard-v-deleted-' + Date.now();
+
+            await create_aged_object(key, bucket, AGE_DAYS);
+            await P.delay(50);
+            await create_aged_object(key, bucket, AGE_DAYS);
+
+            // Delete creates a delete marker; both prior versions become noncurrent
+            // but the delete_marker check in base_conditions filters them
+            await rpc_client.object.delete_object({ bucket, key });
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+            });
+
+            // Versions should still appear (they are not deleted, the delete marker is separate)
+            // but the delete marker itself should not appear
+            const delete_markers = results.filter(o => o.key === key && o.delete_marker);
+            assert.strictEqual(delete_markers.length, 0,
+                'Delete markers should NOT appear in transition results');
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Multi-key ordering
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Multi-key ordering', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-j';
+        const AGE_DAYS = 10;
+        const NONCURRENT_DAYS = 1;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+            await s3.putBucketVersioning({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await s3.listObjectVersions({ Bucket: bucket });
+            const to_delete = [
+                ...(list.Versions || []).map(v => ({ Key: v.Key, VersionId: v.VersionId })),
+                ...(list.DeleteMarkers || []).map(d => ({ Key: d.Key, VersionId: d.VersionId })),
+            ];
+            if (to_delete.length) {
+                await s3.deleteObjects({ Bucket: bucket, Delete: { Objects: to_delete } });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should return results sorted by key ASC, version_seq DESC', async function() {
+            const ts = Date.now();
+            const keys = [`aaa-${ts}`, `bbb-${ts}`, `ccc-${ts}`];
+
+            for (const key of keys) {
+                // 3 versions each → 2 noncurrent per key = 6 total
+                for (let v = 0; v < 3; v++) {
+                    await create_aged_object(key, bucket, AGE_DAYS);
+                    await P.delay(50);
+                }
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+            const results = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: NONCURRENT_DAYS,
+            });
+
+            const matching = results.filter(o => keys.includes(o.key));
+            assert.strictEqual(matching.length, 6,
+                `Expected 6 noncurrent versions (2 per key x 3 keys), got ${matching.length}`);
+
+            // Verify sort: key ASC, version_seq DESC within same key
+            for (let i = 1; i < matching.length; i++) {
+                const prev = matching[i - 1];
+                const curr = matching[i];
+                if (prev.key === curr.key) {
+                    assert(curr.version_seq < prev.version_seq,
+                        `Within key ${prev.key}: version_seq should be DESC, ` +
+                        `got ${prev.version_seq} then ${curr.version_seq}`);
+                } else {
+                    assert(curr.key > prev.key,
+                        `Keys should be ASC: ${prev.key} should come before ${curr.key}`);
+                }
+            }
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Combined NoncurrentDays + NewerNoncurrentVersions
+    // ──────────────────────────────────────────────────────────────────────
+    mocha.describe('Combined NoncurrentDays + NewerNoncurrentVersions', function() {
+        this.timeout(60000); // eslint-disable-line no-invalid-this
+        const bucket = TRANSITION_BUCKET + '-k';
+        const AGE_DAYS = 10;
+        const NUM_VERSIONS = 5;
+
+        mocha.before(async function() {
+            await rpc_client.bucket.create_bucket({ name: bucket });
+            await s3.putBucketVersioning({
+                Bucket: bucket,
+                VersioningConfiguration: { Status: 'Enabled' },
+            });
+        });
+
+        mocha.after(async function() {
+            await delete_lifecycle(s3, bucket);
+            const list = await s3.listObjectVersions({ Bucket: bucket });
+            const to_delete = [
+                ...(list.Versions || []).map(v => ({ Key: v.Key, VersionId: v.VersionId })),
+                ...(list.DeleteMarkers || []).map(d => ({ Key: d.Key, VersionId: d.VersionId })),
+            ];
+            if (to_delete.length) {
+                await s3.deleteObjects({ Bucket: bucket, Delete: { Objects: to_delete } });
+            }
+            await rpc_client.bucket.delete_bucket({ name: bucket });
+        });
+
+        mocha.it('should require BOTH noncurrent_days AND newer_noncurrent_versions to be met', async function() {
+            const key = 'combined-' + Date.now();
+
+            // 5 versions aged 10 days → 4 noncurrent
+            for (let i = 0; i < NUM_VERSIONS; i++) {
+                await create_aged_object(key, bucket, AGE_DAYS);
+                await P.delay(50);
+            }
+
+            const bucket_obj = get_bucket_from_store(bucket);
+
+            // Case 1: days threshold too high (15 > 10 age) → 0 eligible
+            const results_days_too_high = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: 15,
+                newer_noncurrent_versions: 1,
+            });
+            const matching_high = results_days_too_high.filter(o => o.key === key);
+            assert.strictEqual(matching_high.length, 0,
+                'No versions should be eligible when noncurrent_days exceeds actual age');
+
+            // Case 2: both conditions met (days=1, retain=1) → 3 eligible
+            const results_both_met = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: 1,
+                newer_noncurrent_versions: 1,
+            });
+            const matching_both = results_both_met.filter(o => o.key === key);
+            const expected = NUM_VERSIONS - 1 - 1; // 4 noncurrent - 1 retained = 3
+            assert.strictEqual(matching_both.length, expected,
+                `Expected ${expected} eligible when both conditions met, got ${matching_both.length}`);
+
+            // Case 3: retention too high (retain=10 > 4 noncurrent) → 0 eligible
+            const results_retain_high = await MDStore.instance().find_versioned_objects_to_transition({
+                bucket_id: bucket_obj._id,
+                batch_size: 100,
+                noncurrent_days: 1,
+                newer_noncurrent_versions: 10,
+            });
+            const matching_retain = results_retain_high.filter(o => o.key === key);
+            assert.strictEqual(matching_retain.length, 0,
+                'No versions should be eligible when retention count exceeds noncurrent count');
         });
     });
 });


### PR DESCRIPTION
### Describe the Problem
For noncurrent version transition, the MD store method was not using parameterized query.

### Explain the Changes
1. Use a parameterized query in MD store method.
2. Added tests for various scenarios for transition and noncurrent version transition.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle transition processing with more reliable filtering by prefix, size, tags, dates, version counts, and pagination.
  * Improved handling of current and noncurrent object versions, including retention and concurrency safeguards.
  * Enhanced transition processing reliability for unversioned and versioned objects.

* **Tests**
  * Added comprehensive integration coverage for filtering, ordering, pagination, date eligibility, retention rules, and deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->