### PR TITLE
[GLACIER] Fix incorrect storage class when `NSFS_GLACIER_FORCE_STORAGE_CLASS` enabled

### DIFF
--- a/src/endpoint/s3/s3_utils.js
+++ b/src/endpoint/s3/s3_utils.js
@@ -394,10 +394,10 @@ function parse_storage_class_header(req) {
  * @returns {nb.StorageClass}
  */
 function parse_storage_class(storage_class) {
-    if (config.NSFS_GLACIER_FORCE_STORAGE_CLASS) {
-        storage_class = config.NSFS_GLACIER_FORCE_STORAGE_CLASS;
+    if (!storage_class || storage_class === STORAGE_CLASS_STANDARD) {
+        return config.NSFS_GLACIER_FORCE_STORAGE_CLASS ?
+        config.NSFS_GLACIER_FORCE_STORAGE_CLASS : STORAGE_CLASS_STANDARD;
     }
-    if (!storage_class || storage_class === STORAGE_CLASS_STANDARD) return STORAGE_CLASS_STANDARD;
     if (storage_class === STORAGE_CLASS_GLACIER) return STORAGE_CLASS_GLACIER;
     if (storage_class === STORAGE_CLASS_DEEP_ARCHIVE) return STORAGE_CLASS_DEEP_ARCHIVE;
     if (storage_class === STORAGE_CLASS_GLACIER_IR) return STORAGE_CLASS_GLACIER_IR;


### PR DESCRIPTION
### Describe the Problem


### Explain the Changes
1. 

### Issues: Fixed #xxx / Gap #xxx
1. 

### Testing Instructions:
1. 


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit S3 storage classes are now preserved when configuring a forced storage class.
  * Forced storage class settings apply only when the storage class is missing or set to `STANDARD`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->