### PR TITLE
Deep Archive | ObjectsReclaimer | reclaim deleted objects that their transitioned from standard to deep archive but not yet reclaimed their source

### DIFF
--- a/src/server/bg_services/objects_reclaimer.js
+++ b/src/server/bg_services/objects_reclaimer.js
@@ -40,11 +40,13 @@ class ObjectsReclaimer {
      *   archive multipart. If abort fails, the object stays unreclaimed for retry.
      * - Remote archive with restore_status: full map_deleter (local restore copy),
      *   then delete remote keys and mark reclaimed.
-     * - Remote archive without restore_status but with target data
+     * - Remote archive with unreclaimed transition source: full map_deleter
+     *   (local source copy), then delete remote keys and mark reclaimed.
+     * - Remote archive without a local copy but with target data
      *   (archive upload id): soft-delete leftover multiparts only, then
      *   delete remote keys and mark reclaimed.
      *   Mapping cleanup must succeed before enqueue so we do not mark reclaimed
-     *   while restore copies may still remain.
+     *   while local copies may still remain.
      * @returns {Promise<{ had_work: boolean, had_errors: boolean }>}
      */
     async reclaim_deleted_objects() {
@@ -66,7 +68,8 @@ class ObjectsReclaimer {
             try {
                 const bucket = system_store.data.get_by_id(obj.bucket);
                 const is_remote_data = deep_archive_utils.is_remote_archive_object(obj, bucket);
-                const should_delete_mappings = is_remote_data ? Boolean(obj.restore_status) : true;
+                const has_local_copy = Boolean(obj.restore_status) || deep_archive_utils.is_transition_source_pending_purge(obj);
+                const should_delete_mappings = is_remote_data ? has_local_copy : true;
                 const is_md_only_multipart_upload = Boolean(obj.target_data_info?.upload_id);
                 const should_delete_md_only_multiparts = is_remote_data && !should_delete_mappings && is_md_only_multipart_upload;
                 if (should_delete_mappings) {

--- a/src/test/integration_tests/internal/test_objects_reclaimer.js
+++ b/src/test/integration_tests/internal/test_objects_reclaimer.js
@@ -331,6 +331,33 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
             const parts = await MDStore.instance().find_all_parts_of_object(after);
             assert.strictEqual(parts.length, 0, 'local mappings should be deleted');
         });
+
+        mocha.it('reclaims object deleted while transition source was still pending purge', async function() {
+            // Not picked by reclaim_transition_source_data (requires live objects).
+            // Deleted + unreclaimed source has no restore_status, so the restore
+            // mapping path would skip local parts — this path must still purge them.
+            const obj = await upload_and_patch({
+                storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
+                transition_info: {
+                    status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_end_ts: new Date(Date.now() - 60_000),
+                    source_info: {
+                        storage_class: 'STANDARD',
+                    },
+                },
+                deleted: new Date(),
+            });
+
+            const res = await reclaimer.reclaim_deleted_objects();
+            assert.ok(res.had_work, 'expected reclaim work for deleted+unreclaimed transition source');
+            assert.ok(!res.had_errors, 'reclaim should not error');
+
+            const after = await MDStore.instance().find_object_by_id(obj._id);
+            assert.ok(after.deleted, 'object remains soft-deleted');
+            assert.ok(after.reclaimed, 'deleted+unreclaimed transition source should be marked reclaimed');
+            const parts = await MDStore.instance().find_all_parts_of_object(after);
+            assert.strictEqual(parts.length, 0, 'local source mappings should be deleted');
+        });
     });
 
     mocha.describe('delete_object_mappings_for_expired_restore_or_transition', function() {
@@ -411,7 +438,7 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                             storage_class: 'STANDARD',
                         },
                     },
-            });
+                });
 
             const res = await reclaimer.reclaim_transition_source_data();
             assert.ok(res.had_work && !res.had_errors);


### PR DESCRIPTION

### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of deleted archive objects when local copies or pending transition data remain.
  - Ensured source mappings are fully purged after transition data is reclaimed.
  - Preserved the object’s soft-deleted state while marking cleanup as complete.
  - Improved handling of restore status while archived object cleanup is in progress.

- **Tests**
  - Added coverage for unreclaimed transition sources and restore-status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->