### PR TITLE
DEEP_ARCHIVE | Integration Tests for Restore Object (Using NC)

### DIFF
--- a/src/test/integration_tests/api/s3/test_restore_object.js
+++ b/src/test/integration_tests/api/s3/test_restore_object.js
@@ -1,0 +1,261 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+/**
+ * RestoreObject integration tests (owner, repeat restore, cross-account, bucket policy).
+ *
+ * Containerized coretest hosts the user bucket (archive_policy + MSC). A standalone
+ * NC nsfs archive target (see nc_archive_target.js, same pattern as nc_coretest) provides
+ * the deep-archive S3 target — not loopback to coretest, which returns NotImplemented
+ * on archive payload RestoreObject.
+ */
+
+const coretest = require('../../../utils/coretest/coretest');
+coretest.setup({ pools_to_create: [coretest.POOL_LIST[1]] });
+
+const mocha = require('mocha');
+const assert = require('assert');
+
+const config = require('../../../../../config');
+const s3_utils = require('../../../../endpoint/s3/s3_utils');
+const test_utils = require('../../../system_tests/test_utils');
+const { err_code, generate_s3_policy, generate_s3_client } = test_utils;
+const { start_nc_archive_target, stop_nc_archive_target } = require('../../../utils/nc_archive_target');
+
+const { rpc_client } = coretest;
+
+const NC_ARCHIVE_TARGET_BUCKET = 'test-restore-archive-target';
+const ARCHIVE_CONNECTION = 'restore_nc_archive_connection';
+const ARCHIVE_NSR = 'restore_nc_archive_nsr';
+
+const RESTORE_BKT = 'test-restore-object';
+const RESTORE_OWNER = 'restore-owner';
+const RESTORE_PRINCIPAL = 'restore-principal';
+const RESTORE_KEY_1 = 'restore/object-1';
+const RESTORE_KEY_2 = 'restore/object-2';
+const RESTORE_KEY_DUP = 'restore/duplicate-object';
+const RESTORE_BODY_1 = Buffer.from('restore-payload-1');
+const RESTORE_BODY_2 = Buffer.from('restore-payload-2');
+const RESTORE_BODY_DUP = Buffer.from('restore-payload-dup');
+const RESTORE_DAYS = 5;
+
+mocha.describe('restore_object', function() {
+    // Skip test if DB is not PostgreSQL
+    if (config.DB_TYPE !== 'postgres') return;
+
+    /** @type {import('@aws-sdk/client-s3').S3} */
+    let s3_nc_archive;
+    /** @type {import('@aws-sdk/client-s3').S3} */
+    let s3_restore_owner;
+    /** @type {import('@aws-sdk/client-s3').S3} */
+    let s3_restore_principal;
+    /** @type {string} */
+    let restore_principal_id;
+    /** @type {{ endpoint: string, access_key: string, secret_key: string }} */
+    let archive_target;
+    /** @type {boolean} */
+    let original_archive_target_check_enabled;
+    /** @type {boolean} */
+    let original_archive_policy_check_enabled;
+    let archive_connection_created = false;
+    let archive_nsr_created = false;
+    let restore_bucket_created = false;
+    let nc_archive_target_bucket_created = false;
+    let archive_config_overrides_applied = false;
+
+    mocha.before(async function() {
+        this.timeout(120000); // eslint-disable-line no-invalid-this
+
+        original_archive_target_check_enabled = config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED;
+        original_archive_policy_check_enabled = config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED;
+        config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = false;
+        config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = false;
+        archive_config_overrides_applied = true;
+
+        // Standalone NC nsfs endpoint used as the deep-archive S3 target.
+        archive_target = await start_nc_archive_target();
+        s3_nc_archive = generate_s3_client(archive_target.access_key, archive_target.secret_key, archive_target.endpoint);
+        await s3_nc_archive.createBucket({ Bucket: NC_ARCHIVE_TARGET_BUCKET });
+        nc_archive_target_bucket_created = true;
+
+        // Containerized NooBaa: accounts, archive NSR → NC archive target, MSC restore bucket.
+        const owner_details = await create_restore_test_account(RESTORE_OWNER);
+        const principal_details = await create_restore_test_account(RESTORE_PRINCIPAL);
+        restore_principal_id = principal_details.id.toString();
+
+        const coretest_endpoint = coretest.get_http_address();
+        s3_restore_owner = generate_s3_client(
+            owner_details.access_keys[0].access_key.unwrap(),
+            owner_details.access_keys[0].secret_key.unwrap(),
+            coretest_endpoint
+        );
+        s3_restore_principal = generate_s3_client(
+            principal_details.access_keys[0].access_key.unwrap(),
+            principal_details.access_keys[0].secret_key.unwrap(),
+            coretest_endpoint
+        );
+
+        await rpc_client.account.add_external_connection({
+            name: ARCHIVE_CONNECTION,
+            endpoint: archive_target.endpoint,
+            endpoint_type: 'S3_COMPATIBLE',
+            auth_method: 'AWS_V4',
+            identity: archive_target.access_key,
+            secret: archive_target.secret_key,
+        });
+        archive_connection_created = true;
+        await rpc_client.pool.create_namespace_resource({
+            name: ARCHIVE_NSR,
+            connection: ARCHIVE_CONNECTION,
+            target_bucket: NC_ARCHIVE_TARGET_BUCKET,
+            archive: true,
+        });
+        archive_nsr_created = true;
+
+        // owner creates the bucket (needed for cross-account restore/policy tests)
+        await s3_restore_owner.createBucket({ Bucket: RESTORE_BKT });
+        restore_bucket_created = true;
+        // admin sets archive_policy (not available via S3 CreateBucket)
+        await rpc_client.bucket.update_bucket({ name: RESTORE_BKT, archive_policy: { deep_archive_resource: { resource: ARCHIVE_NSR } }});
+
+        await put_restore_deep_archive_object(s3_restore_owner, RESTORE_KEY_1, RESTORE_BODY_1);
+        await put_restore_deep_archive_object(s3_restore_owner, RESTORE_KEY_2, RESTORE_BODY_2);
+        await put_restore_deep_archive_object(s3_restore_owner, RESTORE_KEY_DUP, RESTORE_BODY_DUP);
+    });
+
+    mocha.after(async function() {
+        try {
+            if (restore_bucket_created) {
+                await test_utils.empty_and_delete_buckets(rpc_client, [RESTORE_BKT]);
+            }
+            if (archive_nsr_created) {
+                await rpc_client.pool.delete_namespace_resource({ name: ARCHIVE_NSR });
+            }
+            if (archive_connection_created) {
+                await rpc_client.account.delete_external_connection({ connection_name: ARCHIVE_CONNECTION });
+            }
+            if (s3_nc_archive && nc_archive_target_bucket_created) {
+                const listed = await s3_nc_archive.listObjectsV2({ Bucket: NC_ARCHIVE_TARGET_BUCKET });
+                if (listed.Contents?.length) {
+                    await s3_nc_archive.deleteObjects({
+                        Bucket: NC_ARCHIVE_TARGET_BUCKET,
+                        Delete: {
+                            Objects: listed.Contents.map(obj => ({ Key: obj.Key })),
+                        },
+                    });
+                }
+                await s3_nc_archive.deleteBucket({ Bucket: NC_ARCHIVE_TARGET_BUCKET });
+            }
+        } catch (err) {
+            console.warn('restore_object: cleanup:', err);
+        } finally {
+            await stop_nc_archive_target();
+            if (archive_config_overrides_applied) {
+                config.ARCHIVE_TARGET_BUCKET_CHECK_ENABLED = original_archive_target_check_enabled;
+                config.ARCHIVE_POLICY_STORAGE_CLASS_CHECK_ENABLED = original_archive_policy_check_enabled;
+                archive_config_overrides_applied = false;
+            }
+        }
+    });
+
+    mocha.it('owner can restore a deep-archive object', async function() {
+        const restore_res = await s3_restore_owner.restoreObject({
+            Bucket: RESTORE_BKT,
+            Key: RESTORE_KEY_1,
+            RestoreRequest: { Days: RESTORE_DAYS },
+        });
+        assert.strictEqual(restore_res.$metadata.httpStatusCode, 202);
+
+        const md = await rpc_client.object.read_object_md({ bucket: RESTORE_BKT, key: RESTORE_KEY_1 });
+        assert.strictEqual(md.restore_status?.ongoing, true);
+    });
+
+    mocha.it('owner gets RestoreAlreadyInProgress on a second restore of the same object', async function() {
+        const restore_res = await s3_restore_owner.restoreObject({
+            Bucket: RESTORE_BKT,
+            Key: RESTORE_KEY_DUP,
+            RestoreRequest: { Days: RESTORE_DAYS },
+        });
+        assert.strictEqual(restore_res.$metadata.httpStatusCode, 202);
+
+        await assert.rejects(
+            s3_restore_owner.restoreObject({
+                Bucket: RESTORE_BKT,
+                Key: RESTORE_KEY_DUP,
+                RestoreRequest: { Days: RESTORE_DAYS },
+            }),
+            err => err_code(err) === 'RestoreAlreadyInProgress'
+        );
+    });
+
+    mocha.it('another account is denied RestoreObject without bucket policy', async function() {
+        await assert.rejects(
+            s3_restore_principal.restoreObject({
+                Bucket: RESTORE_BKT,
+                Key: RESTORE_KEY_2,
+                RestoreRequest: { Days: RESTORE_DAYS },
+            }),
+            err => err_code(err) === 'AccessDenied'
+        );
+    });
+
+    mocha.it('another account can restore with bucket policy granting s3:RestoreObject', async function() {
+        const policy = generate_s3_policy(
+            restore_principal_id,
+            RESTORE_BKT,
+            ['s3:RestoreObject'],
+        ).policy;
+        await s3_restore_owner.putBucketPolicy({
+            Bucket: RESTORE_BKT,
+            Policy: JSON.stringify(policy),
+        });
+
+        const restore_res = await s3_restore_principal.restoreObject({
+            Bucket: RESTORE_BKT,
+            Key: RESTORE_KEY_2,
+            RestoreRequest: { Days: RESTORE_DAYS },
+        });
+        assert.strictEqual(restore_res.$metadata.httpStatusCode, 202);
+
+        const md = await rpc_client.object.read_object_md({ bucket: RESTORE_BKT, key: RESTORE_KEY_2 });
+        assert.strictEqual(md.restore_status?.ongoing, true);
+    });
+});
+
+/**
+ * @param {string} name
+ * @returns {Promise<{
+ *   id: import('../../../../sdk/nb').ID,
+ *   arn: string,
+ *   token: string,
+ *   access_keys: Array<{
+ *     access_key: import('../../../../sdk/nb').SensitiveString,
+ *     secret_key: import('../../../../sdk/nb').SensitiveString,
+ *   }>,
+ * }>}
+ */
+async function create_restore_test_account(name) {
+    return rpc_client.account.create_account({
+        name,
+        email: name,
+        has_login: false,
+        s3_access: true,
+        default_resource: coretest.POOL_LIST[1].name,
+    });
+}
+
+/**
+ * @param {import('@aws-sdk/client-s3').S3} s3_client
+ * @param {string} key
+ * @param {Buffer} body
+ * @returns {Promise<import('@aws-sdk/client-s3').PutObjectCommandOutput>}
+ */
+async function put_restore_deep_archive_object(s3_client, key, body) {
+    return s3_client.putObject({
+        Bucket: RESTORE_BKT,
+        Key: key,
+        Body: body,
+        ContentType: 'application/octet-stream',
+        StorageClass: s3_utils.STORAGE_CLASS_DEEP_ARCHIVE,
+    });
+}

--- a/src/test/utils/coretest/nc_coretest.js
+++ b/src/test/utils/coretest/nc_coretest.js
@@ -17,6 +17,7 @@ const child_process = require('child_process');
 const argv = require('minimist')(process.argv);
 const SensitiveString = require('../../../util/sensitive_string');
 const { exec_manage_cli, TMP_PATH, create_redirect_file, delete_redirect_file } = require('../../system_tests/test_utils');
+const { write_nc_config_json, wait_for_nsfs_process_ready } = require('../nc_nsfs_test_helpers');
 const { TYPES, ACTIONS } = require('../../../manage_nsfs/manage_nsfs_constants');
 const { ConfigFS } = require('../../../sdk/config_fs');
 const os_utils = require('../../../util/os_utils');
@@ -165,7 +166,7 @@ async function start_nsfs_process(setup_options) {
         logStream.end();
     });
     // wait for the process to be ready (else would see ECONNREFUSED issue)
-    await P.delay(5000);
+    await wait_for_nsfs_process_ready();
 }
 
 /**
@@ -217,14 +218,7 @@ async function config_dir_setup() {
     await fs.promises.mkdir(config.NSFS_NC_DEFAULT_CONF_DIR, { recursive: true });
     await fs.promises.mkdir(NC_CORETEST_CONFIG_DIR_PATH, { recursive: true });
     await create_redirect_file(NC_CORETEST_CONFIG_FS, NC_CORETEST_CONFIG_DIR_PATH);
-    await fs.promises.writeFile(CONFIG_FILE_PATH, JSON.stringify({
-        ALLOW_HTTP: true,
-        OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS: 1,
-        NC_RELOAD_CONFIG_INTERVAL: 1,
-        // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
-        // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
-        VACCUM_ANALYZER_INTERVAL: 1,
-    }));
+    await write_nc_config_json(CONFIG_FILE_PATH);
     await fs.promises.mkdir(FIRST_BUCKET_PATH, { recursive: true });
 }
 

--- a/src/test/utils/index/index.js
+++ b/src/test/utils/index/index.js
@@ -94,6 +94,7 @@ require('../../integration_tests/internal/test_agent_blocks_reclaimer');
 require('../../integration_tests/internal/test_objects_reclaimer');
 require('../../integration_tests/api/s3/test_s3_ops');
 require('../../integration_tests/api/s3/test_deep_archive_via_s3');
+require('../../integration_tests/api/s3/test_restore_object');
 require('../../integration_tests/api/s3/test_s3_encryption');
 require('../../integration_tests/api/s3/test_s3_bucket_policy');
 require('../../integration_tests/api/s3/test_s3_bucket_policy_source_ip');

--- a/src/test/utils/nc_archive_target.js
+++ b/src/test/utils/nc_archive_target.js
@@ -1,0 +1,134 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+/**
+ * Starts a standalone NC (nsfs) S3 endpoint for use as a deep-archive target from
+ * containerized coretest. Uses an isolated config_root under TMP_PATH and creates
+ * the NC account in-process via ConfigFS (no manage_nsfs CLI — avoids setgroups
+ * in unprivileged test containers).
+ */
+
+require('../../util/dotenv').load();
+
+const fs = require('fs');
+const path = require('path');
+
+const config = require('../../../config');
+const { ConfigFS } = require('../../sdk/config_fs');
+const { crypto_random_string } = require('../../util/string_utils');
+const { TMP_PATH, set_nc_config_dir_in_config } = require('../system_tests/test_utils');
+const { NSFS_ARCHIVE_TARGET_HTTP_PORT, write_nc_config_json, spawn_nsfs_process,
+        wait_for_nsfs_process_ready, create_nc_account_via_config_fs } = require('./nc_nsfs_test_helpers');
+
+const NC_ARCHIVE_TARGET_ACCOUNT_NAME = 'nc_archive_account';
+const NC_ARCHIVE_TARGET_ACCOUNT_ID = '65a8edc9bc5d5bbf9db71a94';
+const NC_ARCHIVE_TARGET_CONFIG_DIR = path.join(TMP_PATH, 'restore_nc_archive_config');
+const NC_ARCHIVE_TARGET_STORAGE_PATH = path.join(TMP_PATH, 'restore_nc_archive_storage');
+const NC_ARCHIVE_TARGET_LOGS_DIR = path.join(TMP_PATH, 'restore_nc_archive_glacier_logs');
+const NC_ARCHIVE_TARGET_MASTER_KEYS = path.join(NC_ARCHIVE_TARGET_CONFIG_DIR, 'master_keys.json');
+const NC_ARCHIVE_TARGET_CONFIG_FILE = path.join(NC_ARCHIVE_TARGET_CONFIG_DIR, 'config.json');
+
+/** @type {import('child_process').ChildProcess | null} */
+let nsfs_process = null;
+
+/** @type {boolean | undefined} */
+let original_test_mode;
+/** @type {string | undefined} */
+let original_nc_master_keys_file_location;
+/** @type {string | undefined} */
+let original_nsfs_nc_conf_dir;
+
+/**
+ * @returns {Promise<{ endpoint: string, access_key: string, secret_key: string }>}
+ */
+async function start_nc_archive_target() {
+    if (nsfs_process) {
+        throw new Error('nc_archive_target already started');
+    }
+
+    original_test_mode = config.test_mode;
+    original_nc_master_keys_file_location = config.NC_MASTER_KEYS_FILE_LOCATION;
+    original_nsfs_nc_conf_dir = config.NSFS_NC_CONF_DIR;
+
+    config.test_mode = true;
+    config.NC_MASTER_KEYS_FILE_LOCATION = NC_ARCHIVE_TARGET_MASTER_KEYS;
+    set_nc_config_dir_in_config(NC_ARCHIVE_TARGET_CONFIG_DIR);
+
+    await fs.promises.mkdir(NC_ARCHIVE_TARGET_STORAGE_PATH, { recursive: true });
+    await fs.promises.mkdir(NC_ARCHIVE_TARGET_CONFIG_DIR, { recursive: true });
+    await fs.promises.mkdir(NC_ARCHIVE_TARGET_LOGS_DIR, { recursive: true });
+
+    await write_nc_config_json(NC_ARCHIVE_TARGET_CONFIG_FILE, {
+        // Archive payloads use DEEP_ARCHIVE; namespace_fs requires glacier support.
+        NSFS_GLACIER_ENABLED: true,
+        NSFS_GLACIER_LOGS_ENABLED: true,
+        NSFS_GLACIER_LOGS_DIR: NC_ARCHIVE_TARGET_LOGS_DIR,
+    });
+
+    const access_key = crypto_random_string(20);
+    const secret_key = crypto_random_string(40);
+
+    const config_fs = new ConfigFS(NC_ARCHIVE_TARGET_CONFIG_DIR);
+    await create_nc_account_via_config_fs(config_fs, {
+        _id: NC_ARCHIVE_TARGET_ACCOUNT_ID,
+        name: NC_ARCHIVE_TARGET_ACCOUNT_NAME,
+        new_buckets_path: NC_ARCHIVE_TARGET_STORAGE_PATH,
+        access_key,
+        secret_key,
+    });
+
+    // nsfs stdout/stderr → nsfs_integration_test_log.txt in cwd (see spawn_nsfs_process default)
+    ({ process: nsfs_process } = spawn_nsfs_process({
+        http_port: NSFS_ARCHIVE_TARGET_HTTP_PORT,
+        config_root: NC_ARCHIVE_TARGET_CONFIG_DIR,
+    }));
+
+    nsfs_process.on('exit', (code, signal) => {
+        console.warn(`nc_archive_target: nsfs.js exited code=${code} signal=${signal}`);
+        nsfs_process = null;
+    });
+
+    await wait_for_nsfs_process_ready();
+
+    return {
+        endpoint: `http://localhost:${NSFS_ARCHIVE_TARGET_HTTP_PORT}`,
+        access_key,
+        secret_key,
+    };
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function stop_nc_archive_target() {
+    if (nsfs_process) {
+        nsfs_process.kill('SIGKILL');
+        nsfs_process = null;
+    }
+    try {
+        await fs.promises.rm(NC_ARCHIVE_TARGET_STORAGE_PATH, { recursive: true, force: true });
+        await fs.promises.rm(NC_ARCHIVE_TARGET_LOGS_DIR, { recursive: true, force: true });
+        await fs.promises.rm(NC_ARCHIVE_TARGET_CONFIG_DIR, { recursive: true, force: true });
+    } catch (err) {
+        console.warn('nc_archive_target: storage/config cleanup:', err.message);
+    } finally {
+        if (original_test_mode !== undefined) {
+            config.test_mode = original_test_mode;
+            original_test_mode = undefined;
+        }
+        if (original_nc_master_keys_file_location !== undefined) {
+            config.NC_MASTER_KEYS_FILE_LOCATION = original_nc_master_keys_file_location;
+            original_nc_master_keys_file_location = undefined;
+        }
+        if (original_nsfs_nc_conf_dir !== undefined) {
+            config.NSFS_NC_CONF_DIR = original_nsfs_nc_conf_dir;
+            original_nsfs_nc_conf_dir = undefined;
+        }
+    }
+}
+
+module.exports = {
+    start_nc_archive_target,
+    stop_nc_archive_target,
+    NSFS_ARCHIVE_TARGET_HTTP_PORT,
+};

--- a/src/test/utils/nc_nsfs_test_helpers.js
+++ b/src/test/utils/nc_nsfs_test_helpers.js
@@ -1,0 +1,138 @@
+/* Copyright (C) 2026 NooBaa */
+'use strict';
+
+/**
+ * Shared helpers for starting NC nsfs in tests (nc_coretest, archive target, etc).
+ * Kept separate from nc_coretest.js so containerized tests can reuse nsfs startup
+ * without setting NC_CORETEST.
+ */
+
+const fs = require('fs');
+const child_process = require('child_process');
+
+const P = require('../../util/promise');
+
+/** Default NC coretest S3 HTTP port (matches config.ENDPOINT_PORT default). */
+const NSFS_CORETEST_HTTP_PORT = 6001;
+
+/**
+ * HTTP port for a standalone NC archive-target nsfs endpoint: coretest default + 10
+ * so it can run beside nc_coretest on the same host without binding the same port.
+ */
+const NSFS_ARCHIVE_TARGET_HTTP_PORT = NSFS_CORETEST_HTTP_PORT + 10;
+
+/**
+ * Fixed delay after spawning nsfs before sending S3 requests.
+ * Without it, clients often see ECONNREFUSED while the endpoint is still starting.
+ */
+const NSFS_PROCESS_STARTUP_DELAY_MS = 5000;
+
+/** Stable creation_date for test NC account config files (identity.json schema). */
+const NC_TEST_ACCOUNT_CREATION_DATE = '2023-10-30T04:46:33.815Z';
+
+/**
+ * Base config.json entries shared by nc_coretest and isolated archive-target instances.
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+function get_base_nc_config_json(overrides = {}) {
+    return {
+        ALLOW_HTTP: true,
+        OBJECT_SDK_BUCKET_CACHE_EXPIRY_MS: 1,
+        NC_RELOAD_CONFIG_INTERVAL: 1,
+        // DO NOT CHANGE - setting VACCUM_ANALYZER_INTERVAL=1 needed for failing the tests
+        // in case where vaccumAnalyzer is being called before setting process.env.NC_NSFS_NO_DB_ENV = 'true' on nsfs.js
+        VACCUM_ANALYZER_INTERVAL: 1,
+        ...overrides,
+    };
+}
+
+/**
+ * Writes config.json under a config_root directory.
+ * @param {string} config_file_path
+ * @param {object} [overrides]
+ * @returns {Promise<void>}
+ */
+async function write_nc_config_json(config_file_path, overrides = {}) {
+    await fs.promises.writeFile(
+        config_file_path,
+        JSON.stringify(get_base_nc_config_json(overrides)),
+    );
+}
+
+/**
+ * Spawns nsfs.js detached (same pattern as nc_coretest).
+ * detached: child can outlive the parent test process until explicitly killed.
+ * stdout/stderr are piped to log_file for debugging failed runs.
+ * @param {{ http_port: number, config_root: string, log_file?: string, extra_args?: string[] }} options
+ * @returns {{ process: import('child_process').ChildProcess, log_stream: fs.WriteStream }}
+ */
+function spawn_nsfs_process({ http_port, config_root, log_file = 'nsfs_integration_test_log.txt', extra_args = [] }) {
+    const log_stream = fs.createWriteStream(log_file, { flags: 'a' });
+    const argv = [
+        'src/cmd/nsfs.js',
+        '--http_port',
+        String(http_port),
+        '--config_root',
+        config_root,
+        ...extra_args,
+    ];
+    const nsfs_process = child_process.spawn('node', argv, { detached: true });
+    nsfs_process.stdout.pipe(log_stream);
+    nsfs_process.stderr.pipe(log_stream);
+    nsfs_process.on('exit', () => log_stream.end());
+    nsfs_process.on('error', () => log_stream.end());
+    return { process: nsfs_process, log_stream };
+}
+
+/**
+ * Waits for a freshly spawned nsfs process to accept connections.
+ * @returns {Promise<void>}
+ */
+async function wait_for_nsfs_process_ready() {
+    await P.delay(NSFS_PROCESS_STARTUP_DELAY_MS);
+}
+
+/**
+ * Creates an NC account identity via ConfigFS (no manage_nsfs CLI, no setgroups).
+ * @param {import('../../sdk/config_fs').ConfigFS} config_fs
+ * @param {{ _id: string, name: string, email?: string, new_buckets_path: string, access_key: string, secret_key: string, creation_date?: string }} account
+ * @returns {Promise<object>}
+ */
+async function create_nc_account_via_config_fs(config_fs, account) {
+    const {
+        _id,
+        name,
+        email = name,
+        new_buckets_path,
+        access_key,
+        secret_key,
+        creation_date = NC_TEST_ACCOUNT_CREATION_DATE,
+    } = account;
+    await config_fs.create_config_dirs_if_missing();
+    return config_fs.create_account_config_file({
+        _id,
+        name,
+        email,
+        allow_bucket_creation: true,
+        access_keys: [{ access_key, secret_key }],
+        nsfs_account_config: {
+            uid: process.getuid(),
+            gid: process.getgid(),
+            new_buckets_path,
+        },
+        creation_date,
+    });
+}
+
+module.exports = {
+    NSFS_CORETEST_HTTP_PORT,
+    NSFS_ARCHIVE_TARGET_HTTP_PORT,
+    NSFS_PROCESS_STARTUP_DELAY_MS,
+    NC_TEST_ACCOUNT_CREATION_DATE,
+    get_base_nc_config_json,
+    write_nc_config_json,
+    spawn_nsfs_process,
+    wait_for_nsfs_process_ready,
+    create_nc_account_via_config_fs,
+};


### PR DESCRIPTION
### Describe the Problem
Added integration tests for testing `RestoreObject` when the namespace store is an NC address as endpoint - as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823).
Until now, we used `test_deep_archive_via_s3.js` which used noobaa bucket as the target bucket, but since `RestoreObject` API is not implemented there we could not test it (we had mocks and used a unit test like `npx jest src/test/unit_tests/internal/test_namespace_multi_storage_class_restore.test.js`).

### Explain the Changes
1. Added AI-generated and dedicated tests for RestoreObject, to test the API and to allow testing bucket policy between 2 accounts (in `src/test/integration_tests/api/s3/test_restore_object.js`). Also added running NC for the target bucket on the container (in `src/test/utils/nc_archive_target.js`).
2. Moved mutual functions from `nc_coretest.js` so they can be reused (in `nc_nsfs_test_helpers.js`).
3. Added the new test in `src/test/utils/index/index.js` so it will run in the CI.

### Issues: 
List of GAPs:
1. We still do not have tests for the `RestoreWorker` BG worker. 

### Testing Instructions:
#### Automatic Tests:
1. Please run: `make run-single-test testpath=integration_tests/api/s3/test_restore_object.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for restoring objects from deep-archive storage.
  * Verified successful restores, duplicate restore rejection, cross-account access denial, and bucket-policy authorization.
  * Added coverage for standalone archive targets and archive configuration.
  * Improved test environment startup readiness checks, shared setup, and cleanup reliability for storage-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->