### PR TITLE
NSFS | MPU | Complete Multi Part Upload To Surface `InvalidPart` Instead of `InternalError`

### DIFF
--- a/src/sdk/namespace_fs.js
+++ b/src/sdk/namespace_fs.js
@@ -1979,7 +1979,7 @@ class NamespaceFS {
                 const part_size = Number(md_part_stat.xattr[XATTR_PART_SIZE]);
                 const part_offset = Number(md_part_stat.xattr[XATTR_PART_OFFSET]);
                 if (etag !== this._get_etag(md_part_stat)) {
-                    throw new Error('mismatch part etag: ' + util.inspect({ num, etag, md_part_path, md_part_stat, params }));
+                    throw new RpcError('INVALID_PART', 'mismatch part etag: ' + util.inspect({ num, etag, md_part_path, md_part_stat, params }));
                 }
                 if (MD5Async) await MD5Async.update(Buffer.from(etag, 'hex'));
 

--- a/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
+++ b/src/test/unit_tests/nsfs/test_namespace_fs_mpu.js
@@ -49,7 +49,7 @@ function make_DUMMY_OBJECT_SDK() {
 }
 
 
-mocha.describe('namespace_fs mpu optimization tests', function() {
+mocha.describe('namespace_fs multipart upload', function() {
 
     const upload_bkt = 'test_ns_uploads_object';
     const mpu_bkt = 'test_ns_multipart_upload';
@@ -73,6 +73,8 @@ mocha.describe('namespace_fs mpu optimization tests', function() {
             fs_utils.folder_delete(`${tmp_fs_path}/${buck}`)));
     });
     mocha.after(async function() { await fs_utils.folder_delete(tmp_fs_path); });
+
+    mocha.describe('namespace_fs mpu optimization tests', function() {
 
     mocha.it('MPU | MIX | 10000 different size', async function() {
         this.timeout(2000000); // eslint-disable-line no-invalid-this
@@ -426,6 +428,47 @@ mocha.describe('namespace_fs mpu optimization tests', function() {
             }
         };
         await mpu_test_flow(ns_tmp, mpu_bkt, mpu_key, xattr, num_parts, parts_properties, src_file_path);
+    });
+
+    });
+
+    mocha.describe('complete_object_upload validation', function() {
+
+        mocha.it('rejects complete_object_upload with wrong part etag', async function() {
+            const mpu_key = 'mpu_wrong_etag';
+            const wrong_etag = '00000000000000000000000000000000';
+            const src_file_path = 'mpu_wrong_etag.txt';
+            let upload_id;
+            let cleanup_err;
+            try {
+                const create_mpu_res = await create_mpu(ns_tmp, mpu_bkt, mpu_key, {});
+                upload_id = create_mpu_res.obj_id;
+                const part_res = await upload_single_part(ns_tmp, 1, src_file_path, mpu_bkt, mpu_key, upload_id, 64, true, false);
+                assert.ok(part_res.etag);
+
+                try {
+                    await complete_mpu(ns_tmp, mpu_bkt, mpu_key, upload_id, [{ num: 1, etag: wrong_etag }]);
+                    assert.fail('complete_object_upload should fail');
+                } catch (err) {
+                    assert.strictEqual(err.rpc_code, 'INVALID_PART');
+                    assert.ok(err.message.includes('mismatch part etag'));
+                }
+            } finally {
+                if (upload_id) {
+                    try {
+                        await ns_tmp.abort_object_upload({ bucket: mpu_bkt, obj_id: upload_id }, DUMMY_OBJECT_SDK);
+                    } catch (abort_err) {
+                        if (abort_err.rpc_code !== 'NO_SUCH_UPLOAD' && abort_err.code !== 'ENOENT') cleanup_err = abort_err;
+                    }
+                }
+                try {
+                    await fs.promises.rm(src_file_path, { force: true });
+                } catch (rm_err) {
+                    if (rm_err.code !== 'ENOENT') cleanup_err = cleanup_err || rm_err;
+                }
+            }
+            if (cleanup_err) throw cleanup_err;
+        });
     });
 });
 


### PR DESCRIPTION
### Describe the Problem
When I accidentally used the wrong etag in the file on complete MPU, I got `InterError` instead of `InvalidPart`.
It was raised as part of a manual test when using MPU in deep archive (in PR #9978 ).

### Explain the Changes
1. Change the error of `mismatch part etag` from `Error` to `RpcError`.
2. Added AI-generated tests.

### Issues: 
List of GAPs:
1. Now we would surface the error of `InvalidPart`, but it seems like the error `InvalidPartOrder` is not used, so we probably need to handle this as well.

### Testing Instructions:
#### Unit Test:
1. `./node_modules/mocha/bin/mocha.js src/test/unit_tests/nsfs/test_namespace_fs_mpu.js --grep "wrong part etag"`

#### Manual Test:
##### NC
1. Create an account with the CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`, `chmod 777 /Users/buckets/`.
2. For running the endpoint server (open in a different tab in your terminal):
`sudo node src/cmd/nsfs --debug 5 --https_port 6442`
3. Create an account with noobaa CLI: `sudo node src/cmd/manage_nsfs account add --name <account-name> --new_buckets_path /Users/buckets/ --access_key <access-key> --secret_key <secret-key> --uid <uid> --gid <gid>`
Note: before creating the account need to give permission to the `new_buckets_path`: `chmod 777 /Users/buckets/`.
4. Create the alias for S3:
`alias nc-user-1-s3='AWS_SECRET_ACCESS_KEY=<secret-key> AWS_ACCESS_KEY_ID=<access-key> aws --no-verify-ssl --endpoint-url https://localhost:6442'`
5. Check the connection to the endpoint and try to list the buckets:  
`nc-user-1-s3 s3 ls; echo $?`
6. Add a bucket to the account using AWS CLI:  
`nc-user-1-s3 s3 mb s3://buc-2408`  
(`buc-1008` is the bucket name in this example; this will be the target bucket)
7. Create the object: `dd if=/dev/zero of=file_6mb.bin bs=1M count=6 status=progress`
8. Create the MPU: `nc-user-1-s3 s3api create-multipart-upload --bucket buc-2408 --key mpu_test`
Save the upload ID: `UPLOAD_ID='<paste-upload-id>'`
9. Upload parts (1 part) `nc-user-1-s3  s3api upload-part --bucket buc-2408 --key mpu_test --part-number 1 --body file_6mb.bin --upload-id $UPLOAD_ID`
10. Create the file with the parts and etags: `cat mpustruct2`, for example:
```
{
  "Parts": [
    {
      "ETag": "<add-wrong-etag>",
      "PartNumber": 1
    }
  ]
}
```
Replace the last character of the ETag.
11. Complete the MPU: `nc-user-1-s3 s3api complete-multipart-upload --multipart-upload file://mpustruct2 --bucket buc-2408 --key mpu_test --upload-id $UPLOAD_ID`

- [ ] Doc added/updated
- [X] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Multipart upload completion now returns a clear `INVALID_PART` error when a submitted part’s ETag does not match the stored metadata.
- Improved error messaging makes ETag mismatches easier to identify and resolve.
- Invalid multipart completion requests are rejected consistently, preventing uploads from completing with incorrect part information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->