### PR TITLE
Fix postgres_client to support bracketed IPv6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "node-rdkafka": "3.6.1",
         "performance-now": "2.1.0",
         "pg": "8.23.0",
+        "pg-connection-string": "2.14.0",
         "ping": "1.0.0",
         "prom-client": "15.1.3",
         "protobufjs": "8.8.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "node-rdkafka": "3.6.1",
     "performance-now": "2.1.0",
     "pg": "8.23.0",
+    "pg-connection-string": "2.14.0",
     "ping": "1.0.0",
     "prom-client": "15.1.3",
     "protobufjs": "8.8.0",

--- a/src/util/postgres_client.js
+++ b/src/util/postgres_client.js
@@ -11,6 +11,7 @@ const crypto = require('crypto');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 const { Pool, Client, escapeLiteral } = require('pg');
+const parse_pg_connection_string = require('pg-connection-string').parseIntoClientConfig;
 
 const P = require('./promise');
 const dbg = require('./debug_module')(__filename);
@@ -30,6 +31,14 @@ const ssl_utils = require('./ssl_utils');
 const fs_utils = require('./fs_utils');
 
 const DB_CONNECT_ERROR_MESSAGE = 'Could not acquire client from DB connection pool';
+
+// pg-connection-string keeps RFC 3986 brackets on IPv6 literals (e.g. [::1]),
+// which causes getaddrinfo ENOTFOUND when pg passes the host to net.connect.
+// Workaround until fixed upstream: https://github.com/brianc/node-postgres/pull/3698
+function normalize_pg_host(host) {
+    if (!host) return host;
+    return host.replace(/^\[(.+)\]$/, '$1');
+}
 mongodb.Binary.prototype[util.inspect.custom] = function custom_inspect_binary() {
     return `<mongodb.Binary ${this.buffer.toString('base64')} >`;
 };
@@ -1482,9 +1491,12 @@ class PostgresClient extends EventEmitter {
 
 
         if (process.env.POSTGRES_CONNECTION_STRING_PATH) {
+            const connection_string = fs.readFileSync(process.env.POSTGRES_CONNECTION_STRING_PATH, "utf8").trim();
+            const parsed_params = parse_pg_connection_string(connection_string);
+            parsed_params.host = normalize_pg_host(parsed_params.host);
             /** @type {import('pg').PoolConfig} */
             this.new_pool_params = {
-                connectionString: fs.readFileSync(process.env.POSTGRES_CONNECTION_STRING_PATH, "utf8"),
+                ...parsed_params,
                 ...params,
             };
         } else {
@@ -1513,12 +1525,7 @@ class PostgresClient extends EventEmitter {
         }
         // As we now also support external DB we don't want to print secret user data
         // so this code will mask out passwords from the printed pool params
-        this.print_pool_params = _.omit(this.print_pool_params, 'password');
-        if (this.new_pool_params.connectionString) {
-            const original = this.new_pool_params.connectionString;
-            const masked = original.replace(/\/\/(.*?):(.*?)@/, '//$1:*****@');
-            this.print_pool_params.connectionString = masked;
-        }
+        this.print_pool_params = _.omit(this.new_pool_params, 'password');
 
         PostgresClient.implements_interface(this);
         this._ajv = new Ajv({ verbose: true, allErrors: true });


### PR DESCRIPTION
### Describe the Problem
When using POSTGRES_CONNECTION_STRING_PATH with an IPv6 address in the connection string (e.g. `postgresql://user:pass@[fd13:6d20:29dc:1::91]:30432/nbcore)`, the DB upgrade and core startup fail with:
`getaddrinfo ENOTFOUND [fd13:6d20:29dc:1::91]`. Brackets are required around IPv6 literals in URLs (RFC 3986), but pg-connection-string (used by pg 8.23.0) leaves them on the parsed host. Node then treats [fd13:...] as a hostname and DNS lookup fails instead of connecting to the bare IPv6 address

### Explain the Changes
1. Parse POSTGRES_CONNECTION_STRING_PATH with parseIntoClientConfig into individual pool params instead of passing connectionString directly to pg.
2. Add normalize_pg_host() to strip RFC 3986 brackets from IPv6 hosts before creating the pool.
3. Trim whitespace/newlines from the connection string file (common with mounted secrets).
4. Fix print_pool_params to derive from new_pool_params (password omitted) for clearer logging.

Workaround for upstream issue: [#3698](https://github.com/brianc/node-postgres/pull/3698)

### Issues: Fixed #xxx / Gap #xxx
1. Fixed https://redhat.atlassian.net/browse/DFBUGS-10676

### Testing Instructions:
1. Set POSTGRES_CONNECTION_STRING_PATH to a file containing an IPv6 connection string, e.g. postgresql://postgres:<password>@[<ipv6>]:<port>/nbcore.
2. Run noobaa core and confirm Postgres connects successfully (no getaddrinfo ENOTFOUND with bracketed hostname).
3. Verify existing IPv4 / hostname connection strings still work.


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection handling for IPv6 hosts in connection strings.
  * Updated connection configuration processing and password masking in diagnostic logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->