### PR TITLE
Deep Archive | Throw error on invalid storage class when bucket has no archive policy

### DIFF
--- a/config.js
+++ b/config.js
@@ -536,7 +536,15 @@ config.MULTIPART_CONCURRENCY = 10;
 /////////////////////
 // ARCHIVE CHECK   //
 /////////////////////
+
+// When true, create_namespace_resource with archive=true HeadBuckets the target
+// and requires x-noobaa-available-storage-classes to include GLACIER.
 config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+
+// When true, create_object_upload rejects GLACIER/DEEP_ARCHIVE unless the bucket
+// has archive_policy.deep_archive_resource. Set false to skip that check
+// (tests, or systems that use GLACIER on data buckets — never released).
+config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = true;
 
 config.ARCHIVE_NS_CACHE_MAX_USAGE = 100;
 config.ARCHIVE_NS_CACHE_EXPIRY_MS = 10 * 60 * 1000;

--- a/src/endpoint/s3/s3_errors.js
+++ b/src/endpoint/s3/s3_errors.js
@@ -669,6 +669,7 @@ S3Error.RPC_ERRORS_TO_S3 = Object.freeze({
     SERVICE_UNAVAILABLE: S3Error.ServiceUnavailable,
     INVALID_RANGE: S3Error.InvalidRange,
     INVALID_OBJECT_STATE: S3Error.InvalidObjectState,
+    INVALID_STORAGE_CLASS: S3Error.InvalidStorageClass,
     INTERNAL_ERROR: S3Error.InternalError,
     SERVER_SIDE_ENCRYPTION_CONFIGURATION_NOT_FOUND_ERROR: S3Error.ServerSideEncryptionConfigurationNotFoundError,
     NO_SUCH_TAG: S3Error.NoSuchTagSet,

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -36,7 +36,7 @@ const { ChunkAPI } = require('../../sdk/map_api_types');
 const config = require('../../../config');
 const CONSTANTS = require('../../common/constants');
 const Quota = require('../system_services/objects/quota');
-const { STORAGE_CLASS_STANDARD } = require('../../endpoint/s3/s3_utils');
+const { STORAGE_CLASS_STANDARD, GLACIER_STORAGE_CLASSES } = require('../../endpoint/s3/s3_utils');
 const { is_expired_restore_pending_purge, is_transition_source_pending_purge } = require('../../util/deep_archive_utils');
 
 // short living cache for objects
@@ -61,6 +61,12 @@ async function create_object_upload(req) {
     throw_if_maintenance(req);
     load_bucket(req);
     check_quota(req.bucket);
+    // Glacier/Deep Archive objects are unreadable without an archive target and restore path.
+    if (config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED && GLACIER_STORAGE_CLASSES.includes(req.rpc_params.storage_class) &&
+            !req.bucket.archive_policy?.deep_archive_resource) {
+        throw new RpcError('INVALID_STORAGE_CLASS',
+            `The storage class you specified is not valid. ${req.rpc_params.storage_class} requires the bucket to have an archive policy.`);
+    }
 
     const encryption = _get_encryption_for_object(req);
     const obj_id = MDStore.instance().make_md_id();

--- a/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
+++ b/src/test/integration_tests/api/s3/test_deep_archive_via_s3.js
@@ -382,6 +382,8 @@ async function backdate_object(obj_id, age_days) {
 }
 
 mocha.describe('deep_archive_via_s3', function() {
+    let original_archive_policy_check_enabled;
+
     mocha.before(async function() {
         const account_info = await rpc_client.account.read_account({ email: EMAIL });
         const credentials = {
@@ -399,6 +401,8 @@ mocha.describe('deep_archive_via_s3', function() {
         });
 
         config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        original_archive_policy_check_enabled = config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED;
+        config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = false;
         await s3.createBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
         await rpc_client.account.add_external_connection({
             name: ARCHIVE_CONNECTION,
@@ -432,6 +436,7 @@ mocha.describe('deep_archive_via_s3', function() {
             await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET_BUCKET]);
         } finally {
             config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+            config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = original_archive_policy_check_enabled;
         }
     });
 
@@ -504,6 +509,91 @@ mocha.describe('deep_archive_via_s3', function() {
     });
 
     }); // PutObject
+
+    mocha.describe('without archive policy', function() {
+        const NEVER_HAD_POLICY_BUCKET = 'test-msc-s3-never-had-archive';
+        const REMOVED_POLICY_BUCKET = 'test-msc-s3-removed-archive';
+
+        mocha.before(async function() {
+            config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = true;
+            await rpc_client.bucket.create_bucket({ name: NEVER_HAD_POLICY_BUCKET });
+            await rpc_client.bucket.create_bucket({
+                name: REMOVED_POLICY_BUCKET,
+                archive_policy: {
+                    deep_archive_resource: { resource: ARCHIVE_NSR },
+                },
+            });
+            await rpc_client.bucket.update_bucket({
+                name: REMOVED_POLICY_BUCKET,
+                remove_archive_policy: true,
+            });
+        });
+
+        mocha.after(async function() {
+            try {
+                await test_utils.empty_and_delete_buckets(rpc_client, [
+                    NEVER_HAD_POLICY_BUCKET,
+                    REMOVED_POLICY_BUCKET,
+                ]);
+            } finally {
+                // Parent suite disables this check for the rest of the file.
+                config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = false;
+            }
+        });
+
+        [NEVER_HAD_POLICY_BUCKET, REMOVED_POLICY_BUCKET].forEach(bucket => {
+            s3_utils.GLACIER_STORAGE_CLASSES.forEach(storage_class => {
+                mocha.it(`rejects PutObject ${storage_class} on ${bucket}`, async function() {
+                    await assert.rejects(
+                        s3.putObject({
+                            Bucket: bucket,
+                            Key: `no-archive/put-${storage_class}`,
+                            Body: Buffer.from('should-not-archive'),
+                            ContentType: 'application/octet-stream',
+                            StorageClass: storage_class,
+                        }),
+                        err => err_code(err) === 'InvalidStorageClass'
+                    );
+                    await assert.rejects(
+                        s3.headObject({ Bucket: bucket, Key: `no-archive/put-${storage_class}` }),
+                        err => err_code(err) === 'NotFound' || err_code(err) === 'NoSuchKey'
+                    );
+                });
+            });
+
+            mocha.it(`rejects CopyObject to DEEP_ARCHIVE on ${bucket}`, async function() {
+                const source_key = 'no-archive/copy-src';
+                const dest_key = 'no-archive/copy-dst';
+                await s3.putObject({
+                    Bucket: bucket,
+                    Key: source_key,
+                    Body: Buffer.from('copy-src'),
+                    ContentType: 'application/octet-stream',
+                });
+                await assert.rejects(
+                    s3.copyObject({
+                        Bucket: bucket,
+                        Key: dest_key,
+                        CopySource: `/${bucket}/${source_key}`,
+                        StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                    }),
+                    err => err_code(err) === 'InvalidStorageClass'
+                );
+            });
+
+            mocha.it(`rejects CreateMultipartUpload DEEP_ARCHIVE on ${bucket}`, async function() {
+                await assert.rejects(
+                    s3.createMultipartUpload({
+                        Bucket: bucket,
+                        Key: 'no-archive/mpu',
+                        ContentType: 'application/octet-stream',
+                        StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                    }),
+                    err => err_code(err) === 'InvalidStorageClass'
+                );
+            });
+        });
+    });
 
     mocha.describe('CopyObject', function() {
 

--- a/src/test/unit_tests/internal/test_deep_archive_s3.js
+++ b/src/test/unit_tests/internal/test_deep_archive_s3.js
@@ -72,6 +72,7 @@ mocha.describe('archive_policy', function() {
     const UPDATE_ARCHIVE_BUCKET = 'update-archive-policy-bucket';
     const REPLICATION_SOURCE_BUCKET = 'archive-policy-repl-src-bucket';
     const REPLICATION_DEST_BUCKET = 'archive-policy-repl-dest-bucket';
+    const NEVER_HAD_POLICY_BUCKET = 'never-had-archive-policy-bucket';
 
     const target_buckets = [ARCHIVE_TARGET_BUCKET, NON_ARCHIVE_TARGET_BUCKET];
     const namespace_resources = [
@@ -92,6 +93,7 @@ mocha.describe('archive_policy', function() {
         },
         { name: UPDATE_ARCHIVE_BUCKET },
         { name: REPLICATION_SOURCE_BUCKET },
+        { name: NEVER_HAD_POLICY_BUCKET }
     ];
 
     mocha.before(async function() {
@@ -296,6 +298,95 @@ mocha.describe('archive_policy', function() {
         } finally {
             await rpc_client.bucket.delete_bucket({ name });
         }
+    });
+
+    mocha.it('should reject create_object_upload with DEEP_ARCHIVE when bucket never had archive_policy', async function() {
+        await assert.rejects(
+            rpc_client.object.create_object_upload({
+                bucket: 'first.bucket',
+                key: 'archive-test.txt',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            }),
+            err => err.rpc_code === 'INVALID_STORAGE_CLASS' &&
+                err.message.includes('DEEP_ARCHIVE') &&
+                err.message.includes('archive policy')
+        );
+    });
+
+    mocha.it('should reject create_object_upload with DEEP_ARCHIVE when bucket never had archive_policy when check is enabled', async function() {
+        const original_archive_policy_check_enabled = config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED;
+        config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = true;
+        try {
+            await assert.rejects(
+                rpc_client.object.create_object_upload({
+                    bucket: NEVER_HAD_POLICY_BUCKET,
+                    key: 'archive-test.txt',
+                    storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+                }),
+                err => err.rpc_code === 'INVALID_STORAGE_CLASS' &&
+                    err.message.includes('DEEP_ARCHIVE') &&
+                    err.message.includes('archive policy')
+            );
+        } finally {
+            config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = original_archive_policy_check_enabled;
+        }
+    });
+
+    mocha.it('should allow create_object_upload with DEEP_ARCHIVE without archive_policy when check is disabled', async function() {
+        const original_archive_policy_check_enabled = config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED;
+        config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = false;
+        try {
+            const reply = await rpc_client.object.create_object_upload({
+                bucket: NEVER_HAD_POLICY_BUCKET,
+                key: 'archive-check-disabled.txt',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            });
+            assert.ok(reply.obj_id);
+            await rpc_client.object.abort_object_upload({
+                bucket: NEVER_HAD_POLICY_BUCKET,
+                key: 'archive-check-disabled.txt',
+                obj_id: reply.obj_id,
+            });
+        } finally {
+            config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = original_archive_policy_check_enabled;
+        }
+    });
+
+    mocha.it('should reject create_object_upload with DEEP_ARCHIVE after archive_policy is removed', async function() {
+        await rpc_client.bucket.update_bucket({
+            name: UPDATE_ARCHIVE_BUCKET,
+            archive_policy: {
+                deep_archive_resource: { resource: ARCHIVE_NSR },
+            },
+        });
+        await rpc_client.bucket.update_bucket({
+            name: UPDATE_ARCHIVE_BUCKET,
+            remove_archive_policy: true,
+        });
+        await assert.rejects(
+            rpc_client.object.create_object_upload({
+                bucket: UPDATE_ARCHIVE_BUCKET,
+                key: 'removed-archive-deep',
+                storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+            }),
+            err => err.rpc_code === 'INVALID_STORAGE_CLASS' &&
+                err.message.includes('DEEP_ARCHIVE') &&
+                err.message.includes('archive policy')
+        );
+    });
+
+    mocha.it('should allow create_object_upload with DEEP_ARCHIVE when bucket has archive_policy', async function() {
+        const reply = await rpc_client.object.create_object_upload({
+            bucket: ARCHIVE_BUCKET,
+            key: 'archive-deep',
+            storage_class: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+        });
+        assert.ok(reply.obj_id);
+        await rpc_client.object.abort_object_upload({
+            bucket: ARCHIVE_BUCKET,
+            key: 'archive-deep',
+            obj_id: reply.obj_id,
+        });
     });
 });
 

--- a/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
+++ b/src/test/unit_tests/internal/test_namespace_multi_storage_class.js
@@ -207,6 +207,7 @@ async function assert_archived_payload({ msc, arch_ns, object_sdk, key, buf, sto
 
 mocha.describe('NamespaceMultiStorageClass', function() {
     const object_sdk = make_object_sdk();
+    let original_archive_policy_check_enabled;
 
     mocha.before(async function() {
         const account_info = await rpc_client.account.read_account({ email: EMAIL });
@@ -225,6 +226,8 @@ mocha.describe('NamespaceMultiStorageClass', function() {
         });
 
         config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        original_archive_policy_check_enabled = config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED;
+        config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = false;
         await s3.createBucket({ Bucket: ARCHIVE_TARGET_BUCKET });
         await rpc_client.account.add_external_connection({
             name: ARCHIVE_CONNECTION,
@@ -258,6 +261,7 @@ mocha.describe('NamespaceMultiStorageClass', function() {
             await test_utils.empty_and_delete_buckets(rpc_client, [ARCHIVE_TARGET_BUCKET]);
         } finally {
             config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = true;
+            config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = original_archive_policy_check_enabled;
         }
     });
 


### PR DESCRIPTION
### Describe the Problem
NooBaa didn't validate for creating archive objects on buckets without an archive policy. The original implementation of DBs3 was supposed to utilize data buckets but it's not in use per moving to using nsfs.


### Explain the Changes
1. object_server.js - added a check when creating an object on deep archive/glacier storageclass the bucket must have archive policy and added a config for disabling this check.
2. Added missing INVALID_STORAGE_CLASS S3error which was missing and opened an issue for other cases we should throw invalidStorageClass - https://github.com/noobaa/noobaa-core/issues/9998.

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-9710

### Testing Instructions:
1. Added tests.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for Glacier and Deep Archive storage classes during S3 uploads, copies, and multipart uploads.
  * Buckets without an active archive policy reject these requests with an `InvalidStorageClass` error.
  * Added an option to disable archive storage-class validation when needed.
* **Bug Fixes**
  * Improved S3 error reporting for invalid storage-class requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->