### PR TITLE
Deep Archive | Reject archive policy and replication on the same bucket

### DIFF
--- a/docs/design/DeepArchiveAPIsSupport.md
+++ b/docs/design/DeepArchiveAPIsSupport.md
@@ -84,7 +84,7 @@ The primary goal of this epic is to integrate IBM Deep Archive as a supported co
   - outputLocation
   - batch
 - Restore Quota per account
-- Setting replication policy and lifecycle transition policy on the same bucket.
+- Setting replication policy and archive policy on the same bucket.
 
 ---
 ### Stretch Goals
@@ -223,6 +223,7 @@ Constraints:
 
 * `--deep-archive-resource` and `--remove-archive-policy` are mutually exclusive.
 * The referenced NamespaceStore must exist and have `spec.archive: true`.
+* Archive policy and replication policy cannot be set on the same source bucket (`INVALID_REQUEST`). A replication destination may have an archive policy.
 * Update or removal is rejected when the bucket contains completed objects in `DEEP_ARCHIVE` or `GLACIER` storage classes.
 * Changing or removing `archivePolicy` on a BucketClass only affects new OBCs; use `noobaa bucket update` for existing buckets.
 
@@ -1108,7 +1109,7 @@ Write objects to standard storage, then let a lifecycle rule transition them to 
 #### Preconditions
 
 - [Setup](#setup) completed.
-- Bucket has no conflicting replication + lifecycle transition policy (see design doc out-of-scope note).
+- Bucket has no replication policy (archive and replication cannot be set on the same source bucket).
 
 #### Step 1 — Upload to standard storage
 

--- a/src/server/system_services/bucket_server.js
+++ b/src/server/system_services/bucket_server.js
@@ -1006,6 +1006,7 @@ async function get_bucket_changes_archive_policy(req, bucket, update_request, si
         single_bucket_update.$unset = { ...(single_bucket_update.$unset || {}), archive_policy: 1 };
     } else {
         _validate_not_namespace_bucket(bucket);
+        _validate_archive_and_replication_exclusive(bucket, update_request);
         single_bucket_update.archive_policy = resolve_archive_policy({ ...req, rpc_params: update_request });
     }
 }
@@ -2117,6 +2118,7 @@ function validate_non_nsfs_bucket_creation(req) {
 async function put_bucket_replication(req) {
     dbg.log0('put_bucket_replication:', req.rpc_params);
     const bucket = find_bucket(req);
+    _validate_archive_and_replication_exclusive(bucket, req.rpc_params);
 
     await validate_replication(req);
     const replication_rules = normalize_replication(req);
@@ -2682,6 +2684,24 @@ async function update_rows_since_index(req) {
     }
 
     await system_store.make_changes(change);
+}
+
+/**
+ * On NooBaa 6.0, Archive policy and replication policy cannot both be set on the same source bucket.
+ * Destination buckets may have archive_policy but currently archive storageclass is not supported as 
+ * a destination storageclass so objects will be written to the STANDARD (default) storageclass.
+ * @param {object} bucket - existing bucket document from system_store
+ * @param {object} params - RPC params (`archive_policy` from update_bucket, `replication_policy` from put_bucket_replication)
+ * @returns {void}
+ * @throws {RpcError} INVALID_REQUEST when the request would set both policies on the source bucket
+ */
+function _validate_archive_and_replication_exclusive(bucket, params) {
+    if (params.archive_policy && bucket.replication_policy_id) {
+        throw new RpcError('INVALID_REQUEST', 'Cannot set archive policy on a bucket that has a replication policy');
+    }
+    if (params.replication_policy && bucket.archive_policy) {
+        throw new RpcError('INVALID_REQUEST', 'Cannot set replication policy on a bucket that has an archive policy');
+    }
 }
 
 // EXPORTS

--- a/src/test/unit_tests/internal/test_deep_archive_s3.js
+++ b/src/test/unit_tests/internal/test_deep_archive_s3.js
@@ -70,6 +70,8 @@ mocha.describe('archive_policy', function() {
     const ARCHIVE_BUCKET = 'archive-policy-bucket';
     const NAMESPACE_BUCKET = 'archive-policy-ns-bucket';
     const UPDATE_ARCHIVE_BUCKET = 'update-archive-policy-bucket';
+    const REPLICATION_SOURCE_BUCKET = 'archive-policy-repl-src-bucket';
+    const REPLICATION_DEST_BUCKET = 'archive-policy-repl-dest-bucket';
 
     const target_buckets = [ARCHIVE_TARGET_BUCKET, NON_ARCHIVE_TARGET_BUCKET];
     const namespace_resources = [
@@ -89,6 +91,7 @@ mocha.describe('archive_policy', function() {
             },
         },
         { name: UPDATE_ARCHIVE_BUCKET },
+        { name: REPLICATION_SOURCE_BUCKET },
     ];
 
     mocha.before(async function() {
@@ -97,6 +100,7 @@ mocha.describe('archive_policy', function() {
         for (const name of target_buckets) {
             await rpc_client.bucket.create_bucket({ name });
         }
+        await rpc_client.bucket.create_bucket({ name: REPLICATION_DEST_BUCKET });
         await rpc_client.account.add_external_connection({
             name: ARCHIVE_CONNECTION,
             endpoint: coretest.get_http_address(),
@@ -124,6 +128,7 @@ mocha.describe('archive_policy', function() {
             await rpc_client.pool.delete_namespace_resource({ name: nsr.name });
         }
         await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+        await rpc_client.bucket.delete_bucket({ name: REPLICATION_DEST_BUCKET });
         for (const name of target_buckets) {
             await rpc_client.bucket.delete_bucket({ name });
         }
@@ -215,6 +220,82 @@ mocha.describe('archive_policy', function() {
         });
         info = await rpc_client.bucket.read_bucket({ name: UPDATE_ARCHIVE_BUCKET });
         assert.ok(!info.archive_policy);
+    });
+
+    mocha.it('should reject put_bucket_replication on a bucket with archive_policy', async function() {
+        await assert.rejects(
+            () => rpc_client.bucket.put_bucket_replication({
+                name: ARCHIVE_BUCKET,
+                replication_policy: {
+                    rules: [{ rule_id: 'rule-1', destination_bucket: REPLICATION_DEST_BUCKET, sync_versions: false }],
+                },
+            }),
+            err => err.rpc_code === 'INVALID_REQUEST',
+        );
+    });
+
+    mocha.it('should reject update_bucket archive_policy on a bucket with replication', async function() {
+        await rpc_client.bucket.put_bucket_replication({
+            name: REPLICATION_SOURCE_BUCKET,
+            replication_policy: {
+                rules: [{ rule_id: 'rule-1', destination_bucket: REPLICATION_DEST_BUCKET, sync_versions: false }],
+            },
+        });
+        await assert.rejects(
+            () => rpc_client.bucket.update_bucket({
+                name: REPLICATION_SOURCE_BUCKET,
+                archive_policy: {
+                    deep_archive_resource: { resource: ARCHIVE_NSR },
+                },
+            }),
+            err => err.rpc_code === 'INVALID_REQUEST',
+        );
+    });
+
+    mocha.it('should allow put_bucket_replication after remove_archive_policy', async function() {
+        const name = 'archive-then-repl-bucket';
+        await rpc_client.bucket.create_bucket({
+            name,
+            archive_policy: { deep_archive_resource: { resource: ARCHIVE_NSR } },
+        });
+        try {
+            await rpc_client.bucket.update_bucket({ name, remove_archive_policy: true });
+            await rpc_client.bucket.put_bucket_replication({
+                name,
+                replication_policy: {
+                    rules: [{ rule_id: 'rule-1', destination_bucket: REPLICATION_DEST_BUCKET, sync_versions: false }],
+                },
+            });
+            const info = await rpc_client.bucket.read_bucket({ name });
+            assert.ok(info.replication_policy_id);
+            assert.ok(!info.archive_policy);
+        } finally {
+            await rpc_client.bucket.delete_bucket({ name });
+        }
+    });
+
+    mocha.it('should allow update_bucket archive_policy after delete_bucket_replication', async function() {
+        const name = 'repl-then-archive-bucket';
+        await rpc_client.bucket.create_bucket({ name });
+        try {
+            await rpc_client.bucket.put_bucket_replication({
+                name,
+                replication_policy: {
+                    rules: [{ rule_id: 'rule-1', destination_bucket: REPLICATION_DEST_BUCKET, sync_versions: false }],
+                },
+            });
+            await rpc_client.bucket.delete_bucket_replication({ name });
+            await rpc_client.bucket.update_bucket({
+                name,
+                archive_policy: { deep_archive_resource: { resource: ARCHIVE_NSR } },
+            });
+            const info = await rpc_client.bucket.read_bucket({ name });
+            assert.ok(info.archive_policy);
+            assert.strictEqual(info.archive_policy.deep_archive_resource.resource, ARCHIVE_NSR);
+            assert.ok(!info.replication_policy_id);
+        } finally {
+            await rpc_client.bucket.delete_bucket({ name });
+        }
     });
 });
 


### PR DESCRIPTION
### Describe the Problem
For tech preview we would like to reject archive policy and replication on the same bucket.

### Explain the Changes
1. Added a short check on update_bucket and put_bucket_replication that will reject archive policy and replication on the same bucket.policy.
2. Added unit tests
3. Updated the docs.

### Issues: Fixed #xxx / Gap #xxx
1. Gap - a better UX experience would be to add admission webhook for the obc update, but since it's a temporary limitation and might be fixed before introduced to customers.

### Testing Instructions:
1. auto - 
2. Manual - 
Pre-requisites - 
```
> nb namespacestore create s3-compatible ns1 --access-key=<archive-access-key> --secret-key=<archive-secret-key> --endpoint=https://<archive-endpoint> --target-bucket=<archive-target-bucket> --archive
> nb bucketclass create placement-bucketclass bc1 --backingstores=noobaa-default-backing-store --deep-archive-resource=ns1
// create a bucket with archive policy called obc.archive
> nb obc create obc.archive --exact --bucketclass=bc1
// create a bucket with replication policy called obc.replication
> cat repl.json
{"Rules": [{ "rule_id": "rule-2", "destination_bucket": "first.bucket", "filter": {"prefix": "bc"}}]}
> nb obc create obc.replication --exact --replication-policy=repl.json
```

Updating a bucket that has a replication policy with an archive policy - 
```
> nb bucket  update obc.replication --deep-archive-resource=ns1
INFO[0000] ✅ Exists: NooBaa "noobaa"
INFO[0000] ✅ Exists: Service "noobaa-mgmt"
INFO[0000] ✅ Exists: Secret "noobaa-operator"
INFO[0000] ✅ Exists: Secret "noobaa-admin"
INFO[0000] ✅ Exists: NamespaceStore "ns1"
.....
ERRO[0000] ⚠️  RPC: bucket.update_bucket() Response Error: Code=INVALID_REQUEST Message=Cannot set archive policy on a bucket that has a replication policy
FATA[0000] Cannot set archive policy on a bucket that has a replication policy
```

Updating a bucket that has an archive policy with a replication policy - 
```
> k edit obc.archive
set replicationPolicy on the spec - 
replicationPolicy: '{"rules":[{"rule_id":"rule-1","destination_bucket":"first.bucket","filter":{"prefix":"a"}}]}'
> k logs noobaa-operator-7b4475fcc-97svm| grep replication
time="2026-09-01T13:06:47Z" level=info msg="updateReplicationPolicy: updating replication on ob: \"obc-default-obc.archive\" replicationParams: &{Name:obc.archive ReplicationPolicy:{Rules:[map[destination_bucket:first.bucket filter:map[prefix:a] rule_id:rule-1]] LogReplicationInfo:<nil>}}" provisioner=default.noobaa.io/obc
time="2026-09-01T13:06:47Z" level=info msg="✈️  RPC: bucket.put_bucket_replication() Request: {Name:obc.archive ReplicationPolicy:{Rules:[map[destination_bucket:first.bucket filter:map[prefix:a] rule_id:rule-1]] LogReplicationInfo:<nil>}}"
time="2026-09-01T13:06:47Z" level=error msg="⚠️  RPC: bucket.put_bucket_replication() Response Error: Code=INVALID_REQUEST Message=Cannot set replication policy on a bucket that has an archive policy"
E0901 13:06:47.624313       1 controller.go:688] "msg"="updating from Provisioner failed" "error"="Provisioner Failed to update replication on bucket \"obc-default-obc.archive\" with error: Cannot set replication policy on a bucket that has an archive policy" "key"="default/obc.archive"
E0901 13:06:47.624344       1 controller.go:205] "Unhandled Error" err="error syncing 'default/obc.archive': Provisioner Failed to update replication on bucket \"obc-default-obc.archive\" with error: Cannot set replication policy on a bucket that has an archive policy, requeuing" logger="UnhandledError"
```
- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Archive and replication policies can no longer be configured together on the same source bucket.
- Conflicting configurations now return an `INVALID_REQUEST` error.
- Policies can be configured sequentially after the conflicting policy is removed.
- Replication destination buckets may still use archive policies.

## Documentation
- Updated Deep Archive integration guidance and configuration constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->