### PR TITLE
NC | Adding upgrade script for CORS

### DIFF
--- a/src/sdk/config_fs.js
+++ b/src/sdk/config_fs.js
@@ -80,7 +80,7 @@ const CONFIG_DIR_PHASES = Object.freeze({
  * The upgrade script will run via `noobaa-cli upgrade run command`
  */
 
-const CONFIG_DIR_VERSION = '1.0.0';
+const CONFIG_DIR_VERSION = '1.1.0';
 
 class ConfigFS {
 

--- a/src/test/integration_tests/nc/cli/test_cli_upgrade.test.js
+++ b/src/test/integration_tests/nc/cli/test_cli_upgrade.test.js
@@ -72,7 +72,7 @@ const old_expected_system_json2 = {
         },
     },
     config_directory: {
-        'config_dir_version': '1.0.0',
+        'config_dir_version': config_fs.config_dir_version,
         'upgrade_package_version': '5.18.0',
         'phase': CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED,
         'upgrade_history': {
@@ -82,7 +82,7 @@ const old_expected_system_json2 = {
                 'package_from_version': '5.17.0',
                 'package_to_version': '5.18.0',
                 'config_dir_from_version': '0.0.0',
-                'config_dir_to_version': '1.0.0'
+                'config_dir_to_version': config_fs.config_dir_version
             }]
         }
     }
@@ -128,7 +128,7 @@ const new_expected_system_json = {
         },
     },
     config_directory: {
-        'config_dir_version': '1.0.0',
+        'config_dir_version': config_fs.config_dir_version,
         'phase': CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED,
         'upgrade_history': {
             'successful_upgrades': [{
@@ -137,7 +137,7 @@ const new_expected_system_json = {
                     'package_from_version': '5.17.0',
                     'package_to_version': pkg.version,
                     'config_dir_from_version': '0.0.0',
-                    'config_dir_to_version': '1.0.0'
+                    'config_dir_to_version': config_fs.config_dir_version
                 },
                 {
                     'timestamp': 1724687496424,

--- a/src/test/integration_tests/nc/cli/test_nc_health.js
+++ b/src/test/integration_tests/nc/cli/test_nc_health.js
@@ -41,7 +41,7 @@ const get_service_state_mock_default_response = [{ service_status: 'active', pid
 const get_endpoint_response_mock_default_response = [{ response: { response_code: 'RUNNING', total_fork_count: 0 } }];
 const get_system_config_mock_default_response = [{
     ...valid_system_json, config_directory: {
-        phase: CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED, config_dir_version: '1.0.0',
+        phase: CONFIG_DIR_PHASES.CONFIG_DIR_UNLOCKED, config_dir_version: '1.1.0',
         package_version: pkg.version, upgrade_history: []
 } }];
 const default_mock_upgrade_status = { message: 'there is no in-progress upgrade' };

--- a/src/test/unit_tests/nc/configuration/test_upgrade_bucket_cors_upgrade_script.test.js
+++ b/src/test/unit_tests/nc/configuration/test_upgrade_bucket_cors_upgrade_script.test.js
@@ -1,0 +1,137 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const config = require('../../../../../config');
+const dbg = require('../../../../util/debug_module')(__filename);
+const { ConfigFS } = require('../../../../sdk/config_fs');
+const fs_utils = require('../../../../util/fs_utils');
+const nb_native = require('../../../../util/nb_native');
+const native_fs_utils = require('../../../../util/native_fs_utils');
+const { run, get_default_cors_configuration, upgrade_bucket_cors_config, upgrade_buckets_cors } =
+    require('../../../../upgrade/nc_upgrade_scripts/1.1.0/upgrade_bucket_cors');
+
+const TEST_TIMEOUT = 60 * 1000;
+const tmp_fs_path = path.join(os.tmpdir(), 'test_upgrade_bucket_cors');
+const config_root = path.join(tmp_fs_path, 'config_root');
+const config_fs = new ConfigFS(config_root);
+
+const default_cors = get_default_cors_configuration();
+const custom_cors = [{
+    allowed_origins: ['https://example.com'],
+    allowed_methods: ['GET'],
+    allowed_headers: ['*'],
+    expose_headers: ['ETag'],
+}];
+
+function get_bucket_data(name, extra = {}) {
+    return {
+        _id: '65a62e22ceae5e5f1a758aa8' + name,
+        name,
+        owner_account: '65b3c68b59ab67b16f98c26e',
+        versioning: 'DISABLED',
+        creation_date: new Date('December 17, 2023 09:00:00').toISOString(),
+        path: '/tmp/nsfs_root1',
+        should_create_underlying_storage: true,
+        ...extra,
+    };
+}
+
+async function write_bucket_config_file(bucket_data) {
+    const bucket_path = config_fs.get_bucket_path_by_name(bucket_data.name);
+    await nb_native().fs.writeFile(
+        config_fs.fs_context,
+        bucket_path,
+        Buffer.from(JSON.stringify(bucket_data)), {
+            mode: native_fs_utils.get_umasked_mode(config.BASE_MODE_FILE)
+        }
+    );
+}
+
+describe('upgrade_bucket_cors NC upgrade script', () => {
+    beforeEach(async () => {
+        await fs_utils.create_fresh_path(config_fs.buckets_dir_path);
+    });
+
+    afterEach(async () => {
+        await fs_utils.folder_delete(config_root);
+    }, TEST_TIMEOUT);
+
+    describe('upgrade_bucket_cors_config', () => {
+        it('adds default CORS when the bucket has none', async () => {
+            const bucket_data = get_bucket_data('bucket-no-cors');
+            await write_bucket_config_file(bucket_data);
+            await upgrade_bucket_cors_config(config_fs, bucket_data.name, dbg);
+            const upgraded = await config_fs.get_bucket_by_name(bucket_data.name);
+            expect(upgraded.cors_configuration_rules).toEqual(default_cors);
+        });
+
+        it('skips buckets that already have CORS configuration', async () => {
+            const bucket_data = get_bucket_data('bucket-with-cors', { cors_configuration_rules: custom_cors });
+            await write_bucket_config_file(bucket_data);
+            await upgrade_bucket_cors_config(config_fs, bucket_data.name, dbg);
+            const upgraded = await config_fs.get_bucket_by_name(bucket_data.name);
+            expect(upgraded.cors_configuration_rules).toEqual(custom_cors);
+        });
+
+        it('skips missing buckets', async () => {
+            await expect(upgrade_bucket_cors_config(config_fs, 'missing-bucket', dbg)).resolves.toBeUndefined();
+        });
+    });
+
+    describe('upgrade_buckets_cors', () => {
+        it('upgrades multiple buckets and preserves existing CORS', async () => {
+            const bucket_without_cors = get_bucket_data('bucket-a');
+            const bucket_with_cors = get_bucket_data('bucket-b', { cors_configuration_rules: custom_cors });
+            await write_bucket_config_file(bucket_without_cors);
+            await write_bucket_config_file(bucket_with_cors);
+
+            const failed = await upgrade_buckets_cors(config_fs, [bucket_without_cors.name, bucket_with_cors.name], dbg);
+            expect(failed).toEqual([]);
+
+            const upgraded_a = await config_fs.get_bucket_by_name(bucket_without_cors.name);
+            const upgraded_b = await config_fs.get_bucket_by_name(bucket_with_cors.name);
+            expect(upgraded_a.cors_configuration_rules).toEqual(default_cors);
+            expect(upgraded_b.cors_configuration_rules).toEqual(custom_cors);
+        });
+
+        it('returns an empty failed list when there are no buckets', async () => {
+            const failed = await upgrade_buckets_cors(config_fs, [], dbg);
+            expect(failed).toEqual([]);
+        });
+    });
+
+    describe('run', () => {
+        it('adds default CORS to all buckets without CORS', async () => {
+            const bucket1 = get_bucket_data('bucket1');
+            const bucket2 = get_bucket_data('bucket2');
+            await write_bucket_config_file(bucket1);
+            await write_bucket_config_file(bucket2);
+
+            await run({ dbg, config_fs });
+
+            const upgraded1 = await config_fs.get_bucket_by_name(bucket1.name);
+            const upgraded2 = await config_fs.get_bucket_by_name(bucket2.name);
+            expect(upgraded1.cors_configuration_rules).toEqual(default_cors);
+            expect(upgraded2.cors_configuration_rules).toEqual(default_cors);
+        });
+
+        it('is idempotent when all buckets already have CORS', async () => {
+            const bucket_data = get_bucket_data('bucket-already-upgraded', { cors_configuration_rules: default_cors });
+            await write_bucket_config_file(bucket_data);
+            await run({ dbg, config_fs });
+            const upgraded = await config_fs.get_bucket_by_name(bucket_data.name);
+            expect(upgraded.cors_configuration_rules).toEqual(default_cors);
+        });
+
+        it('succeeds when the buckets directory is missing', async () => {
+            await fs_utils.folder_delete(config_fs.buckets_dir_path);
+            await expect(run({ dbg, config_fs })).resolves.toBeUndefined();
+        });
+
+        it('succeeds when the buckets directory is empty', async () => {
+            await expect(run({ dbg, config_fs })).resolves.toBeUndefined();
+        });
+    });
+});

--- a/src/upgrade/nc_upgrade_manager.js
+++ b/src/upgrade/nc_upgrade_manager.js
@@ -268,7 +268,11 @@ class NCUpgradeManager {
      */
     async _run_nc_upgrade_scripts(this_upgrade) {
         try {
-            await run_upgrade_scripts(this_upgrade, this.upgrade_scripts_dir, { dbg, from_version: this_upgrade.package_from_version });
+            await run_upgrade_scripts(this_upgrade, this.upgrade_scripts_dir, {
+                dbg,
+                from_version: this_upgrade.package_from_version,
+                config_fs: this.config_fs
+            });
         } catch (err) {
             const upgrade_failed_msg = `_run_nc_upgrade_scripts: nc upgrade manager failed!!!, ${err}`;
             dbg.error(upgrade_failed_msg);

--- a/src/upgrade/nc_upgrade_scripts/1.1.0/upgrade_bucket_cors.js
+++ b/src/upgrade/nc_upgrade_scripts/1.1.0/upgrade_bucket_cors.js
@@ -1,0 +1,118 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+const util = require('util');
+const P = require('../../../util/promise');
+const config = require('../../../../config');
+const { ConfigFS } = require('../../../sdk/config_fs');
+const native_fs_utils = require('../../../util/native_fs_utils');
+
+/**
+ * get_default_cors_configuration returns the default bucket CORS configuration
+ * @returns {Object[]}
+ */
+function get_default_cors_configuration() {
+    return [{
+        allowed_origins: config.S3_CORS_ALLOW_ORIGIN,
+        allowed_methods: config.S3_CORS_ALLOW_METHODS,
+        allowed_headers: config.S3_CORS_ALLOW_HEADERS,
+        expose_headers: config.S3_CORS_EXPOSE_HEADERS,
+    }];
+}
+
+/**
+ * run adds the default CORS configuration to all existing buckets that do not already have one.
+ * Mirrors the containerized upgrade_scripts/5.19.0/upgrade_bucket_cors.js behavior for NC config-dir buckets.
+ * @param {{dbg: *, from_version?: String, config_fs?: import('../../../sdk/config_fs').ConfigFS}} params
+ */
+async function run({ dbg, config_fs: config_fs_param }) {
+    try {
+        const config_fs = config_fs_param || new ConfigFS(config.NSFS_NC_CONF_DIR, config.NSFS_NC_CONFIG_DIR_BACKEND);
+        dbg.log0('Starting bucket CORS upgrade...');
+
+        const buckets_dir_exists = await config_fs.validate_config_dir_exists(config_fs.buckets_dir_path);
+        if (!buckets_dir_exists) {
+            dbg.log0('Upgrading buckets CORS configuration: buckets directory does not exist, no upgrade needed...');
+            return;
+        }
+
+        const bucket_names = await config_fs.list_buckets();
+        const failed_buckets = await upgrade_buckets_cors(config_fs, bucket_names, dbg);
+
+        if (failed_buckets.length > 0) {
+            throw new Error('NC upgrade process failed, failed_buckets array length is bigger than 0' + util.inspect(failed_buckets));
+        }
+        if (bucket_names.length === 0) {
+            dbg.log0('Upgrading buckets CORS configuration: no upgrade needed...');
+        }
+    } catch (err) {
+        dbg.error('Got error while upgrading buckets CORS configuration:', err);
+        throw err;
+    }
+}
+
+/**
+ * upgrade_buckets_cors iterates all buckets and adds the default CORS configuration with retries
+ * @param {import('../../../sdk/config_fs').ConfigFS} config_fs
+ * @param {String[]} bucket_names
+ * @param {*} dbg
+ * @returns {Promise<Object[]>}
+ */
+async function upgrade_buckets_cors(config_fs, bucket_names, dbg) {
+    const failed_buckets = [];
+    for (const bucket_name of bucket_names) {
+        let retries = 3;
+        while (retries > 0) {
+            try {
+                await upgrade_bucket_cors_config(config_fs, bucket_name, dbg);
+                break;
+            } catch (err) {
+                retries -= 1;
+                dbg.warn(`upgrade bucket CORS failed ${bucket_name}, err ${err} retries left ${retries}`);
+                if (retries <= 0) {
+                    failed_buckets.push({ bucket_name, err });
+                    break;
+                }
+                await P.delay(20);
+            }
+        }
+    }
+    return failed_buckets;
+}
+
+/**
+ * upgrade_bucket_cors_config adds the default CORS configuration to a single bucket
+ * if it does not already have cors_configuration_rules.
+ * Writes via native_fs_utils so the update is allowed while the config directory is locked
+ * during the upgrade.
+ * @param {import('../../../sdk/config_fs').ConfigFS} config_fs
+ * @param {String} bucket_name
+ * @param {*} dbg
+ * @returns {Promise<void>}
+ */
+async function upgrade_bucket_cors_config(config_fs, bucket_name, dbg) {
+    const bucket = await config_fs.get_bucket_by_name(bucket_name, { silent_if_missing: true });
+    if (!bucket) {
+        dbg.warn(`upgrade_bucket_cors_config: bucket ${bucket_name} was not found, skipping`);
+        return;
+    }
+    if (Array.isArray(bucket.cors_configuration_rules) && bucket.cors_configuration_rules.length > 0) {
+        dbg.log0(`upgrade_bucket_cors_config: bucket ${bucket_name} already has CORS configuration, skipping`);
+        return;
+    }
+
+    bucket.cors_configuration_rules = get_default_cors_configuration();
+    dbg.log0(`Adding default bucket CORS configuration to: ${util.inspect(bucket.name)}`);
+    const { string_bucket_data } = config_fs._prepare_for_bucket_schema(bucket);
+    const bucket_config_path = config_fs.get_bucket_path_by_name(bucket_name);
+    await native_fs_utils.update_config_file(config_fs.fs_context, config_fs.buckets_dir_path, bucket_config_path, string_bucket_data);
+}
+
+module.exports = {
+    run,
+    description: 'Update default CORS configuration for all buckets',
+};
+
+module.exports.get_default_cors_configuration = get_default_cors_configuration;
+module.exports.upgrade_buckets_cors = upgrade_buckets_cors;
+module.exports.upgrade_bucket_cors_config = upgrade_bucket_cors_config;

--- a/src/upgrade/upgrade_utils.js
+++ b/src/upgrade/upgrade_utils.js
@@ -88,7 +88,8 @@ async function load_required_scripts(current_version, new_version, upgrade_scrip
     * db_client?: import('../util/db_client'), 
     * system_store?: import('../server/system_services/system_store').SystemStore, 
     * system_server?: import('../server/system_services/system_server'),
-    * from_version?: String
+    * from_version?: String,
+    * config_fs?: import('../sdk/config_fs').ConfigFS
  * }} options 
  */
 async function run_upgrade_scripts(this_upgrade, upgrade_scripts_dir, options) {


### PR DESCRIPTION
### Describe the Problem
We didn't have an upgrade script for CORS, as we have for ODF.
Old buckets need to have a default CORS configuration, as we have for new buckets

### Explain the Changes
1. Add an upgrade script adding the default CORS configuration to every bucket that existed before the upgrade

### Issues: Fixed #xxx / Gap #xxx
1. TBD

### Testing Instructions:
1. Create a few buckets in NC 5.18 - see that there is no CORS configuration in the bucket config JSON
2. Upgrade to latest
3.  See that the buckets have the default config after the upgrade


- [ ] Doc added/updated
- [x] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Existing buckets without CORS settings now receive the configured default CORS rules during upgrades.
  - Upgrade processing retries failed bucket updates and reports any remaining failures.

- **Bug Fixes**
  - Configuration directory upgrades now recognize version 1.1.0.
  - Buckets with existing custom CORS settings remain unchanged.

- **Tests**
  - Added coverage for missing buckets, empty directories, repeated upgrades, custom CORS settings, and upgrade failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->