### PR TITLE
Deep Archive | Fix find_objects_with_transition_done_unreclaimed_source query so it'll hit transition_info_index

### DIFF
--- a/src/server/object_services/md_store.js
+++ b/src/server/object_services/md_store.js
@@ -1003,6 +1003,7 @@ class MDStore {
             deleted: null,
             upload_started: null,
             restore_status: null,
+            transition_info: { $exists: true },
             'transition_info.status': 'DONE',
             'transition_info.source_info': { $exists: true },
             'transition_info.source_info.reclaimed': null,

--- a/src/server/object_services/schemas/object_md_indexes.js
+++ b/src/server/object_services/schemas/object_md_indexes.js
@@ -186,6 +186,7 @@ module.exports = [
     {
         // find_objects_with_transition_done_unreclaimed_source() and other transition_info queries.
         // Partial index: live objects with unreclaimed transition_info (IN_PROGRESS or DONE).
+        // Callers must include transition_info: { $exists: true } so Postgres can prove this predicate; nested fields are not enough.
         // Callers filter status / other fields in the query (e.g. DONE for reclaim).
         fields: {
             _id: 1,

--- a/src/test/integration_tests/db/test_query_plans.js
+++ b/src/test/integration_tests/db/test_query_plans.js
@@ -56,10 +56,14 @@ mocha.describe('md_store query plan verification', function() {
      * @param {string} name - test label for the report
      * @param {Function} fn - async function that invokes the md_store method
      * @param {string[]} tables - table names to check plans for
-     * @param {{ allow_miss?: boolean }} [opts] - pass { allow_miss: true } for known seq-scan cases
+     * @param {{ allow_miss?: boolean, expected_indexes_by_table?: Object.<string, (string|RegExp)[]> }} [opts]
+     *        allow_miss: known seq-scan cases.
+     *        expected_indexes_by_table: table name → indexes that every captured
+     *        plan for that table must use.
      */
     async function check(name, fn, tables, opts) {
         const allow_miss = opts && opts.allow_miss;
+        const expected_indexes_by_table = (opts && opts.expected_indexes_by_table) || {};
         checker.enable(md_store);
         try {
             await fn();
@@ -75,6 +79,11 @@ mocha.describe('md_store query plan verification', function() {
             record(name, '(any)', checker.plans, checker);
         }
         checker.disable();
+        for (const [t, indexes] of Object.entries(expected_indexes_by_table)) {
+            for (const idx of indexes) {
+                checker.assert_index_used(t, idx);
+            }
+        }
         checker.plans = [];
 
         if (!allow_miss) {
@@ -595,7 +604,11 @@ mocha.describe('md_store query plan verification', function() {
 
     mocha.it('objects - find_objects_with_transition_done_unreclaimed_source', async function() {
         await check('find_objects_with_transition_done_unreclaimed_source',
-            () => md_store.find_objects_with_transition_done_unreclaimed_source(10), [OBJ]);
+            () => md_store.find_objects_with_transition_done_unreclaimed_source(10), [OBJ], {
+                expected_indexes_by_table: {
+                    [OBJ]: [`idx_btree_${OBJ}_transition_info_index`],
+                },
+            });
     });
 
     mocha.it('objects - list_objects', async function() {


### PR DESCRIPTION
### Describe the Problem
Currently, find_objects_with_transition_done_unreclaimed_source had implied transition_info exist while having transition_info.status = DONE and other checks, this was not enough, psql needs the query to explicitly mention transition_info exists is true.

### Explain the Changes
1. Added to find_objects_with_transition_done_unreclaimed_source() query explicit `transition_info: { $exists: true }`.
2. added another check for test_query_plans to make sure we hit the expected index and not just objectmd_version_seq_index as we did before.

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. Auto - `./node_modules/mocha/bin/mocha.js --grep 'find_objects_with_transition_done_unreclaimed_source' src/test/integration_tests/db/test_query_plans.js`
2. Manual - 
```
// Tab 1 - 
> nb install --dev
> kubectl patch cm noobaa-config --type merge -p '{"data":{"CONFIG_JS_ARCHIVE_TARGET_BUCKET_CHECK_ENABLED":"false", "CONFIG_JS_OBJECT_RECLAIMER_EMPTY_DELAY":"360000", "CONFIG_JS_LIFECYCLE_INTERVAL":"3000"}}'
nb namespacestore create s3-compatible ns1 --access-key=<access_key> --secret-key=<secret-key> --endpoint=https://<archive-endpoint> --target-bucket=<archive-target-bucket> --archive
> nb bucketclass create placement-bucketclass bc1 --backingstores=noobaa-default-backing-store --deep-archive-resource=ns1
> nb obc create obc1 --exact --bucketclass=bc1
> alias s3='AWS_SECRET_ACCESS_KEY=<obc1-secret-key> AWS_ACCESS_KEY_ID=<obc1-access-key> aws s3 --no-verify-ssl --endpoint-url https://127.0.0.1:10443'
> alias s3api='AWS_SECRET_ACCESS_KEY=<obc1-secret-key> AWS_ACCESS_KEY_ID=<obc1-access-key> aws s3api --no-verify-ssl --endpoint-url https://127.0.0.1:10443'
> cat lifecycle.json
{
  "Rules": [
    {
      "ID": "transition-all-after-1-day",
      "Status": "Enabled",
      "Filter": { "Prefix": "" },
      "Transitions": [
        {
          "Days": 1,
          "StorageClass": "DEEP_ARCHIVE"
        }
      ]
    }
  ]
}
> s3api put-bucket-lifecycle-configuration --bucket obc1  --lifecycle-configuration file://lifecycle.json
// Tab 2 - 
> kubectl port-forward svc/s3 10443:443
// Tab 1 - 
> echo "dsfnkndskjnfdknfdsnjk" > obj1.txt
> for i in $(seq 1 100); do s3 cp obj1.txt "s3://obc1/obj${i}.txt" ; done
> oc rsh noobaa-db-pg-cluster-1 ; psql nbcore 
> UPDATE objectmds
SET data = jsonb_set(
    data,
    '{create_time}',
    to_jsonb(
        to_char(
            (now() AT TIME ZONE 'UTC') - interval '3 days',
            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
        )
    )
)
WHERE (data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb);
// UPDATE 101

now waiting for the objects to be transitioned but not reclaimed
>  SET enable_seqscan = off;
EXPLAIN (ANALYZE, BUFFERS)
SELECT *
FROM objectmds
WHERE (data->'deleted' IS NULL OR data->'deleted' = 'null'::jsonb)
  AND (data->'upload_started' IS NULL OR data->'upload_started' = 'null'::jsonb)
  AND (data->'restore_status' IS NULL OR data->'restore_status' = 'null'::jsonb)
  AND data ? 'transition_info'
  AND data->'transition_info'->>'status' = 'DONE'
  AND data->'transition_info' ? 'source_info'
  AND (
        data->'transition_info'->'source_info'->'reclaimed' IS NULL
        OR data->'transition_info'->'source_info'->'reclaimed' = 'null'::jsonb
      )
  AND data->'transition_info'->'source_info' ? 'transition_timestamp'
LIMIT 1000;

 Limit  (cost=0.14..2.39 rows=1 width=653) (actual time=0.029..0.184 rows=101 loops=1)
   Buffers: shared hit=60
   ->  Index Scan using idx_btree_objectmds_transition_info_index on objectmds  (cost=0.14..2.39 rows=1 width=653) (actual time=0.027..0.168 rows=101 loop
s=1)
         Filter: (((data -> 'transition_info'::text) ? 'source_info'::text) AND (((data -> 'restore_status'::text) IS NULL) OR ((data -> 'restore_status':
:text) = 'null'::jsonb)) AND (((data -> 'transition_info'::text) -> 'source_info'::text) ? 'transition_timestamp'::text) AND (((data -> 'transition_info':
:text) ->> 'status'::text) = 'DONE'::text))
         Buffers: shared hit=60
 Planning:
   Buffers: shared hit=32
 Planning Time: 0.936 ms
 Execution Time: 0.221 ms
 
 In opposed to running it without transition_info exist check - 
 Limit  (cost=0.14..2.48 rows=1 width=574) (actual time=0.042..0.411 rows=101 loops=1)
   Buffers: shared hit=23
   ->  Index Scan using idx_btree_objectmds_bucket on objectmds  (cost=0.14..2.48 rows=1 width=574) (actual time=0.041..0.395 rows=101 loops=1)
         Filter: (((data -> 'transition_info'::text) ? 'source_info'::text) AND (((data -> 'upload_started'::text) IS NULL) OR ((data -> 'upload_started':
:text) = 'null'::jsonb)) AND (((data -> 'restore_status'::text) IS NULL) OR ((data -> 'restore_status'::text) = 'null'::jsonb)) AND (((data -> 'transition
_info'::text) -> 'source_info'::text) ? 'transition_timestamp'::text) AND (((data -> 'transition_info'::text) ->> 'status'::text) = 'DONE'::text) AND ((((
(data -> 'transition_info'::text) -> 'source_info'::text) -> 'reclaimed'::text) IS NULL) OR ((((data -> 'transition_info'::text) -> 'source_info'::text) -
> 'reclaimed'::text) = 'null'::jsonb)))
         Rows Removed by Filter: 101
         Buffers: shared hit=23
 Planning:
   Buffers: shared hit=4
 Planning Time: 0.443 ms
 Execution Time: 0.511 ms
 
 
```


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of completed transitions by considering only objects with available transition metadata.
  * Improved reliability when identifying objects eligible for source reclamation.
  * Improved performance and consistency for transition-related object lookups by ensuring the intended optimized access path is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->