### PR TITLE
DEEP_ARCHIVE | Fix `restore_status` Partial Index Query Plan

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -981,6 +981,7 @@ class MDStore {
         const results = await this._objects.find({
             deleted: null,
             upload_started: null,
+            restore_status: { $exists: true },
             'restore_status.ongoing': false,
             'restore_status.expiry_time': { $lte: now },
         }, {
@@ -1538,6 +1539,7 @@ class MDStore {
         const ongoing_objects = await this._objects.find(compact({
             deleted: null,
             upload_started: null,
+            restore_status: { $exists: true },
             'restore_status.ongoing': true,
             _id: marker ? { $gt: marker } : undefined,
         }), {

--- a/src/test/integration_tests/db/test_query_plans.js
+++ b/src/test/integration_tests/db/test_query_plans.js
@@ -588,6 +588,11 @@ mocha.describe('md_store query plan verification', function() {
         await check('find_expired_restore_objects', () => md_store.find_expired_restore_objects(10), [OBJ]);
     });
 
+    mocha.it('objects - find_objects_restore_status_ongoing', async function() {
+        await check('find_objects_restore_status_ongoing',
+            () => md_store.find_objects_restore_status_ongoing(10), [OBJ]);
+    });
+
     mocha.it('objects - find_objects_with_transition_done_unreclaimed_source', async function() {
         await check('find_objects_with_transition_done_unreclaimed_source',
             () => md_store.find_objects_with_transition_done_unreclaimed_source(10), [OBJ]);


### PR DESCRIPTION
### Describe the Problem
While I tried to rerun the test on the DB as described in [comment](https://github.com/noobaa/noobaa-core/pull/9894#issuecomment-5231344796), I hit a different index while I was testing #10020 - as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)

### Explain the Changes
1. Add `restore_status: { $exists: true },` to queries that have `'restore_status.ongoing':` (`true` or `false`).
2. Add AI-generated test.

### Issues: 
List of GAPs:
1. In PR #9611 the tests were added, but we lack of assertion or verify that the index was indeed used (like we test manually).

### Testing Instructions:
#### Automatic Test:
Please run: `make run-single-test testpath=integration_tests/db/test_query_plans.js`

#### Manual Test:
1. Test the DB to check that we hit the index (based on the [comment](https://github.com/noobaa/noobaa-core/pull/9894#issuecomment-5231344796)), see the [comment](https://github.com/noobaa/noobaa-core/pull/10021#issuecomment-5559192700) below.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restore-related searches now return only objects with an existing restore status, improving result accuracy for expired and ongoing restores.

- **Tests**
  - Added integration coverage to verify query plans for ongoing restore searches and ensure efficient database access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->