### PR TITLE
DEEP_ARCHIVE | Update `restore_status` to have state and use `find_and_update_object`

### DIFF
--- a/src/api/common_api.js
+++ b/src/api/common_api.js
@@ -1716,6 +1716,10 @@ module.exports = {
             type: 'string',
             enum: ['IN_PROGRESS', 'DONE']
         },
+        restore_update_intent_enum: {
+            type: 'string',
+            enum: ['START_RESTORE', 'UPDATE_RESTORE_EXPIRY', 'COMPLETE_RESTORE', 'CLEAR_RESTORE_CLAIM'],
+        },
         bucket_logging: {
             type: 'object',
             required: ['log_bucket', 'log_prefix'],

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -1705,6 +1705,31 @@ module.exports = {
             },
         },
 
+        update_restore_info: {
+            method: 'PUT',
+            params: {
+                type: 'object',
+                required: ['obj_id', 'restore_update_intent'],
+                properties: {
+                    obj_id: { objectid: true },
+                    restore_update_intent: { $ref: 'common_api#/definitions/restore_update_intent_enum' },
+                    expected_restore_claim_id: { objectid: true },
+                    update_restore_status: { $ref: '#/definitions/restore_status' },
+                },
+            },
+            reply: {
+                type: 'object',
+                required: ['cas_matched'],
+                properties: {
+                    cas_matched: { type: 'boolean' },
+                    restore_claim_id: { objectid: true }, // START + cas_matched only (omitted for UPDATE_EXPIRY, COMPLETE, CLEAR_CLAIM)
+                },
+            },
+            auth: {
+                system: 'admin',
+            },
+        },
+
         get_object_restore_info: {
             method: 'GET',
             params: {
@@ -1732,7 +1757,9 @@ module.exports = {
                     restore_status: { $ref: '#/definitions/restore_status' },
                 }
             },
-            auth: { system: ['admin', 'user'] }
+            auth: {
+                system: 'admin',
+            },
         },
     },
 
@@ -1990,6 +2017,7 @@ module.exports = {
                 ongoing: { type: 'boolean' },
                 expiry_time: { idate: true },
                 days: { type: 'integer' },
+                restore_claim_id: { objectid: true },
             }
         },
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -19,6 +19,12 @@ const COMMON_CONSTANTS = {
       IN_PROGRESS: 'IN_PROGRESS',
       DONE: 'DONE',
     },
+    RESTORE_UPDATE_INTENT: {
+      START: 'START_RESTORE',
+      UPDATE_EXPIRY: 'UPDATE_RESTORE_EXPIRY',
+      COMPLETE: 'COMPLETE_RESTORE', // worker finished restore copy
+      CLEAR_CLAIM: 'CLEAR_RESTORE_CLAIM', // roll back failed object restore; clear ongoing for retry
+    },
   },
   STORE_TYPE: {
     S3: 'BLOCK_STORE_S3',

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -677,6 +677,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     INVALID_TARGET_BUCKET: S3Error.InvalidTargetBucketForLogging,
     METHOD_NOT_ALLOWED: S3Error.MethodNotAllowed,
     RESTORE_ALREADY_IN_PROGRESS: S3Error.RestoreAlreadyInProgress,
+    RESTORE_PENDING_RECLAIM: S3Error.BadRequest,
 });
 
 exports.S3Error = S3Error;

--- a/src/sdk/namespace_multi_storage_class.js
+++ b/src/sdk/namespace_multi_storage_class.js
@@ -6,6 +6,7 @@ const dbg = require('../util/debug_module')(__filename);
 const s3_utils = require('../endpoint/s3/s3_utils');
 const S3Error = require('../endpoint/s3/s3_errors').S3Error;
 const { get_archive_key, throw_if_restore_incomplete, is_restore_active, compute_restore_expiry } = require('../util/deep_archive_utils');
+const { ARCHIVE } = require('../common/constants');
 const { get_create_object_upload_params, get_complete_object_upload_params, CREATE_MULTIPART_PARAMS,
     COMPLETE_MULTIPART_PARAMS, destroy_source_stream } = require('../util/object_utils');
 
@@ -465,7 +466,7 @@ class NamespaceMultiStorageClass {
 
     /**
      * Initiates or updates a temporary restore of an archived object.
-     * Loads restore fields via get_object_restore_info (no s3:GetObject check),
+     * Loads restore fields via admin get_object_restore_info (S3 already checked s3:RestoreObject),
      * records restore_status on object MD, and calls restore_object on the archive
      * target namespace. A background worker later completes the temporary STANDARD
      * copy and sets expiry_time. On an already-restored object, replaces expiry with
@@ -477,8 +478,7 @@ class NamespaceMultiStorageClass {
      */
     async restore_object(params, object_sdk) {
         const { bucket, key, days } = params;
-        // Use restore-specific MD RPC (no s3:GetObject). Endpoint already checked s3:RestoreObject.
-        const object_restore_info = await object_sdk.rpc_client.object.get_object_restore_info(
+        const object_restore_info = await object_sdk.internal_rpc_client.object.get_object_restore_info(
             _.pick(params, 'bucket', 'key', 'version_id')
         );
         const storage_class = s3_utils.parse_storage_class(object_restore_info.storage_class);
@@ -496,8 +496,14 @@ class NamespaceMultiStorageClass {
 
         if (is_restore_active(object_restore_info.restore_status)) {
             const expires_on = compute_restore_expiry(days, new Date());
-            await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
-                restore_status: { ongoing: false, expiry_time: expires_on.getTime() } });
+            const extend_expiry_reply = await object_sdk.internal_rpc_client.object.update_restore_info({
+                obj_id: object_restore_info.obj_id,
+                restore_update_intent: ARCHIVE.RESTORE_UPDATE_INTENT.UPDATE_EXPIRY,
+                update_restore_status: { ongoing: false, expiry_time: expires_on.getTime() },
+            });
+            if (!extend_expiry_reply?.cas_matched) {
+                throw new S3Error(S3Error.RestoreAlreadyInProgress);
+            }
             dbg.log1('NamespaceMultiStorageClass.restore_object: updated restore expiry', { bucket, key, expires_on });
             return {
                 accepted: false, // accepted:false means already restored
@@ -508,9 +514,19 @@ class NamespaceMultiStorageClass {
 
         const archive_key = get_archive_key(object_restore_info.bucket_id, object_restore_info.obj_id);
         const archive_params = { ..._.pick(params, 'bucket', 'days', 'encryption'), key: archive_key}; // omit version-id because archive object is keyed by bucket_id/obj_id
-        await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
-            restore_status: { ongoing: true, days } });
-        dbg.log1('NamespaceMultiStorageClass.restore_object: initiating archive restore', { bucket, key, archive_key, days });
+        const start_reply = await object_sdk.internal_rpc_client.object.update_restore_info({
+            obj_id: object_restore_info.obj_id,
+            restore_update_intent: ARCHIVE.RESTORE_UPDATE_INTENT.START,
+            update_restore_status: { ongoing: true, days },
+        });
+        if (!start_reply?.cas_matched) {
+            throw new S3Error(S3Error.RestoreAlreadyInProgress);
+        }
+        if (!start_reply.restore_claim_id) {
+            throw new Error('NamespaceMultiStorageClass.restore_object: missing restore_claim_id on successful START reply');
+        }
+        const restore_claim_id = start_reply.restore_claim_id;
+        dbg.log1('NamespaceMultiStorageClass.restore_object: initiating archive restore', { bucket, key, archive_key, days, restore_claim_id });
         try {
             await target_ns.restore_object(archive_params, object_sdk);
         } catch (err) {
@@ -519,8 +535,17 @@ class NamespaceMultiStorageClass {
                 throw err;
             }
             try {
-                await object_sdk.rpc_client.object.update_object_md({ bucket, key, obj_id: object_restore_info.obj_id,
-                    restore_status: { ongoing: false }});
+                const clear_reply = await object_sdk.internal_rpc_client.object.update_restore_info({
+                    obj_id: object_restore_info.obj_id,
+                    expected_restore_claim_id: restore_claim_id,
+                    restore_update_intent: ARCHIVE.RESTORE_UPDATE_INTENT.CLEAR_CLAIM,
+                    update_restore_status: { ongoing: false },
+                });
+                if (!clear_reply?.cas_matched) {
+                    dbg.error('NamespaceMultiStorageClass.restore_object: failed to clear ' +
+                        'restore_status after archive failure (CAS pre-condition not met)',
+                        { bucket, key, archive_key });
+                }
             } catch (err2) {
                 dbg.error('NamespaceMultiStorageClass.restore_object: failed to clear ' +
                     'restore_status after archive failure', { bucket, key, archive_key }, err2);

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -1385,6 +1385,7 @@ interface CudaMemory {
 type NodeCallback<T = void> = (err: Error | null, res?: T) => void;
 
 type RestoreState = 'CAN_RESTORE' | 'ONGOING' | 'RESTORED';
+type RestoreUpdateIntent = 'START_RESTORE' | 'UPDATE_RESTORE_EXPIRY' | 'COMPLETE_RESTORE' | 'CLEAR_RESTORE_CLAIM'; // used containerized (MSC and restore BG worker)
 type TransitionStatus = 'IN_PROGRESS' | 'DONE';
 
 interface RestoreStatus {
@@ -1392,8 +1393,14 @@ interface RestoreStatus {
     ongoing?: boolean;
     expiry_time?: Date;
     days?: number; // currently used in MSC only
+    restore_claim_id?: ID; // currently used in MSC and BG Restore Worker only
 
     tape_info?: TapeInfo[];
+}
+
+interface UpdateRestoreInfoReply {
+    cas_matched: boolean;
+    restore_claim_id?: ID; // required in practice when intent is START and cas_matched is true; omitted for other intents
 }
 
 interface TapeInfo {

--- a/src/server/bg_services/objects_reclaimer.js
+++ b/src/server/bg_services/objects_reclaimer.js
@@ -113,7 +113,7 @@ class ObjectsReclaimer {
      *
      * Delete mappings first so a failed cleanup stays retryable (restore_status
      * still expired). RestoreObject is blocked while expired restore_status
-     * remains (see update_object_md), so unset after delete is safe.
+     * remains (see update_restore_info), so unset after delete is safe.
      * @returns {Promise<{ had_work: boolean, had_errors: boolean }>}
      */
     async reclaim_expired_restores() {

--- a/src/server/bg_services/restore_worker.js
+++ b/src/server/bg_services/restore_worker.js
@@ -9,6 +9,7 @@ const system_utils = require('../utils/system_utils');
 const auth_server = require('../common_services/auth_server');
 const server_rpc = require('../server_rpc');
 const deep_archive_utils = require('../../util/deep_archive_utils');
+const { ARCHIVE } = require('../../common/constants');
 const { destroy_source_stream } = require('../../util/object_utils');
 const ObjectIO = require('../../sdk/object_io');
 const map_deleter = require('../object_services/map_deleter');
@@ -149,7 +150,10 @@ class RestoreWorker {
     async _write_standard_restore_copy(obj, bucket, size, rpc_client) {
         dbg.log0('RestoreWorker: starting STANDARD restore copy write',
             { key: obj.key, obj_id: String(obj._id), bucket: bucket.name.unwrap(), size });
-        const { days, bucket_name, object_size, restore_copy_layout } = await this._prepare_restore_copy(obj, bucket, size);
+        const { days, bucket_name, object_size, restore_copy_layout, expected_restore_claim_id } =
+            await this._prepare_restore_copy(obj, bucket, size);
+
+        await this._assert_restore_claim_still_valid(obj, expected_restore_claim_id);
 
         if (!restore_copy_layout.is_complete) {
             const is_small_object = object_size <= config.RESTORE_WORKER_LARGE_OBJECT_SIZE;
@@ -157,20 +161,25 @@ class RestoreWorker {
             await this._upload_restore_copy(obj, bucket_name, object_size, rpc_client, restore_copy_layout.mapped_end_offset,
                 { full_archive_read: is_small_object && starting_from_byte_zero });
         }
-        await this._finalize_restore_copy(obj, bucket_name, days, rpc_client);
+        await this._assert_restore_claim_still_valid(obj, expected_restore_claim_id);
+        await this._finalize_restore_copy(obj, bucket_name, days, rpc_client, expected_restore_claim_id);
     }
 
     /**
-     * Validates restore days and size, checks restore-copy part layout, and clears invalid layouts
+     * Validates restore days and size from the batch snapshot, checks restore-copy part layout, and clears invalid layouts
      * @param {nb.ObjectMD} obj
      * @param {nb.Bucket} bucket
      * @param {number} size
-     * @returns {Promise<{ days: number, bucket_name: string, object_size: number, restore_copy_layout: { is_complete: boolean, mapped_end_offset: number, must_clear_parts: boolean } }>}
+     * @returns {Promise<{ days: number, bucket_name: string, object_size: number, restore_copy_layout: { is_complete: boolean, mapped_end_offset: number, must_clear_parts: boolean }, expected_restore_claim_id: nb.ID }>}
      */
     async _prepare_restore_copy(obj, bucket, size) {
         const days = obj.restore_status?.days;
         if (days === undefined || !Number.isInteger(days) || days < 1) {
             throw new Error(`RestoreWorker: missing restore_status.days for object ${obj.key} ${obj._id}`);
+        }
+        const expected_restore_claim_id = obj.restore_status?.restore_claim_id;
+        if (!expected_restore_claim_id) {
+            throw new Error(`RestoreWorker: missing restore_status.restore_claim_id for object ${obj.key} ${obj._id}`);
         }
 
         const object_size = size ?? obj.size;
@@ -191,7 +200,7 @@ class RestoreWorker {
             dbg.log0('RestoreWorker: restore copy already complete, skipping archive read and upload',
                 { key: obj.key, obj_id: String(obj._id), bucket: bucket_name, size: object_size });
         }
-        return { days, bucket_name, object_size, restore_copy_layout };
+        return { days, bucket_name, object_size, restore_copy_layout, expected_restore_claim_id };
     }
 
     /**
@@ -200,12 +209,30 @@ class RestoreWorker {
      * @param {string} bucket_name
      * @param {number} days
      * @param {nb.APIClient} rpc_client
+     * @param {nb.ID} expected_restore_claim_id
      */
-    async _finalize_restore_copy(obj, bucket_name, days, rpc_client) {
+    async _finalize_restore_copy(obj, bucket_name, days, rpc_client, expected_restore_claim_id) {
         const expires_on = deep_archive_utils.compute_restore_expiry(days);
         dbg.log0('RestoreWorker: updating restore_status',
             { key: obj.key, obj_id: String(obj._id), bucket: bucket_name, expiry_time: expires_on });
-        await this._update_restore_status(rpc_client, { bucket_name, key: obj.key, obj_id: obj._id, expires_on });
+        await this._update_restore_status(rpc_client,
+            { bucket_name, key: obj.key, obj_id: obj._id, expires_on, expected_restore_claim_id });
+    }
+
+    /**
+     * Re-reads restore_status before upload/finalize to detect a concurrent COMPLETE, CLEAR_CLAIM, or START with a new claim
+     * @param {nb.ObjectMD} obj
+     * @param {nb.ID} expected_restore_claim_id from the batch snapshot at prepare time
+     */
+    async _assert_restore_claim_still_valid(obj, expected_restore_claim_id) {
+        const obj_md = await MDStore.instance().find_object_by_id(obj._id);
+        const restore_status = obj_md?.restore_status;
+        if (!restore_status?.ongoing) {
+            throw new Error(`RestoreWorker: restore claim no longer ongoing for object ${obj.key} ${obj._id}`);
+        }
+        if (String(restore_status.restore_claim_id) !== String(expected_restore_claim_id)) {
+            throw new Error(`RestoreWorker: restore_claim_id mismatch for object ${obj.key} ${obj._id}`);
+        }
     }
 
     /**
@@ -379,25 +406,33 @@ class RestoreWorker {
     /**
      * Updates restore_status to ongoing false with expiry_time, with short retries
      * @param {nb.APIClient} rpc_client
-     * @param {{ bucket_name: string, key: string, obj_id: nb.ID, expires_on: Date }} params
+     * @param {{ bucket_name: string, key: string, obj_id: nb.ID, expires_on: Date, expected_restore_claim_id: nb.ID }} params
      */
-    async _update_restore_status(rpc_client, { bucket_name, key, obj_id, expires_on }) {
+    async _update_restore_status(rpc_client, { bucket_name, key, obj_id, expires_on, expected_restore_claim_id }) {
         const RESTORE_MD_UPDATE_ATTEMPTS = 3;
         const RESTORE_MD_UPDATE_DELAY_MS = 500;
 
         await P.retry({
             attempts: RESTORE_MD_UPDATE_ATTEMPTS,
             delay_ms: RESTORE_MD_UPDATE_DELAY_MS,
-            func: () => rpc_client.object.update_object_md({
-                bucket: bucket_name,
-                key,
-                obj_id,
-                restore_status: {
-                    ongoing: false,
-                    expiry_time: expires_on.getTime(),
-                },
-            }),
-            error_logger: err => dbg.warn('RestoreWorker: update_object_md failed, retrying',
+            func: async () => {
+                const reply = await rpc_client.object.update_restore_info({
+                    obj_id,
+                    expected_restore_claim_id,
+                    restore_update_intent: ARCHIVE.RESTORE_UPDATE_INTENT.COMPLETE,
+                    update_restore_status: {
+                        ongoing: false,
+                        expiry_time: expires_on.getTime(),
+                    },
+                });
+                if (!reply?.cas_matched) {
+                    const err = new Error(
+                        `RestoreWorker: update_restore_info CAS pre-condition not met obj_id=${obj_id}`);
+                    err.DO_NOT_RETRY = true;
+                    throw err;
+                }
+            },
+            error_logger: err => dbg.warn('RestoreWorker: update_restore_info failed, retrying',
                 { key, obj_id: String(obj_id), bucket: bucket_name }, err),
         });
         dbg.log0('RestoreWorker: restore_status updated',

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 3000]*/
+/*eslint max-lines: ["error", 3100]*/
 'use strict';
 
 /** @typedef {typeof import('../../sdk/nb')} nb */
@@ -1413,6 +1413,62 @@ class MDStore {
     get_object_version_id({ version_seq, version_enabled }) {
         if (!version_enabled || !version_seq) return 'null';
         return `nbver-${version_seq}`;
+    }
+
+    /**
+     * Atomically updates restore_status when the object matches restore_update_intent pre-condition.
+     * @param {nb.ID} obj_id
+     * @param {nb.RestoreUpdateIntent} restore_update_intent
+     * @param {Object} [set_updates]
+     * @param {Object} [unset_updates]
+     * @param {nb.ID} [expected_restore_claim_id] required for COMPLETE and CLEAR_CLAIM
+     * @param {Date} [now]
+     * @returns {Promise<void>}
+     */
+    async find_and_update_restore_status(obj_id, restore_update_intent, set_updates, unset_updates,
+        expected_restore_claim_id, now = new Date()) {
+        const { RESTORE_UPDATE_INTENT } = COMMON_CONSTANTS.ARCHIVE;
+        const base = {
+            _id: obj_id,
+            deleted: null,
+            upload_started: null,
+        };
+        let filter;
+        switch (restore_update_intent) {
+        case RESTORE_UPDATE_INTENT.START:
+            filter = {
+                ...base,
+                $or: [
+                    { restore_status: null },
+                    {
+                        'restore_status.ongoing': { $ne: true },
+                        $or: [
+                            { 'restore_status.expiry_time': null },
+                            { 'restore_status.expiry_time': { $exists: false } },
+                        ],
+                    },
+                ],
+            };
+            break;
+        case RESTORE_UPDATE_INTENT.UPDATE_EXPIRY:
+            filter = {
+                ...base,
+                'restore_status.ongoing': false,
+                'restore_status.expiry_time': { $gt: now },
+            };
+            break;
+        case RESTORE_UPDATE_INTENT.COMPLETE:
+        case RESTORE_UPDATE_INTENT.CLEAR_CLAIM:
+            filter = {
+                ...base,
+                'restore_status.ongoing': true,
+                'restore_status.restore_claim_id': expected_restore_claim_id,
+            };
+            break;
+        default:
+            throw new Error(`find_and_update_restore_status: unknown restore_update_intent ${restore_update_intent}`);
+        }
+        await this.find_and_update_object(filter, set_updates, unset_updates);
     }
 
     ////////////////

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1,5 +1,5 @@
 /* Copyright (C) 2016 NooBaa */
-/*eslint max-lines: ["error", 2850]*/
+/*eslint max-lines: ["error", 3000]*/
 'use strict';
 
 require('../../util/fips');
@@ -1140,7 +1140,7 @@ async function read_object_md_by_id(req) {
 async function update_object_md(req) {
     dbg.log1('object_server.update object md', req.rpc_params);
     throw_if_maintenance(req);
-    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time', 'target_data_info', 'restore_status');
+    const set_updates = _.pick(req.rpc_params, 'content_type', 'xattr', 'cache_last_valid_time', 'last_modified_time', 'target_data_info');
     if (set_updates.xattr) {
         set_updates.xattr = _.mapKeys(set_updates.xattr, (v, k) => k.replace(/\./g, '@'));
     }
@@ -1150,19 +1150,10 @@ async function update_object_md(req) {
     if (set_updates.last_modified_time) {
         set_updates.last_modified_time = new Date(set_updates.last_modified_time);
     }
-    if (set_updates.restore_status?.expiry_time) {
-        set_updates.restore_status.expiry_time = new Date(set_updates.restore_status.expiry_time);
+    if (req.rpc_params.restore_status) {
+        throw new RpcError('BAD_REQUEST', 'use update_restore_info to update restore_status');
     }
     const obj = await find_object_md(req);
-
-    // TODO we should try avoid blocking the restore in this race condition
-    // the issue here that might happen if we don't block a race condition of trying to do a restore when
-    // the old restore is still pending to be deleted or the transitioned object on the standard is
-    // still pending to be deleted. currently we decided to avoid this situation and client can retry after reclaimer runs
-    if (set_updates.restore_status && (is_expired_restore_pending_purge(obj) || is_transition_source_pending_purge(obj))) {
-        throw new RpcError('INTERNAL_ERROR',
-            'object restore/transition data is pending reclaim; retry later');
-    }
     await MDStore.instance().update_object_by_id(obj._id, set_updates);
     if (req.rpc_params.invalidate_md_cache) {
         object_md_cache.invalidate_key(String(obj._id));
@@ -1355,6 +1346,118 @@ async function unset_transition_in_progress(req) {
     throw_if_maintenance(req);
     const cutoff_date = new Date(req.rpc_params.cutoff_date);
     await MDStore.instance().unset_transition_in_progress(cutoff_date);
+}
+
+/**
+ * Updates restore_status of an object during RestoreObject or restore worker completion.
+ * Handler structure and CAS flow are based on update_transition_info.
+ * restore_update_intent selects the compare-and-set pre-condition in find_and_update_restore_status.
+ *
+ * @param {Object} req - The RPC request object.
+ * @returns {Promise<{ cas_matched: boolean, restore_claim_id?: nb.ID }>} restore_claim_id is always set when cas_matched is true for START
+ * @throws {RpcError}
+ */
+async function update_restore_info(req) {
+    dbg.log1('object_server.update_restore_info:', req.rpc_params);
+    throw_if_maintenance(req);
+    const { rpc_params } = req;
+    const obj_id = get_obj_id(req, 'BAD_OBJECT_ID');
+    const obj = await MDStore.instance().find_object_by_id(obj_id);
+    if (!obj || obj.deleted) {
+        throw new RpcError('NO_SUCH_OBJECT', 'object not found obj_id=' + rpc_params.obj_id);
+    }
+    if (String(req.system._id) !== String(obj.system)) {
+        throw new RpcError('NO_SUCH_OBJECT', 'object not found in system obj_id=' + rpc_params.obj_id);
+    }
+
+    if (is_expired_restore_pending_purge(obj) || is_transition_source_pending_purge(obj)) {
+        throw new RpcError('RESTORE_PENDING_RECLAIM',
+            'object restore/transition data is pending reclaim; retry later');
+    }
+
+    const { restore_update_intent } = rpc_params;
+    if (!restore_update_intent) {
+        throw new RpcError('BAD_REQUEST', 'restore_update_intent is required');
+    }
+
+    const { RESTORE_UPDATE_INTENT } = CONSTANTS.ARCHIVE;
+    let expected_restore_claim_id;
+    if (restore_update_intent === RESTORE_UPDATE_INTENT.COMPLETE ||
+        restore_update_intent === RESTORE_UPDATE_INTENT.CLEAR_CLAIM) {
+        if (!rpc_params.expected_restore_claim_id) {
+            throw new RpcError('BAD_REQUEST', 'expected_restore_claim_id is required');
+        }
+        if (!MDStore.instance().is_valid_md_id(rpc_params.expected_restore_claim_id)) {
+            throw new RpcError('BAD_REQUEST', 'invalid expected_restore_claim_id ' + rpc_params.expected_restore_claim_id);
+        }
+        expected_restore_claim_id = MDStore.instance().make_md_id(rpc_params.expected_restore_claim_id);
+    }
+
+    let restore_claim_id;
+    let set_updates;
+    let unset_updates;
+    if (rpc_params.update_restore_status) {
+        if (restore_update_intent === RESTORE_UPDATE_INTENT.START) {
+            restore_claim_id = make_md_id();
+            set_updates = {
+                restore_status: {
+                    ..._.pick(rpc_params.update_restore_status, 'ongoing', 'days'),
+                    restore_claim_id,
+                },
+            };
+        } else {
+            let allowed_fields;
+            switch (restore_update_intent) {
+            case RESTORE_UPDATE_INTENT.UPDATE_EXPIRY:
+            case RESTORE_UPDATE_INTENT.COMPLETE:
+                allowed_fields = ['ongoing', 'expiry_time'];
+                break;
+            case RESTORE_UPDATE_INTENT.CLEAR_CLAIM:
+                allowed_fields = ['ongoing'];
+                break;
+            default:
+                throw new RpcError('BAD_REQUEST',
+                    'update_restore_status not supported for restore_update_intent ' + restore_update_intent);
+            }
+            set_updates = {};
+            for (const [field, value] of Object.entries(_.pick(rpc_params.update_restore_status, allowed_fields))) {
+                if (field === 'expiry_time' && value) {
+                    set_updates[`restore_status.${field}`] = new Date(value);
+                } else {
+                    set_updates[`restore_status.${field}`] = value;
+                }
+            }
+        }
+    } else if (restore_update_intent === RESTORE_UPDATE_INTENT.START) {
+        throw new RpcError('BAD_REQUEST', 'update_restore_status is required for START');
+    }
+
+    try {
+        await MDStore.instance().find_and_update_restore_status(
+            obj_id, restore_update_intent, set_updates, unset_updates, expected_restore_claim_id, new Date());
+    } catch (error) {
+        if (error instanceof RpcError && error.rpc_code === 'NO_SUCH_OBJECT') {
+            if (restore_update_intent === RESTORE_UPDATE_INTENT.START ||
+                restore_update_intent === RESTORE_UPDATE_INTENT.UPDATE_EXPIRY) {
+                throw new RpcError('RESTORE_ALREADY_IN_PROGRESS',
+                    'restore already in progress or object state changed');
+            }
+            dbg.warn('update_restore_info: CAS pre-condition not met; object may be deleted, restore claim already cleared, or state changed concurrently',
+                { restore_update_intent, obj_id: rpc_params.obj_id, expected_restore_claim_id: rpc_params.expected_restore_claim_id,
+                  restore_status: obj.restore_status, update_restore_status: rpc_params.update_restore_status });
+            return { cas_matched: false };
+        }
+        throw error;
+    }
+    const reply = { cas_matched: true };
+    if (restore_update_intent === RESTORE_UPDATE_INTENT.START) {
+        reply.restore_claim_id = restore_claim_id;
+        if (await MDStore.instance().has_any_parts_for_object(obj)) {
+            dbg.log1('update_restore_info: clearing restore-copy parts on START', { obj_id: String(obj._id), key: obj.key });
+            await map_deleter.delete_object_parts(obj);
+        }
+    }
+    return reply;
 }
 
 /**
@@ -2815,6 +2918,7 @@ exports.find_objects_to_transition = find_objects_to_transition;
 exports.find_versioned_objects_to_transition = find_versioned_objects_to_transition;
 exports.update_transition_info = update_transition_info;
 exports.unset_transition_in_progress = unset_transition_in_progress;
+exports.update_restore_info = update_restore_info;
 
 if (process.env.NODE_ENV === 'test') {
     exports.__testing = {

--- a/src/test/integration_tests/internal/test_objects_reclaimer.js
+++ b/src/test/integration_tests/internal/test_objects_reclaimer.js
@@ -357,7 +357,7 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
         });
     });
 
-    mocha.describe('update_object_md restore fence', function() {
+    mocha.describe('update_restore_info restore fence', function() {
         mocha.it('rejects restore_status update while expired restore is pending purge', async function() {
             const obj = await upload_and_patch({
                 storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
@@ -368,13 +368,12 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
             });
 
             await assert.rejects(
-                () => rpc_client.object.update_object_md({
-                    bucket: BUCKET,
-                    key: obj.key,
+                () => rpc_client.object.update_restore_info({
                     obj_id: String(obj._id),
-                    restore_status: { ongoing: true, days: 7 },
+                    restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                    update_restore_status: { ongoing: true, days: 7 },
                 }),
-                err => err.rpc_code === 'INTERNAL_ERROR',
+                err => err.rpc_code === 'RESTORE_PENDING_RECLAIM',
             );
         });
 
@@ -391,13 +390,12 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
             });
 
             await assert.rejects(
-                () => rpc_client.object.update_object_md({
-                    bucket: BUCKET,
-                    key: obj.key,
+                () => rpc_client.object.update_restore_info({
                     obj_id: String(obj._id),
-                    restore_status: { ongoing: true, days: 7 },
+                    restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                    update_restore_status: { ongoing: true, days: 7 },
                 }),
-                err => err.rpc_code === 'INTERNAL_ERROR',
+                err => err.rpc_code === 'RESTORE_PENDING_RECLAIM',
             );
         });
 
@@ -416,15 +414,78 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
             const res = await reclaimer.reclaim_transition_source_data();
             assert.ok(res.had_work && !res.had_errors);
 
-            await rpc_client.object.update_object_md({
-                bucket: BUCKET,
-                key: obj.key,
+            await rpc_client.object.update_restore_info({
                 obj_id: String(obj._id),
-                restore_status: { ongoing: true, days: 7 },
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                update_restore_status: { ongoing: true, days: 7 },
             });
             const after = await MDStore.instance().find_object_by_id(obj._id);
             assert.strictEqual(after.restore_status.ongoing, true);
             assert.strictEqual(after.restore_status.days, 7);
+            assert.ok(after.restore_status.restore_claim_id);
+        });
+    });
+
+    mocha.describe('update_restore_info restore_claim_id', function() {
+        mocha.it('rejects stale COMPLETE after clear and re-claim', async function() {
+            const obj = await upload_and_patch({
+                storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
+            });
+
+            const start_a = await rpc_client.object.update_restore_info({
+                obj_id: String(obj._id),
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                update_restore_status: { ongoing: true, days: 7 },
+            });
+            assert.ok(start_a.cas_matched);
+            assert.ok(start_a.restore_claim_id);
+
+            const clear_a = await rpc_client.object.update_restore_info({
+                obj_id: String(obj._id),
+                expected_restore_claim_id: start_a.restore_claim_id,
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.CLEAR_CLAIM,
+                update_restore_status: { ongoing: false },
+            });
+            assert.strictEqual(clear_a.cas_matched, true);
+
+            const start_b = await rpc_client.object.update_restore_info({
+                obj_id: String(obj._id),
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                update_restore_status: { ongoing: true, days: 1 },
+            });
+            assert.ok(start_b.cas_matched);
+            assert.ok(start_b.restore_claim_id);
+            assert.notStrictEqual(String(start_b.restore_claim_id), String(start_a.restore_claim_id));
+
+            const stale_complete = await rpc_client.object.update_restore_info({
+                obj_id: String(obj._id),
+                expected_restore_claim_id: start_a.restore_claim_id,
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.COMPLETE,
+                update_restore_status: {
+                    ongoing: false,
+                    expiry_time: Date.now() + 7 * 24 * 60 * 60 * 1000,
+                },
+            });
+            assert.strictEqual(stale_complete.cas_matched, false);
+
+            const mid = await MDStore.instance().find_object_by_id(obj._id);
+            assert.strictEqual(mid.restore_status.ongoing, true);
+            assert.strictEqual(String(mid.restore_status.restore_claim_id), String(start_b.restore_claim_id));
+            assert.strictEqual(mid.restore_status.days, 1);
+
+            const complete_b = await rpc_client.object.update_restore_info({
+                obj_id: String(obj._id),
+                expected_restore_claim_id: start_b.restore_claim_id,
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.COMPLETE,
+                update_restore_status: {
+                    ongoing: false,
+                    expiry_time: Date.now() + 1 * 24 * 60 * 60 * 1000,
+                },
+            });
+            assert.strictEqual(complete_b.cas_matched, true);
+            const after = await MDStore.instance().find_object_by_id(obj._id);
+            assert.strictEqual(after.restore_status.ongoing, false);
+            assert.strictEqual(String(after.restore_status.restore_claim_id), String(start_b.restore_claim_id));
         });
     });
 });

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js
@@ -6,10 +6,12 @@ const s3_utils = require('../../../endpoint/s3/s3_utils');
 const S3Error = require('../../../endpoint/s3/s3_errors').S3Error;
 const { RpcError } = require('../../../rpc');
 const { get_archive_key, compute_restore_expiry } = require('../../../util/deep_archive_utils');
+const CONSTANTS = require('../../../common/constants');
 
 const BUCKET = 'restore-it-bucket';
 const BUCKET_ID = '507f1f77bcf86cd799439011';
 const OBJ_ID = '507f1f77bcf86cd799439012';
+const CLAIM_ID = '507f1f77bcf86cd799439013';
 const KEY = 'archived/object';
 
 /**
@@ -31,13 +33,18 @@ function make_msc_fixture({ object_restore_info: object_restore_info_override, a
         archive_restore_impl || (async () => ({ accepted: true }))
     );
     const get_object_restore_info = jest.fn().mockResolvedValue(object_restore_info);
-    const update_object_md = jest.fn().mockResolvedValue(undefined);
+    const update_restore_info = jest.fn().mockImplementation(async params => {
+        if (params.restore_update_intent === CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START) {
+            return { cas_matched: true, restore_claim_id: CLAIM_ID };
+        }
+        return { cas_matched: true };
+    });
 
     const metadata_ns = {};
     const archive_ns = { restore_object: archive_restore_object };
     const object_sdk = {
-        rpc_client: {
-            object: { get_object_restore_info, update_object_md },
+        internal_rpc_client: {
+            object: { get_object_restore_info, update_restore_info },
         },
     };
 
@@ -57,7 +64,7 @@ function make_msc_fixture({ object_restore_info: object_restore_info_override, a
         object_sdk,
         get_object_restore_info,
         archive_restore_object,
-        update_object_md,
+        update_restore_info,
     };
 }
 
@@ -120,7 +127,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
     const params = { bucket: BUCKET, key: KEY, days: 7 };
 
     it('rejects STANDARD objects with error InvalidObjectStorageClass', async () => {
-        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture({
             object_restore_info: {
                 storage_class: s3_utils.STORAGE_CLASS_STANDARD,
             },
@@ -129,7 +136,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
             code: S3Error.InvalidObjectStorageClass.code,
         });
-        expect(update_object_md).not.toHaveBeenCalled();
+        expect(update_restore_info).not.toHaveBeenCalled();
         expect(archive_restore_object).not.toHaveBeenCalled();
     });
 
@@ -138,18 +145,17 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
             ns_msc,
             object_sdk,
             archive_restore_object,
-            update_object_md,
+            update_restore_info,
         } = make_msc_fixture();
 
         const result = await ns_msc.restore_object(params, object_sdk);
 
         expect(result).toEqual({ accepted: true });
-        expect(update_object_md).toHaveBeenCalledTimes(1);
-        expect(update_object_md).toHaveBeenCalledWith({
-            bucket: BUCKET,
-            key: KEY,
+        expect(update_restore_info).toHaveBeenCalledTimes(1);
+        expect(update_restore_info).toHaveBeenCalledWith({
             obj_id: OBJ_ID,
-            restore_status: {
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+            update_restore_status: {
                 ongoing: true,
                 days: 7,
             },
@@ -165,9 +171,9 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
             object_sdk,
         );
         // Initiate only — BG worker owns clearing ongoing / setting expiry_time.
-        expect(update_object_md.mock.calls[0][0].restore_status.expiry_time).toBeUndefined();
+        expect(update_restore_info.mock.calls[0][0].update_restore_status.expiry_time).toBeUndefined();
         // restore_status update must happen before the archive call.
-        expect(update_object_md.mock.invocationCallOrder[0])
+        expect(update_restore_info.mock.invocationCallOrder[0])
             .toBeLessThan(archive_restore_object.mock.invocationCallOrder[0]);
     });
 
@@ -184,7 +190,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
     });
 
     it('rejects when restore_status.ongoing is true with error RestoreAlreadyInProgress', async () => {
-        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture({
             object_restore_info: {
                 restore_status: { ongoing: true, days: 3 },
             },
@@ -193,13 +199,13 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
             code: S3Error.RestoreAlreadyInProgress.code,
         });
-        expect(update_object_md).not.toHaveBeenCalled();
+        expect(update_restore_info).not.toHaveBeenCalled();
         expect(archive_restore_object).not.toHaveBeenCalled();
     });
 
     it('replaces expiry with now+days even when that shortens it', async () => {
         const future_expiry = new Date('2099-01-01T00:00:00Z');
-        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture({
             object_restore_info: {
                 storage_class: s3_utils.STORAGE_CLASS_GLACIER,
                 restore_status: {
@@ -221,11 +227,10 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         expect(result.expires_on.getTime()).toBeLessThanOrEqual(expected_max);
         expect(result.expires_on.getTime()).toBeLessThan(future_expiry.getTime());
 
-        expect(update_object_md).toHaveBeenCalledWith({
-            bucket: BUCKET,
-            key: KEY,
+        expect(update_restore_info).toHaveBeenCalledWith({
             obj_id: OBJ_ID,
-            restore_status: {
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.UPDATE_EXPIRY,
+            update_restore_status: {
                 ongoing: false,
                 expiry_time: result.expires_on.getTime(),
             },
@@ -235,7 +240,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
 
     it('updates expiry to now+days when that is later than existing', async () => {
         const existing_expiry = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000);
-        const { ns_msc, object_sdk, archive_restore_object, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture({
             object_restore_info: {
                 restore_status: {
                     ongoing: false,
@@ -255,11 +260,10 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         expect(result.expires_on.getTime()).toBeLessThanOrEqual(expected_max);
         expect(result.expires_on.getTime()).toBeGreaterThan(existing_expiry.getTime());
 
-        expect(update_object_md).toHaveBeenCalledWith({
-            bucket: BUCKET,
-            key: KEY,
+        expect(update_restore_info).toHaveBeenCalledWith({
             obj_id: OBJ_ID,
-            restore_status: {
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.UPDATE_EXPIRY,
+            update_restore_status: {
                 ongoing: false,
                 expiry_time: result.expires_on.getTime(),
             },
@@ -268,7 +272,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
     });
 
     it('re-initiates restore when previous expiry has passed', async () => {
-        const { ns_msc, archive_restore_object, object_sdk, update_object_md } = make_msc_fixture({
+        const { ns_msc, archive_restore_object, object_sdk, update_restore_info } = make_msc_fixture({
             object_restore_info: {
                 restore_status: {
                     ongoing: false,
@@ -280,9 +284,10 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         const result = await ns_msc.restore_object(params, object_sdk);
 
         expect(result).toEqual({ accepted: true });
-        expect(update_object_md).toHaveBeenCalledWith(
+        expect(update_restore_info).toHaveBeenCalledWith(
             expect.objectContaining({
-                restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
+                restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+                update_restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
             }),
         );
         expect(archive_restore_object).toHaveBeenCalledTimes(1);
@@ -290,24 +295,27 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
 
     it('clears ongoing and rethrows when archive restore_object fails', async () => {
         const archive_err = new Error('archive restore failed');
-        const { ns_msc, object_sdk, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, update_restore_info } = make_msc_fixture({
             archive_restore_impl: async () => {
                 throw archive_err;
             },
         });
 
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(archive_err);
-        expect(update_object_md).toHaveBeenCalledTimes(2);
-        expect(update_object_md).toHaveBeenNthCalledWith(1, expect.objectContaining({
-            restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
+        expect(update_restore_info).toHaveBeenCalledTimes(2);
+        expect(update_restore_info).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+            update_restore_status: expect.objectContaining({ ongoing: true, days: 7 }),
         }));
-        expect(update_object_md).toHaveBeenNthCalledWith(2, expect.objectContaining({
-            restore_status: { ongoing: false },
+        expect(update_restore_info).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.CLEAR_CLAIM,
+            expected_restore_claim_id: CLAIM_ID,
+            update_restore_status: { ongoing: false },
         }));
     });
 
     it('keeps ongoing when archive throws error RestoreAlreadyInProgress', async () => {
-        const { ns_msc, object_sdk, update_object_md } = make_msc_fixture({
+        const { ns_msc, object_sdk, update_restore_info } = make_msc_fixture({
             archive_restore_impl: async () => {
                 throw new S3Error(S3Error.RestoreAlreadyInProgress);
             },
@@ -316,10 +324,59 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
             code: S3Error.RestoreAlreadyInProgress.code,
         });
-        expect(update_object_md).toHaveBeenCalledTimes(1);
-        expect(update_object_md).toHaveBeenCalledWith(expect.objectContaining({
-            restore_status: expect.objectContaining({ ongoing: true }),
+        expect(update_restore_info).toHaveBeenCalledTimes(1);
+        expect(update_restore_info).toHaveBeenCalledWith(expect.objectContaining({
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.START,
+            update_restore_status: expect.objectContaining({ ongoing: true }),
         }));
+    });
+
+    it('rejects when restore claim fails with RESTORE_ALREADY_IN_PROGRESS', async () => {
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture();
+        update_restore_info.mockRejectedValueOnce(new RpcError('RESTORE_ALREADY_IN_PROGRESS', 'restore already in progress'));
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            rpc_code: 'RESTORE_ALREADY_IN_PROGRESS',
+        });
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('rejects when START returns cas_matched false', async () => {
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture();
+        update_restore_info.mockResolvedValueOnce({ cas_matched: false });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            code: S3Error.RestoreAlreadyInProgress.code,
+        });
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('rejects when START succeeds without restore_claim_id', async () => {
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture();
+        update_restore_info.mockResolvedValueOnce({ cas_matched: true });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toThrow(
+            'NamespaceMultiStorageClass.restore_object: missing restore_claim_id on successful START reply');
+        expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('rejects when UPDATE_EXPIRY returns cas_matched false', async () => {
+        const future_expiry = new Date('2099-01-01T00:00:00Z');
+        const { ns_msc, object_sdk, archive_restore_object, update_restore_info } = make_msc_fixture({
+            object_restore_info: {
+                storage_class: s3_utils.STORAGE_CLASS_GLACIER,
+                restore_status: {
+                    ongoing: false,
+                    expiry_time: future_expiry.getTime(),
+                },
+            },
+        });
+        update_restore_info.mockResolvedValueOnce({ cas_matched: false });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toMatchObject({
+            code: S3Error.RestoreAlreadyInProgress.code,
+        });
+        expect(archive_restore_object).not.toHaveBeenCalled();
     });
 
     it('allows client retry after failed archive initiate once ongoing is cleared', async () => {
@@ -330,8 +387,10 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
             },
         });
         await expect(first.ns_msc.restore_object(params, first.object_sdk)).rejects.toBe(archive_err);
-        expect(first.update_object_md).toHaveBeenNthCalledWith(2, expect.objectContaining({
-            restore_status: { ongoing: false },
+        expect(first.update_restore_info).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            restore_update_intent: CONSTANTS.ARCHIVE.RESTORE_UPDATE_INTENT.CLEAR_CLAIM,
+            expected_restore_claim_id: CLAIM_ID,
+            update_restore_status: { ongoing: false },
         }));
 
         // After compensating clear: ongoing=false → new initiate is allowed.
@@ -352,7 +411,7 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
             ns_msc,
             object_sdk,
             get_object_restore_info,
-            update_object_md,
+            update_restore_info,
             archive_restore_object,
         } = make_msc_fixture();
         const no_such_object_err = new RpcError('NO_SUCH_OBJECT',
@@ -360,8 +419,23 @@ describe('NamespaceMultiStorageClass.restore_object', () => {
         get_object_restore_info.mockRejectedValue(no_such_object_err);
 
         await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(no_such_object_err);
-        expect(update_object_md).not.toHaveBeenCalled();
+        expect(update_restore_info).not.toHaveBeenCalled();
         expect(archive_restore_object).not.toHaveBeenCalled();
+    });
+
+    it('rethrows archive error when clear restore claim returns false', async () => {
+        const archive_err = new Error('archive restore failed');
+        const { ns_msc, object_sdk, update_restore_info } = make_msc_fixture({
+            archive_restore_impl: async () => {
+                throw archive_err;
+            },
+        });
+        update_restore_info
+            .mockResolvedValueOnce({ cas_matched: true, restore_claim_id: CLAIM_ID })
+            .mockResolvedValueOnce({ cas_matched: false });
+
+        await expect(ns_msc.restore_object(params, object_sdk)).rejects.toBe(archive_err);
+        expect(update_restore_info).toHaveBeenCalledTimes(2);
     });
 });
 


### PR DESCRIPTION
### Describe the Problem
Use the  `find_and_update_object` in the restore_status as part of handling the TOCTOU race that we have in our code, as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823).

Note: it does not include the get-by-range implementation.

### Explain the Changes
1. Add the `restore_update_intent_enum` in `src/api/common_api.js` (based on`transition_status_enum`) and `RESTORE_UPDATE_INTENT` in `src/common/constants.js` (based on `RESTORE_UPDATE_INTENT`), and also `RestoreUpdateIntent` in `src/sdk/nb.d.ts`.
2. Add the `update_restore_info` (based on `update_transition_info`).
3. Add the `find_and_update_restore_status` for creating the filter for each case (based on `update_transition_info` in the `object_server` that part of creating the `filter` and calling `find_and_update_object` and the catch clause).
4. Instead of calling `update_object_md` for updating the `restore_status` call `update_restore_info` and include the `restore_update_intent` so we can know if the object was changed between the read and the update (to have `CAS` - compare and set update, atomic). Notice that when it returns `false` we need to handle it as well.
5. In `object_server` in `update_object_md` avoid setting the `restore_status` and implement `update_restore_info`, move relevant parts to it, and remove the TODO since it is handled in this change.
6. Edit test files with calls to `update_restore_info` instead of `update_object_md`.

### Issues: 
List of GAPs:
1. We can still have a TOCTOU issue on the data side (since the write is not atomic, for example, in the range case) - open issue #10008.
2. We have an issue with the date and timestamp - opened issue #10005.

### Testing Instructions:
#### Unit Tests
Please run:
1. `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`
2. `make run-single-test testpath=integration_tests/internal/test_objects_reclaimer.js`

#### Manual Tests:
1. I followed the setup in [comment](https://github.com/noobaa/noobaa-core/pull/9978#issuecomment-5407004378).
2. Regression: (1) restore full object (hello.txt example) (2) restore object read by range (used `config.RESTORE_WORKER_LARGE_OBJECT_SIZE = 5 * 1024 * 1024; // 5 MiB SDSD` with file of 6 MiB) - both succeeded.
3. I put an object and then sent 2 concurrent restore object calls: `s3-obc-user-2 s3api restore-object --bucket obc2 --key hello2.txt --restore-request Days=7 & s3-obc-user-2 s3api restore-object --bucket obc2 --key hello2.txt --restore-request Days=7 & wait`
Partial output (1 process it done and 1 process had expected error):
```
[1] 88795
[2] 88796
...
An error occurred (RestoreAlreadyInProgress) when calling the RestoreObject operation: Object restore is already in progress.
[2]  + 88796 exit 254   AWS_SECRET_ACCESS_KEY=... = aws    s3api
[1]  + 88795 done       AWS_SECRET_ACCESS_KEY=... = aws    s3api
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated API for starting, extending, completing, and clearing object restore operations.
  - Restore operations now track claims and support conditional updates to protect against concurrent changes.
  - Restore status includes additional lifecycle information for monitoring transitions.
- **Bug Fixes**
  - Concurrent restore requests now return clear “restore already in progress” results.
  - Restore completion failures follow the existing retry behavior.
  - Restore claims are safely cleared after unsuccessful operations.
  - Pending-reclaim restore attempts now return a standard bad-request response.
- **Tests**
  - Expanded coverage for restore lifecycle transitions, concurrency handling, claim tracking, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->