### PR TITLE
Deep Archive | Refactor source_info.transition_timestamp to transition_end_ts

### DIFF
--- a/docs/design/DeepArchiveAPIsSupport.md
+++ b/docs/design/DeepArchiveAPIsSupport.md
@@ -307,7 +307,7 @@ The existing lifecycle bg worker currently **skips** `Transition` / `NoncurrentV
    - Set the object's `transition_info` to `{ status: "IN_PROGRESS" }` (`source_info` is set only when marking `DONE`)
    - Read object data from standard storage class
    - Writes object data to IBM Deep Archive (S3-compatible write, per-request timeout)
-   - Update object DB metadata fields - `storage_class = 'DEEP_ARCHIVE'`, `transition_info = { status: "DONE", source_info: { storage_class: <source>, transition_timestamp } }`
+   - Update object DB metadata fields - `storage_class = 'DEEP_ARCHIVE'`, `transition_info = { status: "DONE", transition_end_ts, source_info: { storage_class: <source> } }`
 3. The ObjectsReclaimer BG worker deletes the source storage-class copy (local data mappings). After a successful delete, it sets `transition_info.source_info.reclaimed` to the reclaim timestamp so the object leaves the unreclaimed find/index and is not retried.
 
 **Notes -**

--- a/src/api/object_api.js
+++ b/src/api/object_api.js
@@ -2000,16 +2000,16 @@ module.exports = {
             properties: {
                 status: { $ref: 'common_api#/definitions/transition_status_enum' },
                 transition_start_ts: { idate: true },
+                transition_end_ts: { idate: true },
                 source_info: { $ref: '#/definitions/source_info' },
             }
         },
 
         source_info: {
             type: 'object',
-            required: ['storage_class', 'transition_timestamp'],
+            required: ['storage_class'],
             properties: {
                 storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
-                transition_timestamp: { idate: true },
                 reclaimed: { idate: true },
             }
         },

--- a/src/sdk/nb.d.ts
+++ b/src/sdk/nb.d.ts
@@ -461,9 +461,9 @@ interface ObjectMD {
 interface TransitionInfo {
     status: TransitionStatus;
     transition_start_ts?: Date;
+    transition_end_ts?: Date;
     source_info?: {
         storage_class: StorageClass;
-        transition_timestamp?: Date;
         reclaimed?: Date;
     };
 }

--- a/src/server/bg_services/lifecycle.js
+++ b/src/server/bg_services/lifecycle.js
@@ -521,7 +521,6 @@ async function transition_objects(system, bucket_info, objects, target_storage_c
         const obj_id = obj.obj_id;
         const source_info = {
             storage_class: obj.storage_class || STORAGE_CLASS_STANDARD,
-            transition_timestamp: Date.now(),
         };
         try {
             const res = await server_rpc.client.object.update_transition_info({

--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1006,7 +1006,7 @@ class MDStore {
             'transition_info.status': 'DONE',
             'transition_info.source_info': { $exists: true },
             'transition_info.source_info.reclaimed': null,
-            'transition_info.source_info.transition_timestamp': { $exists: true },
+            'transition_info.transition_end_ts': { $exists: true },
         }, {
             limit: limit ?? 1000,
             preferred_pool: 'read_only',

--- a/src/server/object_services/object_server.js
+++ b/src/server/object_services/object_server.js
@@ -1298,11 +1298,9 @@ async function update_transition_info(req) {
             } else if (!rpc_params.source_info?.storage_class) {
                 throw new Error("update_transition_info: source_info.storage_class is required for updating to DONE");
             }
+            transition_info.transition_end_ts = new Date();
             transition_info.source_info = {
                 storage_class: rpc_params.source_info?.storage_class || STORAGE_CLASS_STANDARD,
-                transition_timestamp: rpc_params.source_info?.transition_timestamp ?
-                    new Date(rpc_params.source_info.transition_timestamp) :
-                    new Date(),
             };
             set_updates = { transition_info, storage_class: rpc_params.storage_class};
         } else {
@@ -2058,10 +2056,10 @@ function get_object_info(md, options = {}) {
             status: md.transition_info.status,
             transition_start_ts: md.transition_info.transition_start_ts ?
                 new Date(md.transition_info.transition_start_ts).getTime() : undefined,
+            transition_end_ts: md.transition_info.transition_end_ts ?
+                new Date(md.transition_info.transition_end_ts).getTime() : undefined,
             source_info: md.transition_info.source_info ? {
                 storage_class: md.transition_info.source_info.storage_class,
-                transition_timestamp: md.transition_info.source_info.transition_timestamp ?
-                    new Date(md.transition_info.source_info.transition_timestamp).getTime() : undefined,
                 reclaimed: md.transition_info.source_info.reclaimed ?
                     new Date(md.transition_info.source_info.reclaimed).getTime() : undefined,
             } : undefined,

--- a/src/server/object_services/schemas/object_md_schema.js
+++ b/src/server/object_services/schemas/object_md_schema.js
@@ -152,12 +152,12 @@ module.exports = {
             properties: {
                 status: { $ref: 'common_api#/definitions/transition_status_enum' },
                 transition_start_ts: { date: true },
+                transition_end_ts: { date: true },
                 source_info: {
                     type: 'object',
-                    required: ['storage_class', 'transition_timestamp'],
+                    required: ['storage_class'],
                     properties: {
                         storage_class: { $ref: 'common_api#/definitions/storage_class_enum' },
-                        transition_timestamp: { date: true },
                         reclaimed: { date: true },
                     }
                 },

--- a/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
+++ b/src/test/integration_tests/api/s3/test_lifecycle_transitions.js
@@ -734,9 +734,9 @@ mocha.describe('lifecycle-transitions', function() {
             await MDStore.instance().update_object_by_id(id, {
                 transition_info: {
                     status: ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_end_ts: new Date(),
                     source_info: {
                         storage_class: 'STANDARD',
-                        transition_timestamp: new Date(),
                     },
                 },
                 storage_class: TARGET_STORAGE_CLASS,
@@ -1688,9 +1688,9 @@ mocha.describe('lifecycle-transitions', function() {
             await MDStore.instance().update_object_by_id(id, {
                 transition_info: {
                     status: ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_end_ts: new Date(),
                     source_info: {
                         storage_class: 'STANDARD',
-                        transition_timestamp: new Date(),
                     },
                 },
                 storage_class: TARGET_STORAGE_CLASS,
@@ -1947,9 +1947,9 @@ mocha.describe('lifecycle-transitions', function() {
             await MDStore.instance().update_object_by_id(new mongodb.ObjectId(obj_id), {
                 transition_info: {
                     status: ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_end_ts: new Date(Date.now() - config.LIFECYCLE_TRANSITION_TIMEOUT - 1000),
                     source_info: {
                         storage_class: 'STANDARD',
-                        transition_timestamp: new Date(Date.now() - config.LIFECYCLE_TRANSITION_TIMEOUT - 1000),
                     },
                 },
             });

--- a/src/test/integration_tests/db/test_md_store.js
+++ b/src/test/integration_tests/db/test_md_store.js
@@ -446,10 +446,10 @@ mocha.describe('md_store', function() {
             });
             const source_info = {
                 storage_class: 'STANDARD',
-                transition_timestamp: new Date(Date.now() - 60_000),
             };
             const transition_info = {
                 status: 'DONE',
+                transition_end_ts: new Date(Date.now() - 60_000),
                 source_info,
             };
             const done = {
@@ -526,9 +526,9 @@ mocha.describe('md_store', function() {
             const suffix = Date.now().toString(36);
             const transition_info = {
                 status: 'DONE',
+                transition_end_ts: new Date(Date.now() - 60_000),
                 source_info: {
                     storage_class: 'STANDARD',
-                    transition_timestamp: new Date(Date.now() - 60_000),
                 },
             };
             for (let i = 0; i < 2; i++) {
@@ -621,9 +621,9 @@ mocha.describe('md_store', function() {
                 content_type: 'application/octet-stream',
                 transition_info: {
                     status: 'DONE',
+                    transition_end_ts: new Date(Date.now() - 10 * 60 * 60 * 1000),
                     source_info: {
                         storage_class: 'STANDARD',
-                        transition_timestamp: new Date(Date.now() - 10 * 60 * 60 * 1000),
                     },
                 },
             };

--- a/src/test/integration_tests/db/test_query_plans.js
+++ b/src/test/integration_tests/db/test_query_plans.js
@@ -157,9 +157,9 @@ mocha.describe('md_store query plan verification', function() {
             create_time: new Date(),
             transition_info: {
                 status: 'DONE',
+                transition_end_ts: new Date(Date.now() - 60_000),
                 source_info: {
                     storage_class: 'STANDARD',
-                    transition_timestamp: new Date(Date.now() - 60_000),
                 },
             },
         };

--- a/src/test/integration_tests/internal/test_objects_reclaimer.js
+++ b/src/test/integration_tests/internal/test_objects_reclaimer.js
@@ -168,9 +168,9 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                 storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
                     transition_info: {
                         status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                        transition_end_ts: new Date(Date.now() - 60_000),
                         source_info: {
                             storage_class: 'STANDARD',
-                            transition_timestamp: new Date(Date.now() - 60_000),
                         },
                     },
             });
@@ -196,9 +196,9 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                 storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
                     transition_info: {
                         status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                        transition_end_ts: new Date(Date.now() - 60_000),
                         source_info: {
                             storage_class: 'STANDARD',
-                            transition_timestamp: new Date(Date.now() - 60_000),
                         },
                     },
             });
@@ -239,9 +239,9 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                 },
                 transition_info: {
                     status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                    transition_end_ts: new Date(Date.now() - 60_000),
                     source_info: {
                         storage_class: 'STANDARD',
-                        transition_timestamp: new Date(Date.now() - 60_000),
                     },
                 },
             });
@@ -383,9 +383,9 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                 storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
                     transition_info: {
                         status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                        transition_end_ts: new Date(Date.now() - 60_000),
                         source_info: {
                             storage_class: 'STANDARD',
-                            transition_timestamp: new Date(Date.now() - 60_000),
                         },
                     },
             });
@@ -406,9 +406,9 @@ mocha.describe('ObjectsReclaimer expire paths', function() {
                 storage_class: CONSTANTS.ARCHIVE.STORAGE_CLASS.DEEP_ARCHIVE,
                     transition_info: {
                         status: CONSTANTS.ARCHIVE.TRANSITION_STATUS.DONE,
+                        transition_end_ts: new Date(Date.now() - 60_000),
                         source_info: {
                             storage_class: 'STANDARD',
-                            transition_timestamp: new Date(Date.now() - 60_000),
                         },
                     },
             });

--- a/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
+++ b/src/test/unit_tests/util_functions_tests/test_deep_archive_utils.test.js
@@ -101,19 +101,19 @@ describe('is_expired_restore_pending_purge', () => {
 });
 
 describe('is_transition_source_pending_purge', () => {
-    it('returns true when source_info is unreclaimed and has transition_timestamp', () => {
+    it('returns true when source_info is unreclaimed and has transition_end_ts', () => {
         expect(deep_archive_utils.is_transition_source_pending_purge({
             transition_info: {
                 status: 'DONE',
+                transition_end_ts: new Date('2026-05-01T00:00:00Z'),
                 source_info: {
                     storage_class: 'STANDARD',
-                    transition_timestamp: new Date('2026-05-01T00:00:00Z'),
                 },
             },
         })).toBe(true);
     });
 
-    it('returns false when transition_timestamp is missing', () => {
+    it('returns false when transition_end_ts is missing', () => {
         expect(deep_archive_utils.is_transition_source_pending_purge({
             transition_info: {
                 status: 'DONE',
@@ -128,9 +128,9 @@ describe('is_transition_source_pending_purge', () => {
         expect(deep_archive_utils.is_transition_source_pending_purge({
             transition_info: {
                 status: 'DONE',
+                transition_end_ts: new Date('2026-05-01T00:00:00Z'),
                 source_info: {
                     storage_class: 'STANDARD',
-                    transition_timestamp: new Date('2026-05-01T00:00:00Z'),
                     reclaimed: new Date(),
                 },
             },

--- a/src/util/deep_archive_utils.js
+++ b/src/util/deep_archive_utils.js
@@ -69,7 +69,7 @@ function is_restore_active(restore_status, now = new Date()) {
 /**
  * True when a completed restore copy is past expiry and still on MD — ObjectsReclaimer
  * must purge mappings before a new RestoreObject may run (client can retry later).
- * @param {{ restore_status?: { ongoing?: boolean, expiry_time?: Date|number } }} obj
+ * @param {{ restore_status?: { ongoing?: boolean, expiry_time?: Date } }} obj
  * @param {Date} [now]
  * @returns {boolean}
  */
@@ -83,15 +83,17 @@ function is_expired_restore_pending_purge(obj, now = new Date()) {
 }
 
 /**
- * True when transition source-class data exists (with transition_timestamp) and is not yet
+ * True when transition source-class data exists (with transition_end_ts) and is not yet
  * reclaimed — RestoreObject must wait until ObjectsReclaimer finishes (client can retry later).
- * @param {{ transition_info?: { source_info?: { transition_timestamp?: Date|number, reclaimed?: Date|number } } }} obj
+ * @param {{ transition_info?: { transition_end_ts?: Date, source_info?: { reclaimed?: Date } } }} obj
  * @returns {boolean}
  */
 function is_transition_source_pending_purge(obj) {
-    const source_info = obj.transition_info?.source_info;
+    const transition_info = obj.transition_info;
+    if (!transition_info) return false;
+    const source_info = transition_info.source_info;
     if (!source_info || source_info.reclaimed) return false;
-    if (source_info.transition_timestamp === undefined || source_info.transition_timestamp === null) {
+    if (transition_info.transition_end_ts === undefined || transition_info.transition_end_ts === null) {
         return false;
     }
     return true;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. moved source_info. transition_timestamp to be in the upper layer next to transition_start_ts and renamed it to transition_end_ts 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Transition completion metadata now records the end time in `transition_end_ts`.
  * Restore status now includes the optional `ongoing_since` timestamp.
  * The previous source-level transition timestamp field is no longer used.

* **Behavior Changes**
  * Completed transitions and source cleanup checks now rely on the transition end timestamp.
  * Object metadata responses reflect the updated transition information layout.

* **Documentation**
  * Updated lifecycle transition documentation to describe the revised metadata fields.

* **Tests**
  * Updated transition, cleanup, query, and concurrency coverage for the new metadata format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->