### PR TITLE
block put bucket logging on nc

### DIFF
--- a/src/endpoint/s3/s3_bucket_logging.js
+++ b/src/endpoint/s3/s3_bucket_logging.js
@@ -118,7 +118,12 @@ function endpoint_bucket_op_logs(op_name, req, res, source_bucket, writes_aggreg
             break;
         }
         default: {
-            send_op_logs_to_syslog(req.object_sdk.rpc_client.rpc.router.syslog, s3_log);
+            const syslog = req.object_sdk.rpc_client?.rpc?.router?.syslog;
+            if (!syslog) {
+                dbg.warn('Skipping bucket logging: syslog router is unavailable');
+                break;
+            }
+            send_op_logs_to_syslog(syslog, s3_log);
         }
     }
 }

--- a/src/sdk/bucketspace_fs.js
+++ b/src/sdk/bucketspace_fs.js
@@ -675,22 +675,10 @@ class BucketSpaceFS extends BucketSpaceSimpleFS {
         try {
             const { name, logging } = params;
             dbg.log0('BucketSpaceFS.put_bucket_logging: Bucket name, logging', name, logging);
-            const bucket = await this.config_fs.get_bucket_by_name(name);
-            bucket.logging = logging;
 
-            let target_bucket;
-            try {
-                target_bucket = await this.config_fs.get_bucket_by_name(logging.log_bucket);
-            } catch (err) {
-                dbg.error('ERROR with reading TARGET BUCKET data', logging.log_bucket, err);
-                if (err.code === 'ENOENT') throw new RpcError('INVALID_TARGET_BUCKET', 'The target bucket for logging does not exist');
-                throw err;
-            }
-            if (target_bucket.owner_account !== bucket.owner_account) {
-                dbg.error('TARGET BUCKET NOT OWNED BY USER', target_bucket, bucket);
-                throw new RpcError('INVALID_TARGET_BUCKET', 'The owner for the bucket to be logged and the target bucket must be the same');
-            }
-            await this.config_fs.update_bucket_config_file(bucket);
+            // NC does not support bucket logging delivery yet, so reject enable requests
+            // instead of persisting a misleading logging configuration.
+            throw new RpcError('NOT_IMPLEMENTED', 'Bucket logging is not supported in NC');
         } catch (err) {
             throw translate_error_codes(err, entity_enum.BUCKET);
         }

--- a/src/test/unit_tests/nsfs/test_bucketspace_fs.js
+++ b/src/test/unit_tests/nsfs/test_bucketspace_fs.js
@@ -887,15 +887,18 @@ mocha.describe('bucketspace_fs', function() {
     });
 
     mocha.describe('bucket logging operations', function() {
-        mocha.it('put_bucket_logging ', async function() {
+        mocha.it('put_bucket_logging should fail with NOT_IMPLEMENTED', async function() {
             const logging = {
                 log_bucket: test_bucket,
                 log_prefix: 'test/'
             };
             const param = { name: test_bucket, logging: { ...logging } };
-            await bucketspace_fs.put_bucket_logging(param);
-            const output_log = await bucketspace_fs.get_bucket_logging(param);
-            assert.deepEqual(output_log, logging);
+            await assert.rejects(
+                bucketspace_fs.put_bucket_logging(param),
+                err => err.rpc_code === 'NOT_IMPLEMENTED'
+            );
+            const output_log = await bucketspace_fs.get_bucket_logging({ name: test_bucket });
+            assert.ok(output_log === undefined);
         });
         mocha.it('delete_bucket_logging', async function() {
             const param = { name: test_bucket };


### PR DESCRIPTION
### Describe the Problem
https://redhat.atlassian.net/browse/DFBUGS-9794
NooBaa NC was accepting PutBucketLogging requests even though bucket logging is not supported end to end in that environment. This misled clients into thinking logging was enabled, and later S3 operations could hit the missing rpc_client logging path and emit internal errors.

### Explain the Changes
1. Added an NC-specific guard in PutBucketLogging so enable requests now return NotImplemented instead of persisting a misleading logging configuration.
2. Skip syslog delivery when rpc_client or its syslog router is unavailable, preventing the null-RPC crash seen on later S3 operations.


### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Start an NC nsfs endpoint and create a source bucket and a log bucket with the same account.
2. Run aws --endpoint-url https://<nc-endpoint> --no-verify-ssl s3api put-bucket-logging --bucket <source-bucket> --bucket-logging-status '{"LoggingEnabled":{"TargetBucket":"<log-bucket>","TargetPrefix":"logs/"}}' and confirm the request returns NotImplemented.
3. Run the same request against a nonexistent source bucket and confirm it still returns the bucket-not-found error instead of NotImplemented.
4. If a bucket has stale logging configuration from before this change, run a follow-up S3 operation such as get-object or get-bucket-logging and confirm the request no longer produces a Cannot read properties of null (reading 'rpc') error in the endpoint logs.
5. Run the same PutBucketLogging enable request against a hosted/ODF deployment and confirm the operation still succeeds there.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when syslog logging is unavailable by safely skipping the operation and recording a warning.
  * Bucket logging enablement now clearly reports that the feature is not implemented instead of accepting and storing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->