### PR TITLE
[Backport into 5.21] Reduce ERROR log spam for expected NoSuchKey responses

### DIFF
--- a/src/endpoint/s3/s3_rest.js
+++ b/src/endpoint/s3/s3_rest.js
@@ -563,16 +563,24 @@ function _prepare_error(req, res, err) {
     return s3err;
 }
 
+function _log_s3_request_error(req, err, s3err, reply) {
+    if (s3err.code === 'NoSuchKey' && (req.method === 'GET' || req.method === 'HEAD')) {
+        dbg.log1('S3 NoSuchKey', req.method, req.originalUrl, req.request_id);
+    } else {
+        dbg.error('S3 ERROR', reply,
+            req.method, req.originalUrl,
+            JSON.stringify(req.headers),
+            err.stack || err,
+            err.context ? `- context: ${err.context?.trim()}` : '',
+        );
+    }
+}
+
 function handle_error(req, res, err) {
     const s3err = _prepare_error(req, res, err);
 
     const reply = s3err.reply(req.originalUrl, req.request_id);
-    dbg.error('S3 ERROR', reply,
-        req.method, req.originalUrl,
-        JSON.stringify(req.headers),
-        err.stack || err,
-        err.context ? `- context: ${err.context?.trim()}` : '',
-    );
+    _log_s3_request_error(req, err, s3err, reply);
     if (res.headersSent) {
         dbg.log0('Sending error xml in body, but too late for headers...');
     } else {
@@ -599,10 +607,7 @@ async function _handle_html_response(req, res, err) {
         </body> \
         </html>`;
     res.statusCode = s3err.http_code;
-    dbg.error('S3 ERROR', reply,
-        req.method, req.originalUrl,
-        JSON.stringify(req.headers),
-        err.stack || err);
+    _log_s3_request_error(req, err, s3err, reply);
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Content-Length', Buffer.byteLength(reply));
     res.end(reply);

--- a/src/rpc/rpc.js
+++ b/src/rpc/rpc.js
@@ -264,12 +264,17 @@ class RPC extends EventEmitter {
                 this._request_logger('RPC REQUEST CATCH', req.srv, '==>', err);
             }
 
-            dbg.error('RPC._request: response ERROR',
-                req.base_info,
-                'params', util.inspect(params, true, null, true),
-                req.took_info,
-                err.stack || err
-            );
+            // Expected missing-object outcomes (maps to S3 NoSuchKey) — quiet log, no stack/params dump
+            if (err.rpc_code === 'NO_SUCH_OBJECT') {
+                dbg.log1('RPC._request: NO_SUCH_OBJECT', req.base_info, req.took_info);
+            } else {
+                dbg.error('RPC._request: response ERROR',
+                    req.base_info,
+                    'params', util.inspect(params, true, null, true),
+                    req.took_info,
+                    err.stack || err
+                );
+            }
 
             if (this.should_emit_request_errors) {
                 this.emit('request_error', err);
@@ -355,7 +360,12 @@ class RPC extends EventEmitter {
             await this._send_response(conn, req);
 
         } catch (err) {
-            console.error('RPC._on_request: ERROR', req.base_info, err.stack || err);
+            // Expected missing-object outcomes (maps to S3 NoSuchKey) — quiet log, no stack
+            if (err.rpc_code === 'NO_SUCH_OBJECT') {
+                dbg.log1('RPC._on_request: NO_SUCH_OBJECT', req.base_info);
+            } else {
+                console.error('RPC._on_request: ERROR', req.base_info, err.stack || err);
+            }
             // propagate rpc errors from inner rpc client calls (using err.rpc_code)
             // set default internal error if no other error was specified
             if (err instanceof RpcError) {


### PR DESCRIPTION
(cherry picked from commit 14541784a86951eddc1b155e0b9d2b085984c872) (cherry picked from commit 22ce6b9a5e39de90ffaa310b9ffd8dcc9574d736)

### Describe the Problem
https://redhat.atlassian.net/browse/DFBUGS-10237

### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. https://redhat.atlassian.net/browse/DFBUGS-10237

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added
