### PR TITLE
DEEP_ARCHIVE | find_objects_restore_status_ongoing Add expected Index in Test Query Plans

### DIFF
--- a/src/test/integration_tests/db/test_query_plans.js
+++ b/src/test/integration_tests/db/test_query_plans.js
@@ -594,12 +594,21 @@ mocha.describe('md_store query plan verification', function() {
     });
 
     mocha.it('objects - find_expired_restore_objects', async function() {
-        await check('find_expired_restore_objects', () => md_store.find_expired_restore_objects(10), [OBJ]);
+        await check('find_expired_restore_objects',
+            () => md_store.find_expired_restore_objects(10), [OBJ], {
+            expected_indexes_by_table: {
+                [OBJ]: [`idx_btree_${OBJ}_restore_status_index`],
+            },
+        });
     });
 
     mocha.it('objects - find_objects_restore_status_ongoing', async function() {
         await check('find_objects_restore_status_ongoing',
-            () => md_store.find_objects_restore_status_ongoing(10), [OBJ]);
+            () => md_store.find_objects_restore_status_ongoing(10), [OBJ], {
+                expected_indexes_by_table: {
+                    [OBJ]: [`idx_btree_${OBJ}_restore_status_index`],
+                },
+            });
     });
 
     mocha.it('objects - find_objects_with_transition_done_unreclaimed_source', async function() {


### PR DESCRIPTION
### Describe the Problem
In PR #10023, we added the check for the expected index. In PR #10021, we added a test that didn't include it, so in this change we will add this change as part of [RHSTOR-8823](https://redhat.atlassian.net/browse/RHSTOR-8823)

### Explain the Changes
1. In test cases `objects - find_objects_restore_status_ongoing` and `objects - find_expired_restore_objects` add the `opt` object argument for `expected_indexes_by_table` and include the expected index `estore_status_index`.

### Issues:
1. It is related to #10029, but it doesn't solve it.

### Testing Instructions:
#### Automatic Test:
Please run: `make run-single-test testpath=integration_tests/db/test_query_plans.js`


- [ ] Doc added/updated
- [ ] Tests added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated query-plan integration tests to verify that restore-related queries use the expected objects-table index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->