### PR TITLE
DEEP_ARCHIVE | Use Custom Header Force Evict in RestoreWorker

### DIFF
--- a/src/server/bg_services/restore_worker.js
+++ b/src/server/bg_services/restore_worker.js
@@ -14,6 +14,8 @@ const ObjectIO = require('../../sdk/object_io');
 const map_deleter = require('../object_services/map_deleter');
 const archive_server = require('./archive_server');
 const P = require('../../util/promise');
+const stream = require('stream');
+const stream_utils = require('../../util/stream_utils');
 
 class RestoreWorker {
 
@@ -150,12 +152,14 @@ class RestoreWorker {
         dbg.log0('RestoreWorker: starting STANDARD restore copy write',
             { key: obj.key, obj_id: String(obj._id), bucket: bucket.name.unwrap(), size });
         const { days, bucket_name, object_size, restore_copy_layout } = await this._prepare_restore_copy(obj, bucket, size);
+        const archive_strategy = this._get_restore_archive_strategy(object_size, restore_copy_layout);
 
         if (!restore_copy_layout.is_complete) {
-            const is_small_object = object_size <= config.RESTORE_WORKER_LARGE_OBJECT_SIZE;
-            const starting_from_byte_zero = restore_copy_layout.mapped_end_offset === 0;
             await this._upload_restore_copy(obj, bucket_name, object_size, rpc_client, restore_copy_layout.mapped_end_offset,
-                { full_archive_read: is_small_object && starting_from_byte_zero });
+                { full_archive_read: archive_strategy.full_archive_read });
+        }
+        if (archive_strategy.needs_post_upload_force_evict) {
+            await this._force_evict_archive_object(obj);
         }
         await this._finalize_restore_copy(obj, bucket_name, days, rpc_client);
     }
@@ -373,6 +377,58 @@ class RestoreWorker {
                     seq_start: start_seq, seq_next: next_seq, use_full_archive_read });
             offset = end;
             if (!uses_multi_range) break;
+        }
+    }
+
+    /**
+     * Resolves how to read the deep-archive copy and whether a separate force-evict GET is needed
+     * Small objects starting at byte 0 use a full archive GET which auto-evicts on NSFS
+     * @param {number} object_size
+     * @param {{ mapped_end_offset: number }} restore_copy_layout
+     * @returns {{ full_archive_read: boolean, needs_post_upload_force_evict: boolean }}
+     */
+    _get_restore_archive_strategy(object_size, restore_copy_layout) {
+        const is_small_object = object_size <= config.RESTORE_WORKER_LARGE_OBJECT_SIZE;
+        const starting_from_byte_zero = restore_copy_layout.mapped_end_offset === 0;
+        const full_archive_read = is_small_object && starting_from_byte_zero;
+        const needs_post_upload_force_evict = object_size > 0 && !full_archive_read;
+        return { full_archive_read, needs_post_upload_force_evict };
+    }
+
+    /**
+     * Triggers glacier tape eviction on the archive copy via a minimal ranged GET
+     * with glacier_force_evict, after all restore-copy segments are uploaded
+     * @param {nb.ObjectMD} obj
+     */
+    async _force_evict_archive_object(obj) {
+        let source_stream;
+        try {
+            source_stream = await archive_server.read_archive_object_stream({
+                bucket_id: obj.bucket,
+                obj_id: obj._id,
+                start: 0,
+                end: 1,
+                glacier_force_evict: true,
+            });
+            // Pipe the evict GET body to a no-op writable so NSFS can finish
+            // the response and apply tape eviction without buffering the byte
+            const discard = new stream.Writable({
+                write(_chunk, _encoding, callback) {
+                    callback();
+                },
+            });
+            await stream_utils.pipeline([source_stream, discard]);
+        } catch (err) {
+            destroy_source_stream({ source_stream });
+            const err_code = err.rpc_code || err.code || err.name || err.Code;
+            if (err_code === 'NO_SUCH_OBJECT' || err_code === 'InvalidObjectState') {
+                dbg.log0('RestoreWorker: archive already evicted or removed, skipping force-evict',
+                    { key: obj.key, obj_id: String(obj._id), err_code });
+                return;
+            }
+            dbg.error('RestoreWorker: failed to force-evict archive object',
+                { key: obj.key, obj_id: String(obj._id) }, err);
+            throw err;
         }
     }
 


### PR DESCRIPTION
### Describe the Problem
Edit the BG Worker Restore to use the custom header of force evict - as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)

### Explain the Changes
1. In `_write_standard_restore_copy` in case we upload by range and we complete the upload, call `_force_evict_archive_object` which adds the custom header to force evict the copy with a Get of 1 byte.

### Issues: 
1. Currently, when working on tape the copy is available for the first full get object; when we have the get object by range (which we use for large objects) the copy is not evicted. In PR #9992 this header was created, and in this PR we use this header.

List of GAPs:
1. In case of failure of the GetObject of the full object, see #10019 .

### Testing Instructions:
#### Manual Tests:
1. I followed the setup in [comment](https://github.com/noobaa/noobaa-core/pull/9978#issuecomment-5407004378).
3. Added this: `config.RESTORE_WORKER_LARGE_OBJECT_SIZE = 5 * 1024 * 1024; // 5 MiB SDSD`.
4. Upload a file with 6 MiB (to have the restore by range): `s3-obc-user-2 s3api put-object --bucket obc2 --key test-6-mib --body ./file_6mb.bin --storage-class DEEP_ARCHIVE`
5. Restore the object (and use the manipulation in the instructions): `s3-obc-user-2 s3api restore-object --bucket obc2 --key test-6-mib --restore-request Days=7`
6. In noobaa-core logs:
`kubectl logs -f -l noobaa-core=noobaa -c core -n test1 --tail 1000 | grep RestoreWorker`
(includes added debug printings from AI)
```
Sep-7 11:36:33.070 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: checking restore status for objects: test-6-mib3
Sep-7 11:36:33.129 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: object restored on deep archive, writing STANDARD copy { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', size: 6291456 }
Sep-7 11:36:33.129 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: starting STANDARD restore copy write { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', size: 6291456 }
Sep-7 11:36:33.130 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: reading archive for restore copy { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', size: 6291456, start_offset: 0, archive_read_mode: 'multi_range' }
Sep-7 11:36:33.131 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: [glacier_force_evict_debug] RestoreWorker archive read params (upload segment) { hypothesisId: 'A', key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', archive_read_mode: 'multi_range', use_full_archive_read: false, uses_multi_range: true, start: 0, end: 6291456, object_size: 6291456, glacier_force_evict: false }
Sep-7 11:36:33.902 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: uploaded restore copy segment { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', start: 0, end: 6291456, seq_start: 0, seq_next: 2, use_full_archive_read: false }
Sep-7 11:36:33.902 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: [glacier_force_evict_debug] RestoreWorker starting post-upload force-evict { hypothesisId: 'B', key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', object_size: 6291456 }
Sep-7 11:36:33.908 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: [glacier_force_evict_debug] RestoreWorker force-evict via 1-byte GET { hypothesisId: 'B', key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', start: 0, end: 1 }
Sep-7 11:36:33.942 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: [glacier_force_evict_debug] RestoreWorker draining evict response stream { hypothesisId: 'H2', key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7' }
Sep-7 11:36:33.944 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: [glacier_force_evict_debug] RestoreWorker post-upload force-evict completed { hypothesisId: 'B', key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7' }
Sep-7 11:36:33.946 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: updating restore_status { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', expiry_time: 2026-09-15T00:00:00.000Z }
Sep-7 11:36:34.011 [BGWorkers/38]    [L0] core.server.bg_services.restore_worker:: RestoreWorker: restore_status updated { key: 'test-6-mib3', obj_id: '6a9ea145bbd266000c6d60b7', bucket: 'obc2', expiry_time: 2026-09-15T00:00:00.000Z }
```

In NC logs (`sudo node src/cmd/nsfs --debug 5 --https_port 6442`):
```
Sep-7 15:18:46.343 [nsfs/31546]    [L1] core.sdk.namespace_fs:: NamespaceFS: read_object_stream completed { file_path: '/Users/buckets/buc-0309/noobaa_storage/6a9e98cc5bb8400028db4742/6a9eab2cbbd266000c6d60be', start: 0, end: 1, size: 6291456, took_ms: 1.574333, num_bytes: 1, num_buffers: 1, avg_buffer: 1, log2_size_histogram: { '0': 1 } }
Sep-7 15:18:46.343 [nsfs/31546]    [L1] core.util.http_utils:: HTTP REPLY RAW GET /buc-0309/noobaa_storage/6a9e98cc5bb8400028db4742/6a9eab2cbbd266000c6d60be?x-id=GetObject
```

- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of archived objects after partial or ranged retrieval.
  * Ensured non-empty archived objects are fully restored after the final restore operation.
  * Improved handling of restoration requests when archived data is missing or not currently accessible, preventing unnecessary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->